### PR TITLE
Fix for the NPE with concurrent threads (issue #91)

### DIFF
--- a/src/main/java/org/mapfish/print/MapPrinter.java
+++ b/src/main/java/org/mapfish/print/MapPrinter.java
@@ -173,7 +173,7 @@ public class MapPrinter {
             return output.print(params);
         } finally {
             final long printTime = timer.stop();
-            if (TimeUnit.SECONDS.toNanos(getConfig().getMaxPrintTimeBeforeWarningInSeconds()) < printTime) {
+            if ((config != null) && (TimeUnit.SECONDS.toNanos(config.getMaxPrintTimeBeforeWarningInSeconds()) < printTime)) {
                 LOGGER.warn("[Overtime Print] "+jsonSpec.getInternalObj());
             }
         }


### PR DESCRIPTION
When two or more concurrent threads are downloading a file and they are generating a new one simultaneously the method _stop_ of **_MapPrinter**_ object is invoked and it puts the _config_ var to **null** so when the **_MapPrinter**_ tries to access to _config_ var a NPE is thrown. This fix checks if the _config_ instance variable is **null** before to use it.
Jmeter test:

![seleccion_067](https://cloud.githubusercontent.com/assets/1272750/4402840/d22bbec8-449b-11e4-888c-e2107c66400d.png)
