### PR TITLE
fix condition to get the page param

### DIFF
--- a/src/main/java/org/mapfish/print/config/layout/Block.java
+++ b/src/main/java/org/mapfish/print/config/layout/Block.java
@@ -105,7 +105,7 @@ public abstract class Block {
             throw new InvalidValueException("condition", condition);
         }
 
-        String value = params.optString(condition);
+        String value = params.optString(matcher.group(2));
         if (value == null) {
             value = context.getGlobalParams().optString(matcher.group(2));
         }


### PR DESCRIPTION
In case of condition is « !page_variable », actually it won't work because we get the parameter « !page_variable » instance of « page_variable ».
