### PR TITLE
Check externalGraphic void string.

### DIFF
--- a/src/main/java/org/mapfish/print/map/renderers/vector/PointRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/PointRenderer.java
@@ -123,7 +123,7 @@ public class PointRenderer extends GeometriesRenderer<Point> {
         // See Feature/Vector.js for more information about labels 
         String label = style.optString("label");
         
-        if (style.optString("externalGraphic") != null) {
+        if ((style.optString("externalGraphic") != null ) && (style.optString("externalGraphic").length() > 0)) {
             float opacity = style.optFloat("graphicOpacity", style.optFloat("fillOpacity", 1.0f));
             state.setFillOpacity(opacity);
             state.setStrokeOpacity(opacity);


### PR DESCRIPTION
Check externalGraphic void string. There is a similar check in LabelRenderer.java
It makes possible to print clusters in vector layers like:

```
var layer = new OpenLayers.Layer.Vector('MyVectorLayer', {
    styleMap: new OpenLayers.StyleMap({
        "default": new OpenLayers.Style({
            pointRadius: 10,
    externalGraphic: "${externalGraphic}",
            graphicHeight: "${graphicHeight}",
            graphicWidth: "${graphicWidth}",
        label: "${count}",
            labelAlign: "cm",
            labelYOffset: "${labelYOffset}",
            fontSize: "13px",
            fontFamily: "arial,helvetica,clean,sans-serif",
            fontWeight: "bold",
            fillColor: "#fff",
            strokeColor: "#333",
            strokeWidth: 2,
            cursor: "pointer",
        }, {
            context: {
                externalGraphic: function(feature) {
                    if (feature.cluster.length == 1) {
                        var type = feature.cluster[0].attributes.type;
                        switch(type) {
                        case 1: 
                            return OpenLayers.ImgPath + "img/img1.png";
                        case 2: 
                            return OpenLayers.ImgPath + "img/img2.png";
                        }
                    }
                    return '';
                },
                count: function(feature) {
                    return feature.attributes.count > 1 ? feature.attributes.count : '';
                },
                graphicWidth: function(feature) {
                    if (feature.cluster.length == 1) {
                        var type = feature.cluster[0].attributes.type;
                        if (type == 1 || type == 2 || type == 4) {
                            return 21;
                        } else if (type == 3) {
                            return 15;
                        }
                    }
                },
                graphicHeight: function(feature) {
                    if (feature.cluster.length == 1) {
                        var type = feature.cluster[0].attributes.type;
                        if (type == 1 || type == 2 || type == 3) {
                            return 17;
                        } else if (type == 4) {
                            return 22;
                        }
                    }
                }
            }
        }),
    }),
    strategies: [new OpenLayers.Strategy.Fixed(), cluster],
    protocol: new OpenLayers.Protocol.Script({
        url: options.wmsURL,
        format: new OpenLayers.Format.GeoJSON(),
        params: {
            service: "WFS",
            version: "1.1.0",
            request: "GetFeature",
            typename: 'feature:' + options.layerName,
            outputformat: 'geojsonp',
            lang: OpenLayers.Lang.getCode()
        }
    })
});
```
