### PR TITLE
Added multiple maps on single page support

### DIFF
--- a/docs/protocol.txt
+++ b/docs/protocol.txt
@@ -171,6 +171,67 @@ HTTP command::
 
 Returns the PDF. Can be called only during a limited time since the server side temporary file is deleted afterwards.
 
+Multiple maps on a single page
+******************************
+To print more than one map on a single page you need to:
+ * specify several map blocks in a page of the yaml file, each with a distinct name property value
+ * use a particular syntax in the spec to bind different rendering properties to each map block
+ 
+This is possible specifying a _maps_ object in spec root object with a distinct key - object pair for each map. The
+key will refer the map block name as defined in yaml file. The object will contain layers and srs for the named map.
+Another _maps_ object has to be specified inside the page object to describe positioning, scale and so on.
+
+.. code-block:: javascript
+
+    {
+        ...
+        maps: {
+            "main": {
+                layers: [
+                    ...
+                ],
+                srs: 'EPSG:4326'
+            },
+            "other": {
+                layers: [
+                    ...
+                ],
+                srs: 'EPSG:4326'
+            }
+        },
+        ...
+        pages: [
+            {
+                maps: {
+                    "main": {
+                        center: [6, 45.5],
+                        scale: 4000000,
+                        dpi: 190,
+                        geodetic: false,
+                        strictEpsg4326: false,
+                        ...CUSTOM_PARAMS...
+                    },
+                    "other": {
+                        center: [7.2, 38.6],
+                        scale: 1000000,
+                        dpi: 300,
+                        geodetic: false,
+                        strictEpsg4326: false,
+                        ...CUSTOM_PARAMS...
+                    }
+                }
+                
+            }
+        ],
+        ...
+    }
+
+Other config blocks have been enabled to multiple maps usage.
+The scalebar block can be bound to a specific map, specifying a name property that matches the map
+name.
+Also, in text blocks you can use the ${scale.<mapname>} placeholder to print the scale of the map
+whose name is <mapname>.
+
 Layers Params
 *************
 

