### PR TITLE
Enable & configure gradle eclipse-wtp plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,18 @@ group = 'org.mapfish.print'
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
+apply plugin: 'eclipse-wtp'
 apply plugin: 'idea'
 apply plugin: 'project-report'
+
+eclipse {
+    wtp {
+        component {
+            contextPath = 'mapfish-print'
+            deployName = 'MapfishPrint'
+        }
+    }
+}
 
 repositories {
         mavenLocal()


### PR DESCRIPTION
This PR suggests applying the `eclipse-wtp` plugin for IMHO easier Eclipse integration.

In a fresh clone of mapfish-print, one can then do the following:
- (on the command line) `./gradlew eclipseWtp` (possibly also: `cleanEclipse` and `eclipse`)
- (in Eclipse) "Import existing project" ⇒ find your folder
- (in Eclipse) right click on the project ⇒ "Run as..." ⇒ "Run on server"
- (Select or download a server)
- visit `http://localhost:8080/print-servlet/` or `http://localhost:8080/print-servlet/pdf/info.json`

This is a common workflow for me. It may also work for others.

I am not very familiar with gradle; I hope I did everything "the right way"™. 

Please review.
