### PR TITLE
Add jasperreports-fonts as dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,7 +93,8 @@ dependencies {
     jasper (
             "net.sf.jasperreports:jasperreports:$project.jasperReportVersion",
             "org.codehaus.groovy:groovy-all:$project.groovyVersion",
-            'ar.com.fdvs:DynamicJasper:5.0.0'
+            'ar.com.fdvs:DynamicJasper:5.0.0',
+            'net.sf.jasperreports:jasperreports-fonts:6.0.0'
     )
     compile fileTree(dir: "$projectDir/libs", include: '*.jar')
     compile (


### PR DESCRIPTION
If not a `JRFontNotFoundException` might show up on some servers.