### PR TITLE
Fix job comparator of print queue

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -889,6 +889,7 @@ public class MapPrinterServlet extends BaseMapServlet {
         job.setReferenceId(ref);
         job.setRequestData(specJson);
         job.setSecurityContext(SecurityContextHolder.getContext());
+        job.setCreateTime(System.currentTimeMillis());
 
         // check that we have authorization and configure the job so it can only be access by users with sufficient authorization
         final String templateName = specJson.getString(Constants.JSON_LAYOUT_KEY);

--- a/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
@@ -57,6 +57,7 @@ public abstract class PrintJob implements Callable<PrintJobStatus> {
     private String referenceId;
     private PJsonObject requestData;
     private AccessAssertion access;
+    private Long createTime;
 
     @Autowired
     private MapPrinterFactory mapPrinterFactory;
@@ -82,6 +83,21 @@ public abstract class PrintJob implements Callable<PrintJobStatus> {
     public final void setReferenceId(final String referenceId) {
         this.referenceId = referenceId;
     }
+
+    /*
+     * The timestamp when the job was created.
+     */
+    public final Long getCreateTime() {
+        return this.createTime;
+    }
+
+    /*
+     * Set the timestamp when the job was created.
+     */
+    public final void setCreateTime(final Long createTime) {
+        this.createTime = createTime;
+    }
+
 
     /**
      * Set the data from the client making the request.


### PR DESCRIPTION
The comparator used in the `PriorityBlockingQueue` of our thread pool had two problems: It was never called and it was wrong.

This only seemed to be a problem when `maxNumberOfRunningPrintJobs` was set to 1 (see #217 ), but anyway this PR fixes it by adding the creation time to `PrintJob` and by making sure that the comparator using the creation time is really called.

Closes #217 