### PR TITLE
Update pdfbox dependency to 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   compile ('com.lowagie:itext:2.1.5', 'xerces:xercesImpl:2.4.0', 'org.json:json:20080701', 'org.jyaml:jyaml:1.3',
            'ch.thus:pvalsecc:0.9.2', 'xalan:xalan:2.7.0', 'log4j:log4j:1.2.14', 'com.vividsolutions:jts:1.8',
            "org.mapfish.geo:mapfish-geo-lib:1.2-SNAPSHOT", 'commons-httpclient:commons-httpclient:3.1',
-           'org.geotools:gt-epsg-hsql:2.6.5','org.apache.pdfbox:pdfbox:1.5.0-MAPFISH-1.2', 'javax.media:jai_core:1.1.3',
+           'org.geotools:gt-epsg-hsql:2.6.5','org.apache.pdfbox:pdfbox:1.6.0', 'javax.media:jai_core:1.1.3',
            'javax.media:jai_imageio:1.1', 'javax.media:jai_codec:1.1.3')
   compile ('org.apache.xmlgraphics:batik-transcoder:1.7'){
     exclude module: 'fop'


### PR DESCRIPTION
Image transparency issue included in pdfbox 1.6.0; better use official release.
See https://issues.apache.org/jira/browse/PDFBOX-993
