### PR TITLE
fix image size when we have maxwidth and maxheight attributes

### DIFF
--- a/src/main/java/org/mapfish/print/PDFUtils.java
+++ b/src/main/java/org/mapfish/print/PDFUtils.java
@@ -142,7 +142,11 @@ public class PDFUtils {
             }
             else {
                 if (scale == 0f) {
-                    h = w / template.getWidth() * template.getHeight();
+                    float scalew = template.getWidth() / w;
+                    float scaleh = template.getHeight() / h;
+                    float maxscale = Math.max(scalew, scaleh);
+                    w = template.getWidth() / maxscale;
+                    h = template.getHeight() / maxscale;
                 }
                 else {
                     float maxw = w;


### PR DESCRIPTION
Actually when we have the maxwidth and maxheight attributes on an image block, the maxheight is just ignored :(
