### PR TITLE
Add a strokeLinejoin for vector styling

### DIFF
--- a/src/main/java/org/mapfish/print/map/renderers/vector/LineStringRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/LineStringRenderer.java
@@ -34,6 +34,7 @@ import com.vividsolutions.jts.geom.LineString;
 public class LineStringRenderer extends GeometriesRenderer<LineString> {
     protected static void applyStyle(RenderingContext context, PdfContentByte dc, PJsonObject style, PdfGState state) {
         if (style == null) return;
+
         if (style.optString("strokeColor") != null) {
             dc.setColorStroke(ColorWrapper.convertColor(style.getString("strokeColor")));
         }
@@ -52,6 +53,18 @@ public class LineStringRenderer extends GeometriesRenderer<LineString> {
                 dc.setLineCap(PdfContentByte.LINE_CAP_PROJECTING_SQUARE);
             } else {
                 throw new InvalidValueException("strokeLinecap", linecap);
+            }
+        }
+        final String linejoin = style.optString("strokeLinejoin");
+        if (linejoin != null) {
+            if (linejoin.equalsIgnoreCase("bevel")) {
+                dc.setLineJoin(PdfContentByte.LINE_JOIN_BEVEL);
+            } else if (linejoin.equalsIgnoreCase("miter")) {
+                dc.setLineJoin(PdfContentByte.LINE_JOIN_MITER);
+            } else if (linejoin.equalsIgnoreCase("round")) {
+                dc.setLineJoin(PdfContentByte.LINE_JOIN_ROUND);
+            } else {
+                throw new InvalidValueException("strokeLinecap", linejoin);
             }
         }
         final String dashStyle = style.optString("strokeDashstyle");


### PR DESCRIPTION
Some vector layers with sharp edges like GPS track look very ugly with the library default `PdfContentByte.LINE_JOIN_MITER` 
![print-kml-linejoinmiter](https://f.cloud.github.com/assets/1236739/1899077/3d05bdb6-7c33-11e3-847a-7a6f9a276311.png)

This PR propose to add a `strokeLinejoin` vector style property, similar to the existing `strokeLinecap` one.
So defining the above example with `"strokeLinejoin": "round"`, we will improve the rendering.

![print-kml-linejoinround](https://f.cloud.github.com/assets/1236739/1899105/c71aa30e-7c33-11e3-8cf9-05f0bee3305e.png)

Possible values for `strokeLinejoin` are `miter` (default), `round` and `bevel`.
