### PR TITLE
Use version 2.4.3 of the GeoServer web-app

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -11,7 +11,7 @@ configurations {
 }
 
 dependencies {
-    geoserver ('org.geoserver.web:web-app:2.4.8') {
+    geoserver ('org.geoserver.web:web-app:2.4.3') {
         transitive = false;
     }
     testCompile (project(':core'))


### PR DESCRIPTION
Version 2.4.8 does not contain the test data required for the tests.
