### PR TITLE
Ticket 651

### DIFF
--- a/src/main/java/org/mapfish/print/map/renderers/vector/LabelRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/LabelRenderer.java
@@ -30,6 +30,8 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
 
 public class LabelRenderer {
+	
+	public static final Logger LOGGER = Logger.getLogger(LabelRenderer.class);
 
 	static void applyStyle(RenderingContext context, PdfContentByte dc,
 			PJsonObject style, Geometry geometry) {
@@ -54,7 +56,7 @@ public class LabelRenderer {
 					|| !"HELVETICA".equalsIgnoreCase(fontFamily)
 					|| !"TIMES_ROMAN".equalsIgnoreCase(fontFamily)) {
 
-				System.out.println("Font: '"+ fontFamily + 
+				LOGGER.info("Font: '"+ fontFamily + 
 						"' not supported, supported fonts are 'HELVETICA', " +
 						"'COURIER', 'TIMES_ROMAN', defaults to 'HELVETICA'");
 				fontFamily = "HELVETICA";


### PR DESCRIPTION
Updated LabelRenderer class: Replaced the System.out.println command by introducing a Logger object and using its info method. (http://trac.mapfish.org/trac/mapfish/ticket/651)
