### PR TITLE
custom Params is defined twice in the docs

### DIFF
--- a/docs/protocol.txt
+++ b/docs/protocol.txt
@@ -182,7 +182,6 @@ Support for the WMS protocol with possibilities to go through a WMS-C service (T
 * layers (Required)
 * styles (Optional)
 * format (Required)
-* customParams (Optional) Map, additional URL arguments
 * useNativeAngle (Defaults to false) it true transform the map angle to customParams.angle for GeoServer, and customParams.map_angle for MapServer.
 
 WMTS


### PR DESCRIPTION
Fix a bug in the wms section of the protocol documentation where it listed customParams twice
