### PR TITLE
externalgraphic + grahpicyoffset was not working properly

### DIFF
--- a/src/main/java/org/mapfish/print/map/renderers/vector/PointRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/PointRenderer.java
@@ -102,7 +102,8 @@ public class PointRenderer extends GeometriesRenderer<Point> {
             try {
                 Image image = PDFUtils.createImage(context, width * f, height * f, new URI(style.getString("externalGraphic")), 0.0f);
                 // fix for height: because the coordinate system is mirrored, we need to move the image by height, and then subtract the offset
-                image.setAbsolutePosition((float) coordinate.x + offsetX * f, (float) coordinate.y - height * f - offsetY * f);                dc.addImage(image);
+                image.setAbsolutePosition((float) coordinate.x + offsetX * f, (float) coordinate.y - height * f - offsetY * f);
+                dc.addImage(image);
             } catch (BadElementException e) {
                 context.addError(e);
             } catch (URISyntaxException e) {


### PR DESCRIPTION
due to the way graphicyoffset was handled, the offset was working vice versa to the appropriate openlayers code.
As an example: yoffset: 0 would produce an icon with an arrow pointing to the bottom to be set "just right" with the arrow pointing at the coordinates in mapfish-print, however yoffset: -height would do the same in openlayers.
This minor code change changes the behaviour for externalGraphic:
yNew = y - height - yoffset
because yoffset is negative and height is positiv, an yoffset of -height will cancel out the height.
the default value of yoffset = -height/2.0f is still the same and is still producing the same effect.
