### PR TITLE
Modify sample JSON files to conform to spec

### DIFF
--- a/samples/spec.json
+++ b/samples/spec.json
@@ -1,21 +1,21 @@
 {
-    layout: 'A4 portrait',
-    title: 'A simple example',
-    srs: 'EPSG:4326',
-    dpi: 254,
-    units: 'degrees',
-    outputFormat: 'png',
-    layers: [{
-            type: 'WMS',
-            layers: ['basic'],
-            baseURL: 'http://labs.metacarta.com/wms/vmap0',
-            format: 'image/jpeg'
+    "layout": "A4 portrait",
+    "title": "A simple example",
+    "srs": "EPSG:4326",
+    "dpi": 254,
+    "units": "degrees",
+    "outputFormat": "png",
+    "layers": [{
+            "type": "WMS",
+            "layers": ["basic"],
+            "baseURL": "http://labs.metacarta.com/wms/vmap0",
+            "format": "image/jpeg"
         },
         {
-            type: 'WMS',
-            layers: ['routes'],
-            baseURL: 'http://www.camptocamp.org/cgi-bin/mapserv_c2corg',
-            format: 'image/png'
+            "type": "WMS",
+            "layers": ["routes"],
+            "baseURL": "http://www.camptocamp.org/cgi-bin/mapserv_c2corg",
+            "format": "image/png"
         },    {
                 "opacity": 0.5,
                 "customParams": {},
@@ -62,32 +62,32 @@
                 "name": "Cosmetic"
             }
     ],
-    pages: [
+    "pages": [
         {
-            center: [6, 45.5],
-            scale: 4000000,
-            mapTitle: "First map",
-            comment: "This is the first page selected by the user.",
-            rotation: 0,
-            data: {
-                data: [
-                    {id:1, name: 'blah', icon: 'icon_pan', nameBackgroundColor: 'red', nameBorderColor: 'blue'},
-                    {id:2, name: 'blip', icon: 'icon_zoomin', nameBackgroundColor: 'yellow', nameBorderColor: 'green'}
+            "center": [6, 45.5],
+            "scale": 4000000,
+            "mapTitle": "First map",
+            "comment": "This is the first page selected by the user.",
+            "rotation": 0,
+            "data": {
+                "data": [
+                    {"id":1, "name": "blah", "icon": "icon_pan", "nameBackgroundColor": "red", "nameBorderColor": "blue"},
+                    {"id":2, "name": "blip", "icon": "icon_zoomin", "nameBackgroundColor": "yellow", "nameBorderColor": "green"}
                 ],
-                columns: ['id', 'name', 'icon']
+                "columns": ["id", "name", "icon"]
             }
         },{
-            center: [6, 45.5],
-            scale: 4000000,
-            mapTitle: "First map",
-            comment: "This is the first page selected by the user.",
-            rotation: 0,
-            data: {
-                data: [
-                    {id:1, name: 'blah', icon: 'icon_pan', nameBackgroundColor: 'red', nameBorderColor: 'blue'},
-                    {id:2, name: 'blip', icon: 'icon_zoomin', nameBackgroundColor: 'yellow', nameBorderColor: 'green'}
+            "center": [6, 45.5],
+            "scale": 4000000,
+            "mapTitle": "First map",
+            "comment": "This is the first page selected by the user.",
+            "rotation": 0,
+            "data": {
+                "data": [
+                    {"id":1, "name": "blah", "icon": "icon_pan", "nameBackgroundColor": "red", "nameBorderColor": "blue"},
+                    {"id":2, "name": "blip", "icon": "icon_zoomin", "nameBackgroundColor": "yellow", "nameBorderColor": "green"}
                 ],
-                columns: ['id', 'name', 'icon']
+                "columns": ["id", "name", "icon"]
             }
         }
     ]

--- a/samples/specGIF.json
+++ b/samples/specGIF.json
@@ -1,39 +1,39 @@
 {
-   layout: 'A4 portrait',
-   title: 'A simple example',
-   srs: 'EPSG:4326',
-   units: 'dd',
-   outputFilename: 'mapfish-print',
-   outputFormat: 'gif',
-   layers: [
+   "layout": "A4 portrait",
+   "title": "A simple example",
+   "srs": "EPSG:4326",
+   "units": "dd",
+   "outputFilename": "mapfish-print",
+   "outputFormat": "gif",
+   "layers": [
        {
-           type: 'WMS',
-           format: 'image/png',
-           layers: ['basic'],
-           baseURL: 'http://labs.metacarta.com/wms/vmap0'
+           "type": "WMS",
+           "format": "image/png",
+           "layers": ["basic"],
+           "baseURL": "http://labs.metacarta.com/wms/vmap0"
        }
    ],
-   pages: [
+   "pages": [
        {
-           center: [6, 45.5],
-           scale: 4000000,
-           dpi: 190,
-           mapTitle: "First map",
-           comment: "The \"routes\" layer is not shown (the scale is too small)",
-           data: [
-               {id:1, name: 'blah', icon: 'icon_pan'},
-               {id:2, name: 'blip', icon: 'icon_zoomin'}
+           "center": [6, 45.5],
+           "scale": 4000000,
+           "dpi": 190,
+           "mapTitle": "First map",
+           "comment": "The 'routes' layer is not shown (the scale is too small)",
+           "data": [
+               {"id":1, "name": "blah", "icon": "icon_pan"},
+               {"id":2, "name": "blip", "icon": "icon_zoomin"}
            ]
        },
        {
-           center: [6.9, 46.2],
-           scale: 500000,
-           dpi: 190,
-           mapTitle: "Second map",
-           comment: "This is a zoomed in version of the first map. Since the scale is more appropriate, we show the \"routes\" layer.",
-           data: [
-               {id:1, name: 'blah', icon: 'icon_pan'},
-               {id:2, name: 'blip', icon: 'icon_zoomin'}
+           "center": [6.9, 46.2],
+           "scale": 500000,
+           "dpi": 190,
+           "mapTitle": "Second map",
+           "comment": "This is a zoomed in version of the first map. Since the scale is more appropriate, we show the 'routes' layer.",
+           "data": [
+               {"id":1, "name": "blah", "icon": "icon_pan"},
+               {"id":2, "name": "blip", "icon": "icon_zoomin"}
            ]
        }
    ]

--- a/samples/specNonPremiumGoogle.json
+++ b/samples/specNonPremiumGoogle.json
@@ -1,42 +1,42 @@
 {
-    layout: 'A4 portrait',
-    title: 'Google Maps Print',
-    srs: 'EPSG:900913',
-    dpi: 254,
-    geodetic: true,
+    "layout": "A4 portrait",
+    "title": "Google Maps Print",
+    "srs": "EPSG:900913",
+    "dpi": 254,
+    "geodetic": true,
 
-    units: 'm',
-    layers: [
+    "units": "m",
+    "layers": [
          {
-        	baseURL: 'http://maps.google.com/maps/api/staticmap',
-        	type : 'TiledGoogle',
-        	maxExtent: [-20037508.3392,-20037508.3392,20037508.3392,20037508.3392],
-        	tileSize: [256,256],
-        	resolutions: [156543.0339,78271.51695,39135.758475,19567.8792375,9783.93961875,4891.969809375,2445.9849046875,1222.99245234375,611.496226171875,305.7481130859375,152.87405654296876,76.43702827148438,38.21851413574219,19.109257067871095,9.554628533935547,4.777314266967774,2.388657133483887,1.1943285667419434,0.5971642833709717],
-        	extension : 'png',
-        	format : 'png32',
-        	sensor: 'false',
-        	language: 'german',
-        	markers: [
-        	    'color:blue|label:S|46.5195933305192,6.566684726913701'
+        	"baseURL": "http://maps.google.com/maps/api/staticmap",
+        	"type" : "TiledGoogle",
+        	"maxExtent": [-20037508.3392,-20037508.3392,20037508.3392,20037508.3392],
+        	"tileSize": [256,256],
+        	"resolutions": [156543.0339,78271.51695,39135.758475,19567.8792375,9783.93961875,4891.969809375,2445.9849046875,1222.99245234375,611.496226171875,305.7481130859375,152.87405654296876,76.43702827148438,38.21851413574219,19.109257067871095,9.554628533935547,4.777314266967774,2.388657133483887,1.1943285667419434,0.5971642833709717],
+        	"extension" : "png",
+        	"format" : "png32",
+        	"sensor": "false",
+        	"language": "german",
+        	"markers": [
+        	    "color:blue|label:S|46.5195933305192,6.566684726913701"
         	],
-        	path: 'color:0x0000ff|weight:5|46.5095933305192,6.506684726913701|46.5195933305192,6.526684726913701|46.5395933305192,6.536684726913701|46.5695933305192,6.576684726913701',
-        	maptype: 'street'
+        	"path": "color:0x0000ff|weight:5|46.5095933305192,6.506684726913701|46.5195933305192,6.526684726913701|46.5395933305192,6.536684726913701|46.5695933305192,6.576684726913701",
+        	"maptype": "street"
         }
     ],
-    pages: [
+    "pages": [
         {
-            center: [731000,5864000],
-            scale: 100000,
-            mapTitle: "Google Map",
-            comment: "This is the first page selected by the user.",
-            rotation: 0,
-            data: {
-                data: [
-                    {id:1, name: 'blah', icon: 'icon_pan', nameBackgroundColor: 'red', nameBorderColor: 'blue'},
-                    {id:2, name: 'blip', icon: 'icon_zoomin', nameBackgroundColor: 'yellow', nameBorderColor: 'green'}
+            "center": [731000,5864000],
+            "scale": 100000,
+            "mapTitle": "Google Map",
+            "comment": "This is the first page selected by the user.",
+            "rotation": 0,
+            "data": {
+                "data": [
+                    {"id":1, "name": "blah", "icon": "icon_pan", "nameBackgroundColor": "red", "nameBorderColor": "blue"},
+                    {"id":2, "name": "blip", "icon": "icon_zoomin", "nameBackgroundColor": "yellow", "nameBorderColor": "green"}
                 ],
-                columns: ['id', 'name', 'icon']
+                "columns": ["id", "name", "icon"]
             }
         }
     ]

--- a/samples/specOSM.json
+++ b/samples/specOSM.json
@@ -1,32 +1,32 @@
 {
-    layout: 'A4 portrait',
-    title: 'A simple example',
-    srs: 'EPSG:900913',
-    dpi: 190,
-    units: 'm',
-    layers: [
+    "layout": "A4 portrait",
+    "title": "A simple example",
+    "srs": "EPSG:900913",
+    "dpi": 190,
+    "units": "m",
+    "layers": [
         {
-        	baseURL: 'http://tile.openstreetmap.org/',
-        	type : 'Osm',
-        	maxExtent: [-20037508.3392,-20037508.3392,20037508.3392,20037508.3392],
-        	tileSize: [256,256],
-        	resolutions: [156543.0339,78271.51695,39135.758475,19567.8792375,9783.93961875,4891.969809375,2445.9849046875,1222.99245234375,611.496226171875,305.7481130859375,152.87405654296876,76.43702827148438,38.21851413574219,19.109257067871095,9.554628533935547,4.777314266967774,2.388657133483887,1.1943285667419434,0.5971642833709717],
-        	extension : 'png'
+        	"baseURL": "http://tile.openstreetmap.org/",
+        	"type" : "Osm",
+        	"maxExtent": [-20037508.3392,-20037508.3392,20037508.3392,20037508.3392],
+        	"tileSize": [256,256],
+        	"resolutions": [156543.0339,78271.51695,39135.758475,19567.8792375,9783.93961875,4891.969809375,2445.9849046875,1222.99245234375,611.496226171875,305.7481130859375,152.87405654296876,76.43702827148438,38.21851413574219,19.109257067871095,9.554628533935547,4.777314266967774,2.388657133483887,1.1943285667419434,0.5971642833709717],
+        	"extension" : "png"
         }
     ],
-    pages: [
+    "pages": [
         {
-            center: [731000,5864000],
-            scale: 100000,
-            mapTitle: "OSM Map",
-            comment: "This is the first page selected by the user.",
-            rotation: 0,
-            data: {
-                data: [
-                    {id:1, name: 'blah', icon: 'icon_pan', nameBackgroundColor: 'red', nameBorderColor: 'blue'},
-                    {id:2, name: 'blip', icon: 'icon_zoomin', nameBackgroundColor: 'yellow', nameBorderColor: 'green'}
+            "center": [731000,5864000],
+            "scale": 100000,
+            "mapTitle": "OSM Map",
+            "comment": "This is the first page selected by the user.",
+            "rotation": 0,
+            "data": {
+                "data": [
+                    {"id":1, "name": "blah", "icon": "icon_pan", "nameBackgroundColor": "red", "nameBorderColor": "blue"},
+                    {"id":2, "name": "blip", "icon": "icon_zoomin", "nameBackgroundColor": "yellow", "nameBorderColor": "green"}
                 ],
-                columns: ['id', 'name', 'icon']
+                "columns": ["id", "name", "icon"]
             }
         }
     ]

--- a/samples/specPremiumGoogle.json
+++ b/samples/specPremiumGoogle.json
@@ -1,42 +1,42 @@
 {
-    layout: 'A4 portrait',
-    title: 'Google Maps Print',
-    srs: 'EPSG:900913',
-    dpi: 254,
-    geodetic: true,
+    "layout": "A4 portrait",
+    "title": "Google Maps Print",
+    "srs": "EPSG:900913",
+    "dpi": 254,
+    "geodetic": true,
 
-    units: 'm',
-    layers: [
+    "units": "m",
+    "layers": [
          {
-        	baseURL: 'http://maps.google.com/maps/api/staticmap',
-        	type : 'Google',
-        	maxExtent: [-20037508.3392,-20037508.3392,20037508.3392,20037508.3392],
-        	tileSize: [256,256],
-        	resolutions: [156543.0339,78271.51695,39135.758475,19567.8792375,9783.93961875,4891.969809375,2445.9849046875,1222.99245234375,611.496226171875,305.7481130859375,152.87405654296876,76.43702827148438,38.21851413574219,19.109257067871095,9.554628533935547,4.777314266967774,2.388657133483887,1.1943285667419434,0.5971642833709717],
-        	extension : 'png',
-        	format : 'png32',
-        	sensor: 'false',
-        	language: 'german',
-        	markers: [
-        	    'color:blue|label:S|46.5195933305192,6.566684726913701'
+        	"baseURL": "http://maps.google.com/maps/api/staticmap",
+        	"type" : "Google",
+        	"maxExtent": [-20037508.3392,-20037508.3392,20037508.3392,20037508.3392],
+        	"tileSize": [256,256],
+        	"resolutions": [156543.0339,78271.51695,39135.758475,19567.8792375,9783.93961875,4891.969809375,2445.9849046875,1222.99245234375,611.496226171875,305.7481130859375,152.87405654296876,76.43702827148438,38.21851413574219,19.109257067871095,9.554628533935547,4.777314266967774,2.388657133483887,1.1943285667419434,0.5971642833709717],
+        	"extension" : "png",
+        	"format" : "png32",
+        	"sensor": "false",
+        	"language": "german",
+        	"markers": [
+        	    "color:blue|label:S|46.5195933305192,6.566684726913701"
         	],
-        	path: 'color:0x0000ff|weight:5|46.5095933305192,6.506684726913701|46.5195933305192,6.526684726913701|46.5395933305192,6.536684726913701|46.5695933305192,6.576684726913701',
-        	maptype: 'street'
+        	"path": "color:0x0000ff|weight:5|46.5095933305192,6.506684726913701|46.5195933305192,6.526684726913701|46.5395933305192,6.536684726913701|46.5695933305192,6.576684726913701",
+        	"maptype": "street"
         }
     ],
-    pages: [
+    "pages": [
         {
-            center: [731000,5864000],
-            scale: 100000,
-            mapTitle: "Google Map",
-            comment: "This is the first page selected by the user.",
-            rotation: 0,
-            data: {
-                data: [
-                    {id:1, name: 'blah', icon: 'icon_pan', nameBackgroundColor: 'red', nameBorderColor: 'blue'},
-                    {id:2, name: 'blip', icon: 'icon_zoomin', nameBackgroundColor: 'yellow', nameBorderColor: 'green'}
+            "center": [731000,5864000],
+            "scale": 100000,
+            "mapTitle": "Google Map",
+            "comment": "This is the first page selected by the user.",
+            "rotation": 0,
+            "data": {
+                "data": [
+                    {"id":1, "name": "blah", "icon": "icon_pan", "nameBackgroundColor": "red", "nameBorderColor": "blue"},
+                    {"id":2, "name": "blip", "icon": "icon_zoomin", "nameBackgroundColor": "yellow", "nameBorderColor": "green"}
                 ],
-                columns: ['id', 'name', 'icon']
+                "columns": ["id", "name", "icon"]
             }
         }
     ]

--- a/samples/specUSGS.json
+++ b/samples/specUSGS.json
@@ -1,30 +1,30 @@
 {
-    layout: 'A4 portrait',
-    title: 'A simple example',
-    srs: 'EPSG:4326',
-    units: 'degrees',
-    layers: [
+    "layout": "A4 portrait",
+    "title": "A simple example",
+    "srs": "EPSG:4326",
+    "units": "degrees",
+    "layers": [
         {
-            type: 'WMS',
-            layers: ['DRG'],
-            baseURL: 'http://terraservice.net/OgcMap.ashx',
-            format: 'image/png'
+            "type": "WMS",
+            "layers": ["DRG"],
+            "baseURL": "http://terraservice.net/OgcMap.ashx",
+            "format": "image/png"
         }
     ],
-    pages: [
+    "pages": [
         {
-            center: [-106, 34],
-            scale: 100000,
-            dpi: 190,
-            mapTitle: "First map",
-            comment: "This is the first page selected by the user.",
-            rotation: 0,
-            data: {
-                data: [
-                    {id:1, name: 'blah', icon: 'icon_pan', nameBackgroundColor: 'red', nameBorderColor: 'blue'},
-                    {id:2, name: 'blip', icon: 'icon_zoomin', nameBackgroundColor: 'yellow', nameBorderColor: 'green'}
+            "center": [-106, 34],
+            "scale": 100000,
+            "dpi": 190,
+            "mapTitle": "First map",
+            "comment": "This is the first page selected by the user.",
+            "rotation": 0,
+            "data": {
+                "data": [
+                    {"id":1, "name": "blah", "icon": "icon_pan", "nameBackgroundColor": "red", "nameBorderColor": "blue"},
+                    {"id":2, "name": "blip", "icon": "icon_zoomin", "nameBackgroundColor": "yellow", "nameBorderColor": "green"}
                 ],
-                columns: ['id', 'name', 'icon']
+                "columns": ["id", "name", "icon"]
             }
         }
     ]

--- a/samples/specVector.json
+++ b/samples/specVector.json
@@ -5,7 +5,7 @@
         "dataOwner":"ch.swisstopo",
         "scale":500000,
         "comment": "This is the first page selected by the user.",
-        mapTitle: "First map"
+        "mapTitle": "First map"
     }
 ],"dpi":"127","units":"m","srs":"EPSG:2169","layers":[
     {
@@ -14,7 +14,7 @@
         "type":"Vector",
         "styles":{
             "1":{"label":"","labelSelect":true,"pointRadius":6,"fillColor":"#ee9900","fillOpacity":0.4,"hoverFillColor":"white","hoverFillOpacity":0.8,"strokeColor":"#ee9900","strokeOpacity":1,"strokeWidth":1,"strokeLinecap":"round","strokeDashstyle":"solid","hoverStrokeColor":"red","hoverStrokeOpacity":1,"hoverStrokeWidth":0.2,"hoverPointRadius":1,"hoverPointUnit":"%","pointerEvents":"visiblePainted","cursor":"inherit"},
-            "2":{"label":"Vérité","labelSelect":true,fontFamily:"Courier",fontColor:"#FF0000",fontSize:28,fontWeight:"Bold",labelAlign:"rt",labelXOffset:-25,labelYOffset:-25,"pointRadius":0,"fillColor":"#ee9900","fillOpacity":0.4,"hoverFillColor":"white","hoverFillOpacity":0.8,"strokeColor":"#ee9900","strokeOpacity":1,"strokeWidth":1,"strokeLinecap":"round","strokeDashstyle":"solid","hoverStrokeColor":"red","hoverStrokeOpacity":1,"hoverStrokeWidth":0.2,"hoverPointRadius":1,"hoverPointUnit":"%","pointerEvents":"visiblePainted","cursor":"inherit"},
+            "2":{"label":"Vérité","labelSelect":true,"fontFamily":"Courier","fontColor":"#FF0000","fontSize":28,"fontWeight":"Bold","labelAlign":"rt","labelXOffset":-25,"labelYOffset":-25,"pointRadius":0,"fillColor":"#ee9900","fillOpacity":0.4,"hoverFillColor":"white","hoverFillOpacity":0.8,"strokeColor":"#ee9900","strokeOpacity":1,"strokeWidth":1,"strokeLinecap":"round","strokeDashstyle":"solid","hoverStrokeColor":"red","hoverStrokeOpacity":1,"hoverStrokeWidth":0.2,"hoverPointRadius":1,"hoverPointUnit":"%","pointerEvents":"visiblePainted","cursor":"inherit"},
             "3":{"label":"","labelSelect":true,"pointRadius":6,"fillColor":"#ee9900","fillOpacity":0.4,"hoverFillColor":"white","hoverFillOpacity":0.8,"strokeColor":"#ee9900","strokeOpacity":1,"strokeWidth":1,"strokeLinecap":"round","strokeDashstyle":"solid","hoverStrokeColor":"red","hoverStrokeOpacity":1,"hoverStrokeWidth":0.2,"hoverPointRadius":1,"hoverPointUnit":"%","pointerEvents":"visiblePainted","cursor":"inherit"},
             "4":{"label":"","labelSelect":true,"pointRadius":6,"fillColor":"#ee9900","fillOpacity":0.4,"hoverFillColor":"white","hoverFillOpacity":0.8,"strokeColor":"#ee9900","strokeOpacity":1,"strokeWidth":1,"strokeLinecap":"round","strokeDashstyle":"solid","hoverStrokeColor":"red","hoverStrokeOpacity":1,"hoverStrokeWidth":0.2,"hoverPointRadius":1,"hoverPointUnit":"%","pointerEvents":"visiblePainted","cursor":"inherit"}},
         "styleProperty":"_style",
@@ -84,4 +84,4 @@
         "name":"overview"
     }
 ],"layout":"A4 portrait",
-title: 'A simple example'}
+"title": "A simple example"}

--- a/samples/specVector2.json
+++ b/samples/specVector2.json
@@ -2,7 +2,7 @@
    "units" : "m",
    "srs" : "EPSG:2180",
    "layout" : "A4 portrait",
-   "title": 'A simple example',
+   "title": "A simple example",
    "dpi" : 127,
    "layers" :
       [


### PR DESCRIPTION
Some of the sample files are invalid JSON currently, and this can present problems for people who may want to parse them in the process of templating them or using a network client to post them.

from http://simonwillison.net/2006/oct/11/json/
"In JSON (unlike in JavaScript) these MUST be double-quoted strings. In fact, ALL strings in JSON must be enclosed in double quotes (JavaScript also allows single quotes; JSON does not)."
"This stuff matters. Python’s excellent simplejson module is a strict parser; it refuses to consume invalid JSON."

In my example, ruby's JSON module was kicking them out as invalid.

So I modified them to pass validation.Basically it was a lot of double-quotes needed.Now these pass through JSONLint without warnings.

I understand these are sample files, but people often use files such as these as a starting point for their own designs, so why not give them a leg up and ease confusion?
