### PR TITLE
Fixes: Run from commandline not working

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,11 @@ To list all the commandline options then execute:
 
   > ./gradlew run -PprintArgs="-config examples/config.yaml -spec examples/spec.json -output ./output.pdf"
 
+If you want to run in debug mode you can do the following:
+
+.. code::
+  > ./gradlew run --debug-jvm -PprintArgs="-config examples/config.yaml -spec examples/spec.json -output ./output.pdf"
+
 
 Run in Eclipse
 --------------

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -230,6 +230,7 @@ task libSourcesJar(type: Jar) {
 
 gradle.taskGraph.whenReady {taskGraph ->
     if (taskGraph.hasTask(run)) {
+        mainClassName = "org.mapfish.print.cli.Main"
         if (project.hasProperty("printArgs")) {
             run.args printArgs.toString().split(" ").toList()
         } else {

--- a/core/src/main/java/org/mapfish/print/cli/CliDefinition.java
+++ b/core/src/main/java/org/mapfish/print/cli/CliDefinition.java
@@ -22,8 +22,7 @@ package org.mapfish.print.cli;
 import com.sampullara.cli.Argument;
 
 /**
- * A shell version of the MapPrinter. Can be used for testing or for calling
- * from other languages than Java.
+ * The CLI API definition.
  */
 public final class CliDefinition {
     CliDefinition() {
@@ -53,7 +52,4 @@ public final class CliDefinition {
 
     @Argument(description = "If true then request data (spec) is in a old api request data (Mapfish v2 compatible).", alias = "v2")
     public boolean v2Api = false;
-
-    @Argument(description = "Print all the commandline options.", alias = "?")
-    public boolean help = false;
 }

--- a/core/src/main/java/org/mapfish/print/cli/CliDefinition.java
+++ b/core/src/main/java/org/mapfish/print/cli/CliDefinition.java
@@ -24,7 +24,7 @@ import com.sampullara.cli.Argument;
 /**
  * The CLI API definition.
  */
-public final class CliDefinition {
+public final class CliDefinition extends CliHelpDefinition {
     CliDefinition() {
         // this is intentionally empty
     }

--- a/core/src/main/java/org/mapfish/print/cli/CliHelpDefinition.java
+++ b/core/src/main/java/org/mapfish/print/cli/CliHelpDefinition.java
@@ -24,7 +24,7 @@ import com.sampullara.cli.Argument;
 /**
  * The Cli definition for when the user wants to print the cli usage/options.
  */
-public final class CliHelpDefinition {
+public class CliHelpDefinition {
     CliHelpDefinition() {
         // this is intentionally empty
     }

--- a/core/src/main/java/org/mapfish/print/cli/CliHelpDefinition.java
+++ b/core/src/main/java/org/mapfish/print/cli/CliHelpDefinition.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014  Camptocamp
+ *
+ * This file is part of MapFish Print
+ *
+ * MapFish Print is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MapFish Print is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MapFish Print.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mapfish.print.cli;
+
+import com.sampullara.cli.Argument;
+
+/**
+ * The Cli definition for when the user wants to print the cli usage/options.
+ */
+public final class CliHelpDefinition {
+    CliHelpDefinition() {
+        // this is intentionally empty
+    }
+
+    // CHECKSTYLE:OFF
+    @Argument(description = "Print all the commandline options.", alias = "?")
+    public boolean help = false;
+}

--- a/core/src/main/java/org/mapfish/print/cli/Main.java
+++ b/core/src/main/java/org/mapfish/print/cli/Main.java
@@ -82,6 +82,13 @@ public final class Main {
      * @throws Exception
      */
     public static void main(final String[] args) throws Exception {
+        final CliHelpDefinition helpCli = new CliHelpDefinition();
+
+        Args.parse(helpCli, args);
+        if (helpCli.help) {
+            printUsage(0);
+            return;
+        }
 
         final CliDefinition cli = new CliDefinition();
         try {
@@ -90,10 +97,6 @@ public final class Main {
             if (!unusedArguments.isEmpty()) {
                 System.out.println("\n\nThe following arguments are not recognized: " + unusedArguments);
                 printUsage(1);
-                return;
-            }
-            if (cli.help) {
-                printUsage(0);
                 return;
             }
         } catch (IllegalArgumentException invalidOption) {

--- a/core/src/main/java/org/mapfish/print/cli/Main.java
+++ b/core/src/main/java/org/mapfish/print/cli/Main.java
@@ -84,10 +84,14 @@ public final class Main {
     public static void main(final String[] args) throws Exception {
         final CliHelpDefinition helpCli = new CliHelpDefinition();
 
-        Args.parse(helpCli, args);
-        if (helpCli.help) {
-            printUsage(0);
-            return;
+        try {
+            Args.parse(helpCli, args);
+            if (helpCli.help) {
+                printUsage(0);
+                return;
+            }
+        } catch (IllegalArgumentException invalidOption) {
+            // Ignore because it is probably one of the non-help options.
         }
 
         final CliDefinition cli = new CliDefinition();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 06 11:47:52 CET 2015
+#Wed Mar 18 11:08:38 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip


### PR DESCRIPTION
This is a fix for: https://github.com/mapfish/mapfish-print/issues/226

It also upgrades gradle from 2.0 to the latest 2.3

and fix the case where executing -help from commandline returns a non-null (error) return value from the main application.  This caused gradle to indicate a failure when the correct behaviour was actually happening