### PR TITLE
Fixes issue 24 - Spring's DI problems with multiple applications using the MFPM

### DIFF
--- a/src/main/resources/spring-application-context.xml
+++ b/src/main/resources/spring-application-context.xml
@@ -5,7 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 	<context:annotation-config></context:annotation-config>
-	<bean id="mapPrinter" class="org.mapfish.print.MapPrinter"></bean>
+    <!-- mapPrinter commented out, see BaseMapServlet for new logic -->
+	<!--<bean id="mapPrinter" class="org.mapfish.print.MapPrinter"></bean>-->
 	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
 
 	<!-- Define MapReaderFactories -->


### PR DESCRIPTION
Our applications broke because of an introduced bug by "Springifying" the application. It was not considered that more than one MapPrinter objects are needed. Details can be found in the issue.
