### PR TITLE
Standalone application hangs on completion

### DIFF
--- a/src/main/java/org/mapfish/print/ShellMapPrinter.java
+++ b/src/main/java/org/mapfish/print/ShellMapPrinter.java
@@ -222,5 +222,7 @@ public class ShellMapPrinter {
             }
             System.exit(-2);
         }
+        System.exit(0);
+
     }
 }


### PR DESCRIPTION
Not sure what is left hanging around at the end of the main/run methods, but something is stopping the application (as run via ShellMapPrinter class) from closing.

Manually calling System.exit resolves this. Not sure if we want to open a bug to track down what is still not destroyed or if we don't care.
