### PR TITLE
 fix issue #234

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/AbstractFeatureSourceLayerPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/AbstractFeatureSourceLayerPlugin.java
@@ -20,7 +20,6 @@
 package org.mapfish.print.map.geotools;
 
 import com.google.common.collect.Sets;
-import jsr166y.ForkJoinPool;
 import org.geotools.data.FeatureSource;
 import org.geotools.styling.Style;
 import org.mapfish.print.attribute.map.MapfishMapContext;
@@ -31,6 +30,7 @@ import org.mapfish.print.map.style.StyleParser;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Abstract class for FeatureSource based {@link org.mapfish.print.map.MapLayerFactoryPlugin} objects.
@@ -52,7 +52,7 @@ public abstract class AbstractFeatureSourceLayerPlugin<P> implements MapLayerFac
      * A fork join pool for running async tasks.
      */
     @Autowired
-    protected ForkJoinPool forkJoinPool;
+    protected ExecutorService forkJoinPool;
 
     private final Set<String> typeNames;
 

--- a/core/src/main/java/org/mapfish/print/map/geotools/GeotiffLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/GeotiffLayer.java
@@ -23,7 +23,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
-import jsr166y.ForkJoinPool;
 import org.geotools.coverage.grid.io.AbstractGridCoverage2DReader;
 import org.geotools.gce.geotiff.GeoTiffFormat;
 import org.mapfish.print.Constants;
@@ -75,7 +74,7 @@ public final class GeotiffLayer extends AbstractGridCoverage2DReaderLayer {
      */
     public static final class Plugin extends AbstractGridCoverageLayerPlugin implements MapLayerFactoryPlugin<GeotiffParam> {
         @Autowired
-        private ForkJoinPool forkJoinPool;
+        private ExecutorService forkJoinPool;
 
         private Set<String> typeNames = Sets.newHashSet("geotiff");
 


### PR DESCRIPTION
using interface ExecutorService for bean forkJoinPool to be able to use java.util.concurrent.ForkJoinPool if java version is greater than 6.

fix issue #234