### PR TITLE
Openjdk PDF Test patch

### DIFF
--- a/src/test/java/org/mapfish/print/PdfTestCase.java
+++ b/src/test/java/org/mapfish/print/PdfTestCase.java
@@ -60,9 +60,12 @@ public abstract class PdfTestCase extends PrintTestCase {
         spec.getInternalObj().put("units", "meters");
 
         doc = new Document(PageSize.A4);
+
+        //This test expects to be able to write files into the same directory the classes
+        //are compiled to, in this case the build/classes/test directory
+        String expectedPath = "build"+File.separator + "classes" + File.separator + "test";
         String baseDir = PdfTestCase.class.getClassLoader().getResource(".").getFile();
         if(baseDir.indexOf("pulse-java.jar") != -1){
-            String expectedPath = "build"+File.separator + "classes" + File.separator + "test";
             String[] paths = System.getProperty("java.class.path").split(File.pathSeparator);
 
             for(String path : paths){


### PR DESCRIPTION
When running the gradle tests from within Intellij (and likely other ides and environments) using openjdk, the classloader differences cause some of the tests to fail.  While the wrapper script provided is great for cli usage, it doesn't help for those attempting to run from these integrated environments.

This patch updates the way the pdf unit tests look for their "base directory," and if a openjdk-based failure is detected, attempts to use an alternate, claspath based lookup method.

This should be a near no-op for situations where the previous approach was already sufficient.