--- a/src/main/java/org/mapfish/print/config/layout/Block.java
+++ b/src/main/java/org/mapfish/print/config/layout/Block.java
@@ -50,7 +50,7 @@ public abstract class Block {
      */
     public abstract void render(PJsonObject params, PdfElement target, RenderingContext context) throws DocumentException;
 
-    public MapBlock getMap() {
+    public MapBlock getMap(String name) {
         return null;
     }
 
@@ -79,7 +79,7 @@ public abstract class Block {
     }
 
     public Color getBackgroundColorVal(RenderingContext context, PJsonObject params) {
-        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, backgroundColor));
+        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, backgroundColor, null));
     }
 
     public void setBackgroundColor(String backgroundColor) {

--- a/src/main/java/org/mapfish/print/config/layout/BorderConfig.java
+++ b/src/main/java/org/mapfish/print/config/layout/BorderConfig.java
@@ -91,19 +91,19 @@ public class BorderConfig {
     }
 
     public Color getBorderColorLeftVal(RenderingContext context, PJsonObject params) {
-        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorLeft));
+        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorLeft, null));
     }
 
     public Color getBorderColorTopVal(RenderingContext context, PJsonObject params) {
-        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorTop));
+        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorTop, null));
     }
 
     public Color getBorderColorRightVal(RenderingContext context, PJsonObject params) {
-        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorRight));
+        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorRight, null));
     }
 
     public Color getBorderColorBottomVal(RenderingContext context, PJsonObject params) {
-        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorBottom));
+        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, borderColorBottom, null));
     }
 
     public void validate() {

--- a/src/main/java/org/mapfish/print/config/layout/CellConfig.java
+++ b/src/main/java/org/mapfish/print/config/layout/CellConfig.java
@@ -105,7 +105,7 @@ public class CellConfig extends BorderConfig {
     }
 
     public Color getBackgroundColorVal(RenderingContext context, PJsonObject params) {
-        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, backgroundColor));
+        return ColorWrapper.convertColor(PDFUtils.evalString(context, params, backgroundColor, null));
     }
 
     public void setAlign(HorizontalAlign align) {

--- a/src/main/java/org/mapfish/print/config/layout/ColumnsBlock.java
+++ b/src/main/java/org/mapfish/print/config/layout/ColumnsBlock.java
@@ -111,9 +111,9 @@ public class ColumnsBlock extends Block {
                 width != Double.MIN_VALUE;
     }
 
-    public MapBlock getMap() {
+    public MapBlock getMap(String name) {
         for (Block item : items) {
-            MapBlock result = item.getMap();
+            MapBlock result = item.getMap(name);
             if (result != null) {
                 return result;
             }

--- a/src/main/java/org/mapfish/print/config/layout/ImageBlock.java
+++ b/src/main/java/org/mapfish/print/config/layout/ImageBlock.java
@@ -54,7 +54,7 @@ public class ImageBlock extends Block {
     public void render(PJsonObject params, PdfElement target, RenderingContext context) throws DocumentException {
         final URI url;
         try {
-            final String urlTxt = PDFUtils.evalString(context, params, this.url);
+            final String urlTxt = PDFUtils.evalString(context, params, this.url, null);
             url = new URI(urlTxt);
         } catch (URISyntaxException e) {
             throw new InvalidValueException("url", this.url, e);
@@ -67,7 +67,7 @@ public class ImageBlock extends Block {
     }
 
     private float getRotationRadian(RenderingContext context, PJsonObject params) {
-        return (float) (Float.parseFloat(PDFUtils.evalString(context, params, this.rotation)) * Math.PI / 180.0F);
+        return (float) (Float.parseFloat(PDFUtils.evalString(context, params, this.rotation, null)) * Math.PI / 180.0F);
     }
 
     private void drawSVG(RenderingContext context, PJsonObject params, PdfElement paragraph, URI url) throws DocumentException {

--- a/src/main/java/org/mapfish/print/config/layout/MainPage.java
+++ b/src/main/java/org/mapfish/print/config/layout/MainPage.java
@@ -41,7 +41,7 @@ public class MainPage extends Page {
     }
 
     public void printClientConfig(JSONWriter json) throws JSONException {
-        MapBlock map = getMap();
+        MapBlock map = getMap(null);
         if (map != null) {
             json.key("map");
             map.printClientConfig(json);
@@ -63,11 +63,11 @@ public class MainPage extends Page {
         super.render(params, context);
     }
 
-    public MapBlock getMap() {
+    public MapBlock getMap(String name) {
         MapBlock result = null;
         for (int i = 0; i < items.size() && result == null; i++) {
             Block block = items.get(i);
-            result = block.getMap();
+            result = block.getMap(name);
         }
         return result;
     }

--- a/src/main/java/org/mapfish/print/config/layout/MetaData.java
+++ b/src/main/java/org/mapfish/print/config/layout/MetaData.java
@@ -70,23 +70,23 @@ public class MetaData {
         final Document doc = context.getDocument();
 
         if (title != null) {
-            doc.addTitle(PDFUtils.evalString(context, params, title));
+            doc.addTitle(PDFUtils.evalString(context, params, title, null));
         }
 
         if (author != null) {
-            doc.addAuthor(PDFUtils.evalString(context, params, author));
+            doc.addAuthor(PDFUtils.evalString(context, params, author, null));
         }
 
         if (subject != null) {
-            doc.addSubject(PDFUtils.evalString(context, params, subject));
+            doc.addSubject(PDFUtils.evalString(context, params, subject, null));
         }
 
         if (keywords != null) {
-            doc.addKeywords(PDFUtils.evalString(context, params, keywords));
+            doc.addKeywords(PDFUtils.evalString(context, params, keywords, null));
         }
 
         if (creator != null) {
-            doc.addCreator(PDFUtils.evalString(context, params, creator));
+            doc.addCreator(PDFUtils.evalString(context, params, creator, null));
         }
     }
 }

--- a/src/main/java/org/mapfish/print/config/layout/Page.java
+++ b/src/main/java/org/mapfish/print/config/layout/Page.java
@@ -58,7 +58,7 @@ public class Page {
                     getMarginTop(context, params) + (header != null ? header.getHeight() : 0),
                     getMarginBottom(context, params) + (footer != null ? footer.getHeight() : 0));
 
-            context.getCustomBlocks().setBackgroundPdf(PDFUtils.evalString(context, params, backgroundPdf));
+            context.getCustomBlocks().setBackgroundPdf(PDFUtils.evalString(context, params, backgroundPdf, null));
             if (doc.isOpen()) {
                 doc.newPage();
             } else {
@@ -110,7 +110,7 @@ public class Page {
     }
 
     public String getPageSize(RenderingContext context, PJsonObject params) {
-        return PDFUtils.evalString(context, params, pageSize);
+        return PDFUtils.evalString(context, params, pageSize, null);
     }
 
     public void setPageSize(String pageSize) {
@@ -131,19 +131,19 @@ public class Page {
     }
 
     public int getMarginLeft(RenderingContext context, PJsonObject params) {
-        return Integer.parseInt(PDFUtils.evalString(context, params, marginLeft));
+        return Integer.parseInt(PDFUtils.evalString(context, params, marginLeft, null));
     }
 
     public int getMarginRight(RenderingContext context, PJsonObject params) {
-        return Integer.parseInt(PDFUtils.evalString(context, params, marginRight));
+        return Integer.parseInt(PDFUtils.evalString(context, params, marginRight, null));
     }
 
     public int getMarginTop(RenderingContext context, PJsonObject params) {
-        return Integer.parseInt(PDFUtils.evalString(context, params, marginTop));
+        return Integer.parseInt(PDFUtils.evalString(context, params, marginTop, null));
     }
 
     public int getMarginBottom(RenderingContext context, PJsonObject params) {
-        return Integer.parseInt(PDFUtils.evalString(context, params, marginBottom));
+        return Integer.parseInt(PDFUtils.evalString(context, params, marginBottom, null));
     }
 
     public void setMarginLeft(String marginLeft) {

--- a/src/main/java/org/mapfish/print/config/layout/ScalebarBlock.java
+++ b/src/main/java/org/mapfish/print/config/layout/ScalebarBlock.java
@@ -34,6 +34,7 @@ import org.mapfish.print.scalebar.Label;
 import org.mapfish.print.scalebar.ScalebarDrawer;
 import org.mapfish.print.scalebar.Type;
 import org.mapfish.print.utils.DistanceUnit;
+import org.mapfish.print.utils.Maps;
 import org.mapfish.print.utils.PJsonObject;
 
 import com.lowagie.text.DocumentException;
@@ -74,6 +75,8 @@ public class ScalebarBlock extends FontBlock {
     private String barBgColor = null;
 
     private Double lineWidth = null;
+    
+    private String name = null;
 
 
     public void render(PJsonObject params, PdfElement target, RenderingContext context) throws DocumentException {
@@ -83,7 +86,7 @@ public class ScalebarBlock extends FontBlock {
             throw new InvalidJsonValueException(globalParams, "units", globalParams.getString("units"));
         }
         DistanceUnit scaleUnit = (units != null ? units : mapUnits);
-        final double scale = context.getLayout().getMainPage().getMap().createTransformer(context, params).getScale();
+        final double scale = context.getLayout().getMainPage().getMap(name).createTransformer(context, params).getScale();
 
         final double maxWidthIntervaleDistance = DistanceUnit.PT.convertTo(maxSize, scaleUnit) * scale / intervals;
         final double intervalDistance = getNearestNiceValue(maxWidthIntervaleDistance, scaleUnit);
@@ -371,4 +374,14 @@ public class ScalebarBlock extends FontBlock {
     public Color getColorVal() {
         return ColorWrapper.convertColor(color);
     }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    
 }

--- a/src/main/java/org/mapfish/print/config/layout/TextBlock.java
+++ b/src/main/java/org/mapfish/print/config/layout/TextBlock.java
@@ -43,7 +43,7 @@ public class TextBlock extends FontBlock {
         final Font pdfFont = getPdfFont();
         paragraph.setFont(pdfFont);
 
-        final Phrase text = PDFUtils.renderString(context, params, this.text, pdfFont);
+        final Phrase text = PDFUtils.renderString(context, params, this.text, pdfFont, null);
         paragraph.add(text);
 
         if (getAlign() != null) paragraph.setAlignment(getAlign().getCode());

--- a/src/main/java/org/mapfish/print/map/MapChunkDrawer.java
+++ b/src/main/java/org/mapfish/print/map/MapChunkDrawer.java
@@ -29,6 +29,7 @@ import org.mapfish.print.PDFCustomBlocks;
 import org.mapfish.print.RenderingContext;
 import org.mapfish.print.Transformer;
 import org.mapfish.print.map.readers.MapReader;
+import org.mapfish.print.utils.Maps;
 import org.mapfish.print.utils.PJsonArray;
 import org.mapfish.print.utils.PJsonObject;
 
@@ -68,7 +69,7 @@ public class MapChunkDrawer extends ChunkDrawer {
     }
 
     public void renderImpl(Rectangle rectangle, PdfContentByte dc) {
-        final PJsonObject parent = context.getGlobalParams();
+        final PJsonObject parent = Maps.getMapRoot(context.getGlobalParams(), name);
         PJsonArray layers = parent.getJSONArray("layers");
         String srs = parent.getString("srs");
 
@@ -79,7 +80,7 @@ public class MapChunkDrawer extends ChunkDrawer {
         Transformer mainTransformer = null;
         if (!Double.isNaN(overviewMap)) {
             //manage the overview map
-            mainTransformer = context.getLayout().getMainPage().getMap().createTransformer(context, params);
+            mainTransformer = context.getLayout().getMainPage().getMap(name).createTransformer(context, params);
             transformer.zoom(mainTransformer, (float) (1.0 / overviewMap));
             transformer.setRotation(0);   //overview always north up!
             context.setStyleFactor((float) (transformer.getPaperW() / mainTransformer.getPaperW() / overviewMap));

--- a/src/main/java/org/mapfish/print/utils/Maps.java
+++ b/src/main/java/org/mapfish/print/utils/Maps.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2014  Camptocamp
+ *
+ * This file is part of MapFish Print
+ *
+ * MapFish Print is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MapFish Print is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MapFish Print.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapfish.print.utils;
+
+/**
+ * Utility class for map blocks management.
+ * 
+ * @author mbarto
+ *
+ */
+public class Maps {
+    /**
+     * Extracts a map configuration for the given map name.
+     * 
+     * @param parent
+     * @param name
+     * @return
+     */
+    public static PJsonObject getMapRoot(PJsonObject parent, String name) {
+        // if we have multiple maps they are configured in a maps block
+        PJsonObject maps = parent.optJSONObject("maps");
+        if (maps != null && name != null) {
+            if(maps.has(name)) { 
+                return maps.getJSONObject(name);
+            } else {
+                throw new RuntimeException("Cannot find any map named " + name);
+            }
+        }
+        return parent;
+    }
+}

--- a/src/test/java/org/mapfish/print/ScalebarTest.java
+++ b/src/test/java/org/mapfish/print/ScalebarTest.java
@@ -50,8 +50,8 @@ public class ScalebarTest extends PdfTestCase {
             dc.lineTo(MARGIN + 100 * i, height);
         }
         dc.stroke();*/
-        context.getLayout().getMainPage().getMap().setWidth("100");
-        context.getLayout().getMainPage().getMap().setHeight("100");
+        context.getLayout().getMainPage().getMap(null).setWidth("100");
+        context.getLayout().getMainPage().getMap(null).setHeight("100");
         ScalebarBlock block = createBaseBlock();
         draw(page1, doc, context, block);
 

--- a/src/test/java/org/mapfish/print/config/layout/MapBlockTest.java
+++ b/src/test/java/org/mapfish/print/config/layout/MapBlockTest.java
@@ -1,24 +1,48 @@
 package org.mapfish.print.config.layout;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.TreeSet;
+
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.renderer.lite.RendererUtilities;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mapfish.print.MapPrinter;
+import org.mapfish.print.PDFCustomBlocks;
 import org.mapfish.print.RenderingContext;
 import org.mapfish.print.Transformer;
 import org.mapfish.print.config.Config;
+import org.mapfish.print.map.readers.MapReaderFactory;
+import org.mapfish.print.map.readers.MapReaderFactoryFinder;
+import org.mapfish.print.map.readers.VectorMapReader;
 import org.mapfish.print.utils.DistanceUnit;
 import org.mapfish.print.utils.PJsonObject;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.pvalsecc.misc.FileUtilities;
 
-import java.util.Collections;
-import java.util.TreeSet;
-
-import static org.junit.Assert.assertEquals;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Element;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfTemplate;
+import com.lowagie.text.pdf.PdfWriter;
 
 /**
  * Test MapBlock's createTransformer method.
@@ -35,6 +59,9 @@ public class MapBlockTest {
     private Config config;
     private double centerY;
     private double centerX;
+    
+    private static String tempDir = System.getProperty("java.io.tmpdir");
+    private static String fileSeparator = System.getProperty("file.separator");
 
     @Before
     public void init(){
@@ -210,5 +237,85 @@ public class MapBlockTest {
         assertEquals(maxx, transformer.getMaxGeoX(), delta);
         assertEquals(miny, transformer.getMinGeoY(), delta);
         assertEquals(maxy, transformer.getMaxGeoY(), delta);
+    }
+    
+    @Test
+    public void testMultipleMaps() throws IOException, DocumentException,
+            JSONException {
+    
+        PJsonObject globalParams = MapPrinter.parseSpec(FileUtilities
+                .readWholeTextFile(new File(MapBlockTest.class.getClassLoader()
+                        .getResource("config/multiple-maps.json").getFile())));
+        
+        PJsonObject params = globalParams.getJSONArray("pages").getJSONObject(0);
+        
+        // mocked PdfWriter
+        final PdfWriter writer = Mockito.mock(PdfWriter.class);
+        final PdfContentByte dc = Mockito.mock(PdfContentByte.class);
+        Mockito.when(writer.getDirectContent()).thenReturn(dc);
+        
+        // mocked RenderingContext
+        final RenderingContext context = Mockito.mock(RenderingContext.class);
+        Mockito.when(context.getGlobalParams()).thenReturn(globalParams);
+        Mockito.when(context.getConfig()).thenReturn(config);
+        Mockito.when(context.getPdfLock()).thenReturn(new Object());
+        PDFCustomBlocks blocks = new PDFCustomBlocks(writer, context);
+        Mockito.when(context.getCustomBlocks()).thenReturn(blocks);
+        Mockito.when(context.getWriter()).thenReturn(writer);
+        
+        
+        
+        // mock the MapReader creation chain to return a VectorMapReader for test layers
+        MapReaderFactoryFinder finder = Mockito.mock(MapReaderFactoryFinder.class);
+        config.setMapReaderFactoryFinder(finder);
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                VectorMapReader reader = new VectorMapReader(context, (PJsonObject)invocation.getArguments()[3]);
+                ((List)invocation.getArguments()[0]).add(reader);
+                return reader;
+            }
+            
+        }).when(finder).create(Mockito.anyList(),Mockito.anyString(),Mockito.any(RenderingContext.class), Mockito.any(PJsonObject.class));
+        
+        // mock PdfElement
+        Block.PdfElement target = Mockito.mock(Block.PdfElement.class);
+        
+        // render the mapblock named 'main'
+        renderMap(params, target, context, "main");
+        
+        // check that a circle is drawn on map
+        Mockito.verify(dc, Mockito.atLeastOnce()).circle(Mockito.anyFloat(),
+                Mockito.anyFloat(), Mockito.anyFloat());
+    
+        // render the mapblock named 'other'
+        renderMap(params, target, context, "other");
+        
+        // check that a linestring is drawn on map
+        Mockito.verify(dc, Mockito.atLeastOnce()).moveTo(Mockito.anyFloat(),
+                Mockito.anyFloat());
+        Mockito.verify(dc, Mockito.atLeastOnce()).lineTo(Mockito.anyFloat(),
+                Mockito.anyFloat());
+        
+        // render the mapblock named 'error' (not existing in spec)
+        boolean error = false;
+        try {
+            
+            renderMap(params, target, context, "error");
+        } catch(RuntimeException e) {
+            error = true;
+        }
+        assertTrue(error);
+    }
+
+    private void renderMap(PJsonObject params, Block.PdfElement target,
+            final RenderingContext context, String mapName) throws DocumentException {
+        MapBlock mapBlock = new MapBlock();
+        mapBlock.setAbsoluteX("10");
+        mapBlock.setAbsoluteY("10");
+        mapBlock.setWidth("100");
+        mapBlock.setHeight("100");
+        mapBlock.setName(mapName);
+        mapBlock.render(params, target, context);
     }
 }

--- a/src/test/resources/config/multiple-maps.json
+++ b/src/test/resources/config/multiple-maps.json
@@ -1,0 +1,75 @@
+{
+    "maps": {
+        "main": {
+            "layers": [{
+                "type": "vector",
+                "styles": {
+                    "": {
+                        "pointRadius": 10,
+                        "fill": "red",
+                        "stroke-width": "3",
+                        "fill-opacity": 0.6
+                    }
+                },
+                "geoJson": {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "geometry": {
+                                "type": "Point",
+                                "coordinates": [102.0, 0.6]
+                             },
+                             "properties": {}
+                         }
+                     ]
+                }
+            }],
+            "srs": "EPSG:4326"
+        },
+        "other": {
+            "layers": [{
+                "type": "vector",
+                "styles": {
+                    "": {
+                        "stroke": "red",
+                        "stroke-width": "3",
+                        "fill-opacity": 0.6
+                    }
+                },
+                "geoJson": {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "geometry": {
+                                "type": "LineString",
+                                "coordinates": [
+                                  [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+                                ]
+                             },
+                             "properties": {}
+                         }
+                     ]
+                }
+            }],
+            "srs": "EPSG:4326"
+        }
+    },
+    "units": "m",
+    "pages": [{
+        "maps": {
+            "main": {
+                "dpi": "300", 
+                "center": [47, 12],
+                "scale": 20000
+            
+            },
+            "other": {
+                "dpi": "300", 
+                "center": [45.2, 13.1],
+                "scale": 20000
+            }
+         }
+    }]
+}

--- a/src/test/resources/org/mapfish/print/config/sample_config_yaml/configMultipleMaps.yaml
+++ b/src/test/resources/org/mapfish/print/config/sample_config_yaml/configMultipleMaps.yaml
@@ -1,0 +1,204 @@
+#===========================================================================
+# allowed DPIs
+#===========================================================================
+dpis: [254, 190, 127, 91, 56]
+
+#===========================================================================
+# allowed Formats
+#===========================================================================
+formats: ['*']
+
+#===========================================================================
+# the allowed scales
+#===========================================================================
+scales:
+  - 25000
+  - 50000
+  - 100000
+  - 200000
+  - 500000
+  - 1000000
+  - 2000000
+  - 4000000
+
+outputFilename: 'pigma-${date}.pdf'
+
+#===========================================================================
+# the list of allowed hosts
+#===========================================================================
+hosts:
+  - !localMatch
+    dummy: true
+  - !ipMatch
+    ip: www.camptocamp.org
+  - !dnsMatch
+    host: labs.metacarta.com
+    port: 80
+  - !dnsMatch
+    host: terraservice.net
+    port: 80
+  - !dnsMatch
+    host: tile.openstreetmap.org
+    port: 80
+  - !dnsMatch
+    host: www.geocat.ch
+    port: 80
+
+security:
+  - !basicAuth
+    matcher: !dnsMatch
+      host: c2cpc61.camptocamp.com
+      port:80
+    username: xyz
+    password: yxz
+    preemptive: true
+
+
+layouts:
+  #===========================================================================
+  A4 portrait:
+  #===========================================================================
+    metaData:
+      title: '${title}'
+      author: 'MapFish print module'
+      subject: 'Simple layout'
+      keywords: 'map,print'
+      creator: 'MapFish'
+
+    titlePage:
+      pageSize: A4
+      items:
+        - !text
+          spacingAfter: 150
+        - !text
+          font: Helvetica
+          fontSize: 40
+          spacingAfter: 100
+          align: center
+          text: '${title}'
+        - !image
+          maxWidth: 160
+          maxHeight: 160
+          spacingAfter: 100
+          align: center
+          url: http://trac.mapfish.org/trac/mapfish/attachment/ticket/3/logo_v8_sphere.svg?format=raw
+        - !image
+          maxWidth: 160
+          maxHeight: 160
+          spacingAfter: 100
+          align: center
+          url: 'file://${configDir}/logo-camptocamp-transparent.png'
+        - !text
+          font: Helvetica
+          fontSize: 14
+          align: left
+          text: |
+            Two layers are asked by the client:
+            - a base layer from Metacarta
+            - a transparent layer from Camptocamp.org (routes)
+            .
+            Some text is added over the map, just to demonstrate the absolute positionning.
+      footer: &commonFooter
+        height: 30
+        items:
+          - !columns
+            config:
+              cells:
+                - paddingBottom: 5
+            items:
+              - !image
+                maxWidth: 40
+                backgroundColor: #FF0000
+                align: left
+                url: '${configDir}/small-logo-camptocamp.png'
+              - !text
+                backgroundColor: #FF0000
+                text: ©Camptocamp SA
+              - !text
+                align: right
+                text: 'Page ${pageNum}'
+
+    #-------------------------------------------------------------------------
+    mainPage:
+      pageSize: A4
+      rotation: true
+      header:
+        height: 50
+        items:
+          - !text
+            font: Helvetica
+            fontSize: 30
+            align: right
+            text: '${mapTitle}'
+      items:
+        - !map
+          name: main
+          spacingAfter: 30
+          width: 440
+          height: 483
+        - !map
+          name: other
+          spacingAfter: 30
+          width: 440
+          height: 483
+        - !columns
+          # columns can have an absolute position. In that case, they need the 3 following fields:
+          absoluteX: 410
+          absoluteY: 310
+          width: 100
+          items:
+            - !scalebar
+              type: bar
+              maxSize: 100
+              barBgColor: white
+              fontSize: 8
+              align: right
+        - !text
+          text: '${comment}'
+          spacingAfter: 30
+        - !attributes
+          source: data
+          spacingAfter: 30
+          columnDefs:
+            id:
+              columnWeight: 2
+              header: !text
+                text: ID
+                backgroundColor: #A0A0A0
+              cell: !text
+                text: '${id}'
+            name:
+              columnWeight: 5
+              header: !text
+                text: Name
+                backgroundColor: #A0A0A0
+              cell: !columns
+                config:
+                  cells:
+                    - backgroundColor: '${nameBackgroundColor}'
+                      borderWidth: 1
+                      borderColor: '${nameBorderColor}'
+                items:
+                  - !text
+                    text: '${name}'
+            icon:
+              columnWeight: 2
+              header: !text
+                text: Symbol
+                backgroundColor: #A0A0A0
+              cell: !image
+                align: center
+                maxWidth: 15
+                maxHeight: 15
+                url: 'http://www.mapfish.org/svn/mapfish/framework/client/trunk/mfbase/mapfish/img/${icon}.png'
+        - !text
+          font: Helvetica
+          fontSize: 9
+          align: right
+          text: '1:${scale.main} ${now MM.dd.yyyy}'
+        - !text
+          font: Helvetica
+          fontSize: 9
+          align: right
+          text: '1:${scale.other} ${now MM.dd.yyyy}'
+      footer: *commonFooter


### PR DESCRIPTION
With this pull request multiple !map blocks can be specified on the same page and referenced on spec by name. Scalbar blocks can refer a particular map too and in text blocks the {scale.<mapname>} placeholder can be used.
