### PR TITLE
support for Vector style 'stroke' and 'fill' attributes 

### DIFF
--- a/src/main/java/org/mapfish/print/map/renderers/vector/LineStringRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/LineStringRenderer.java
@@ -88,6 +88,6 @@ public class LineStringRenderer extends GeometriesRenderer<LineString> {
             Coordinate coord = coords[i];
             dc.lineTo((float) coord.x, (float) coord.y);
         }
-        dc.stroke();
+        if (style.optBool("stroke", true)) dc.stroke();
     }
 }

--- a/src/main/java/org/mapfish/print/map/renderers/vector/PointRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/PointRenderer.java
@@ -130,8 +130,14 @@ public class PointRenderer extends GeometriesRenderer<Point> {
             PolygonRenderer.applyStyle(context, dc, style, state);
             dc.setGState(state);
 
-            dc.circle((float) coordinate.x, (float) coordinate.y, pointRadius * f);
-            dc.fillStroke();
+            dc.circle((float) coordinate.x, (float) coordinate.y, pointRadius * f);            
+            renderStrokeAndFill(dc, style.optBool("stroke", true), style.optBool("fill", true));
         }
+    }
+
+    private void renderStrokeAndFill(PdfContentByte dc, boolean stroke, boolean fill) {
+        if (stroke && fill) dc.fillStroke();
+        else if (stroke) dc.stroke();
+        else if (fill) dc.fill();
     }
 }

--- a/src/main/java/org/mapfish/print/map/renderers/vector/PolygonRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/PolygonRenderer.java
@@ -52,7 +52,7 @@ class PolygonRenderer extends GeometriesRenderer<Polygon> {
         for (int i = 0; i < geometry.getNumInteriorRing(); ++i) {
             renderRing(dc, geometry.getInteriorRingN(i));
         }
-        dc.eoFillStroke();
+        renderStrokeAndFill(dc, style.optBool("stroke", true), style.optBool("fill", true));
     }
 
     private void renderRing(PdfContentByte dc, LineString ring) {
@@ -64,5 +64,11 @@ class PolygonRenderer extends GeometriesRenderer<Polygon> {
             dc.lineTo((float) coord.x, (float) coord.y);
         }
         dc.closePath();
+    }
+    
+    private void renderStrokeAndFill(PdfContentByte dc, boolean stroke, boolean fill) {
+        if (stroke && fill) dc.eoFillStroke();
+        else if (stroke) dc.stroke();
+        else if (fill) dc.eoFill();
     }
 }


### PR DESCRIPTION
Hi, my application had been using the OpenLayers.Feature.Vector.style boolean attributes 'stroke' and 'fill' as described here:

http://dev.openlayers.org/docs/files/OpenLayers/Feature/Vector-js.html#OpenLayers.Feature.Vector.OpenLayers.Feature.Vector.style

...to switch on/off stroking and filling. This didn't seem to be supported by mapfish-print so I implemented a fix for that. Please include if you think others would find it useful (or please advise how I can improve it!)

Thanks
