### PR TITLE
Do not require map in template for "info.json"

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIMapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIMapPrinterServlet.java
@@ -39,6 +39,8 @@ import org.mapfish.print.servlet.NoSuchAppException;
 import org.mapfish.print.servlet.job.JobManager;
 import org.mapfish.print.servlet.job.NoSuchReferenceException;
 import org.mapfish.print.wrapper.json.PJsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
@@ -64,6 +66,8 @@ import static org.mapfish.print.servlet.ServletMapPrinterFactory.DEFAULT_CONFIGU
  */
 @Controller
 public class OldAPIMapPrinterServlet extends BaseMapServlet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OldAPIMapPrinterServlet.class);
+
     static final String REPORT_SUFFIX = ".printout";
     private static final String DEP_SEG = "/dep";
     private static final String INFO_URL = "/info.json";
@@ -332,26 +336,25 @@ public class OldAPIMapPrinterServlet extends BaseMapServlet {
                     }
                 }
                 if (map == null) {
-                    throw new UnsupportedOperationException("Template '" + name + "' contains "
-                                                            + "no map configuration.");
-                }
-                
-                MapAttributeValues mapValues = map.createValue(template);
-                json.key("map");
-                json.object();
-                {
-                    json.key("width").value(mapValues.getMapSize().width);
-                    json.key("height").value(mapValues.getMapSize().height);
-                }
-                json.endObject();
-                
-                // get the zoom levels and dpi values from the first template
-                if (maxDpi == null) {
-                    maxDpi = map.getMaxDpi();
-                    dpiSuggestions = map.getDpiSuggestions();
-                }
-                if (zoomLevels == null) {
-                    zoomLevels = mapValues.getZoomLevels();
+                    LOGGER.warn("Template '" + name + "' contains no map configuration.");
+                } else {
+                    MapAttributeValues mapValues = map.createValue(template);
+                    json.key("map");
+                    json.object();
+                    {
+                        json.key("width").value(mapValues.getMapSize().width);
+                        json.key("height").value(mapValues.getMapSize().height);
+                    }
+                    json.endObject();
+
+                    // get the zoom levels and dpi values from the first template
+                    if (maxDpi == null) {
+                        maxDpi = map.getMaxDpi();
+                        dpiSuggestions = map.getDpiSuggestions();
+                    }
+                    if (zoomLevels == null) {
+                        zoomLevels = mapValues.getZoomLevels();
+                    }
                 }
             }
             json.endObject();

--- a/core/src/test/java/org/mapfish/print/servlet/oldapi/OldAPIMapPrinterServletTest.java
+++ b/core/src/test/java/org/mapfish/print/servlet/oldapi/OldAPIMapPrinterServletTest.java
@@ -123,6 +123,24 @@ public class OldAPIMapPrinterServletTest extends AbstractMapfishSpringTest {
     }
 
     @Test
+    public void testInfoRequestNoMap() throws Exception {
+        setUpConfigFilesNoMap();
+
+        final MockHttpServletRequest infoRequest = new MockHttpServletRequest();
+        infoRequest.setContextPath("/print-old");
+        final MockHttpServletResponse infoResponse = new MockHttpServletResponse();
+        this.servlet.getInfo(null, null, infoRequest, infoResponse);
+        assertEquals(HttpStatus.OK.value(), infoResponse.getStatus());
+
+        final String result = infoResponse.getContentAsString();
+        final PJsonObject info = parseJSONObjectFromString(result);
+
+        assertTrue(info.getArray("layouts").size() > 0);
+        PObject layout = info.getArray("layouts").getObject(0);
+        assertEquals("Egrid", layout.getString("name"));
+    }
+
+    @Test
     public void testInfoRequestVarAndUrl() throws Exception {
         setUpConfigFiles();
         
@@ -341,6 +359,12 @@ public class OldAPIMapPrinterServletTest extends AbstractMapfishSpringTest {
     private void setUpConfigFilesDpi() throws URISyntaxException {
         final HashMap<String, String> configFiles = Maps.newHashMap();
         configFiles.put("default", getFile(OldAPIMapPrinterServletTest.class, "config-old-api-dpi.yaml").getAbsolutePath());
+        printerFactory.setConfigurationFiles(configFiles);
+    }
+
+    private void setUpConfigFilesNoMap() throws URISyntaxException {
+        final HashMap<String, String> configFiles = Maps.newHashMap();
+        configFiles.put("default", getFile(OldAPIMapPrinterServletTest.class, "config-old-api-no-map.yaml").getAbsolutePath());
         printerFactory.setConfigurationFiles(configFiles);
     }
 

--- a/core/src/test/resources/org/mapfish/print/servlet/oldapi/config-old-api-no-map.yaml
+++ b/core/src/test/resources/org/mapfish/print/servlet/oldapi/config-old-api-no-map.yaml
@@ -1,0 +1,11 @@
+throwErrorOnExtraParameters: true
+
+templates:
+  Egrid: !template
+    reportTemplate: Egrid.jrxml
+    attributes:
+      EGRID: !string {}
+    processors:
+    - !reportBuilder
+      directory: '.'
+


### PR DESCRIPTION
Right now an exception is thrown if there is no map for a template when calling `info.json` of the "old api". This PR removes this constraint.