### PR TITLE
Update to JasperReports 5.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
     version = '3.3-SNAPSHOT'
     ext.junitVersion = "4.11"
     ext.springVersion = "3.2.8.RELEASE"
-    ext.jasperReportVersion = "5.5.0"
+    ext.jasperReportVersion = "5.6.1"
     ext.groovyVersion = "2.3.3"
     ext."signing.keyId" = signing_keyId
     ext."signing.secretKeyRingFile" = signing_secretKeyRingFile

--- a/core/src/main/java/org/mapfish/print/output/JasperReportExcelOutputFormat.java
+++ b/core/src/main/java/org/mapfish/print/output/JasperReportExcelOutputFormat.java
@@ -20,8 +20,9 @@
 package org.mapfish.print.output;
 
 import net.sf.jasperreports.engine.JRException;
-import net.sf.jasperreports.engine.JRExporterParameter;
 import net.sf.jasperreports.engine.export.JRXlsExporter;
+import net.sf.jasperreports.export.SimpleExporterInput;
+import net.sf.jasperreports.export.SimpleOutputStreamExporterOutput;
 
 import java.io.OutputStream;
 
@@ -46,8 +47,9 @@ public final class JasperReportExcelOutputFormat extends AbstractJasperReportOut
     @Override
     protected void doExport(final OutputStream outputStream, final Print print) throws JRException {
         JRXlsExporter exporter = new JRXlsExporter();
-        exporter.setParameter(JRExporterParameter.JASPER_PRINT, print);
-        exporter.setParameter(JRExporterParameter.OUTPUT_STREAM, outputStream);
+
+        exporter.setExporterInput(new SimpleExporterInput(print.print));
+        exporter.setExporterOutput(new SimpleOutputStreamExporterOutput(outputStream));
 
         exporter.exportReport();
     }

--- a/core/src/main/java/org/mapfish/print/output/JasperReportPDFOutputFormat.java
+++ b/core/src/main/java/org/mapfish/print/output/JasperReportPDFOutputFormat.java
@@ -20,9 +20,11 @@
 package org.mapfish.print.output;
 
 import net.sf.jasperreports.engine.JRException;
-import net.sf.jasperreports.engine.JRExporterParameter;
 import net.sf.jasperreports.engine.export.JRPdfExporter;
-import net.sf.jasperreports.engine.export.JRPdfExporterParameter;
+import net.sf.jasperreports.export.SimpleExporterInput;
+import net.sf.jasperreports.export.SimpleOutputStreamExporterOutput;
+import net.sf.jasperreports.export.SimplePdfExporterConfiguration;
+import net.sf.jasperreports.export.type.PdfVersionEnum;
 import org.mapfish.print.config.PDFConfig;
 
 import java.io.OutputStream;
@@ -50,16 +52,22 @@ public final class JasperReportPDFOutputFormat extends AbstractJasperReportOutpu
 
         JRPdfExporter exporter = new JRPdfExporter(print.context);
 
-        exporter.setParameter(JRExporterParameter.JASPER_PRINT, print.print);
-        exporter.setParameter(JRExporterParameter.OUTPUT_STREAM, outputStream);
-        exporter.setParameter(JRPdfExporterParameter.PDF_VERSION, JRPdfExporterParameter.PDF_VERSION_1_7);
+        exporter.setExporterInput(new SimpleExporterInput(print.print));
+        exporter.setExporterOutput(new SimpleOutputStreamExporterOutput(outputStream));
+
+        SimplePdfExporterConfiguration configuration = new SimplePdfExporterConfiguration();
+        configuration.setPdfVersion(PdfVersionEnum.VERSION_1_7);
+
         final PDFConfig pdfConfig = print.values.getObject(Values.PDF_CONFIG, PDFConfig.class);
-        exporter.setParameter(JRPdfExporterParameter.IS_COMPRESSED, pdfConfig.isCompressed());
-        exporter.setParameter(JRPdfExporterParameter.METADATA_AUTHOR, pdfConfig.getAuthor());
-        exporter.setParameter(JRPdfExporterParameter.METADATA_CREATOR, pdfConfig.getCreator());
-        exporter.setParameter(JRPdfExporterParameter.METADATA_SUBJECT, pdfConfig.getSubject());
-        exporter.setParameter(JRPdfExporterParameter.METADATA_TITLE, pdfConfig.getTitle());
-        exporter.setParameter(JRPdfExporterParameter.METADATA_KEYWORDS, pdfConfig.getKeywordsAsString());
+
+        configuration.setCompressed(pdfConfig.isCompressed());
+        configuration.setMetadataAuthor(pdfConfig.getAuthor());
+        configuration.setMetadataCreator(pdfConfig.getCreator());
+        configuration.setMetadataSubject(pdfConfig.getSubject());
+        configuration.setMetadataTitle(pdfConfig.getTitle());
+        configuration.setMetadataKeywords(pdfConfig.getKeywordsAsString());
+
+        exporter.setConfiguration(configuration);
 
         exporter.exportReport();
     }

--- a/core/src/main/java/org/mapfish/print/output/MapfishPrintRepositoryService.java
+++ b/core/src/main/java/org/mapfish/print/output/MapfishPrintRepositoryService.java
@@ -47,7 +47,6 @@ import javax.annotation.Nonnull;
  *
  * @author Jesse on 8/28/2014.
  */
-@SuppressWarnings("deprecation")
 class MapfishPrintRepositoryService implements StreamRepositoryService {
 
     private final ConfigFileResolvingHttpRequestFactory httpRequestFactory;
@@ -57,16 +56,6 @@ class MapfishPrintRepositoryService implements StreamRepositoryService {
                                   @Nonnull final MfClientHttpRequestFactoryImpl httpRequestFactory) {
         this.httpRequestFactory = new ConfigFileResolvingHttpRequestFactory(httpRequestFactory, configuration);
         this.jasperReportsContext = DefaultJasperReportsContext.getInstance();
-    }
-
-    @Override
-    public void setContext(final net.sf.jasperreports.repo.RepositoryContext context) {
-        // deprecated method so nothing to do
-    }
-
-    @Override
-    public void revertContext() {
-        // deprecated method so nothing to do
     }
 
     @Override

--- a/core/src/main/java/org/mapfish/print/test/util/ImageSimilarity.java
+++ b/core/src/main/java/org/mapfish/print/test/util/ImageSimilarity.java
@@ -21,10 +21,11 @@ package org.mapfish.print.test.util;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.io.Files;
-import net.sf.jasperreports.engine.JRExporterParameter;
 import net.sf.jasperreports.engine.JasperPrint;
 import net.sf.jasperreports.engine.export.JRGraphics2DExporter;
-import net.sf.jasperreports.engine.export.JRGraphics2DExporterParameter;
+import net.sf.jasperreports.export.SimpleExporterInput;
+import net.sf.jasperreports.export.SimpleGraphics2DExporterOutput;
+import net.sf.jasperreports.export.SimpleGraphics2DReportConfiguration;
 import org.apache.batik.transcoder.TranscoderException;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
@@ -33,6 +34,7 @@ import org.apache.batik.transcoder.image.TIFFTranscoder;
 
 import java.awt.Color;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -291,9 +293,17 @@ public final class ImageSimilarity {
         BufferedImage pageImage = new BufferedImage(jasperPrint.getPageWidth(), jasperPrint.getPageHeight(), BufferedImage.TYPE_INT_RGB);
 
         JRGraphics2DExporter exporter = new JRGraphics2DExporter();
-        exporter.setParameter(JRExporterParameter.JASPER_PRINT, jasperPrint);
-        exporter.setParameter(JRGraphics2DExporterParameter.GRAPHICS_2D, pageImage.getGraphics());
-        exporter.setParameter(JRExporterParameter.PAGE_INDEX, page);
+
+        exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+
+        SimpleGraphics2DExporterOutput output = new SimpleGraphics2DExporterOutput();
+        output.setGraphics2D((Graphics2D)pageImage.getGraphics());
+        exporter.setExporterOutput(output);
+
+        SimpleGraphics2DReportConfiguration configuration = new SimpleGraphics2DReportConfiguration();
+        configuration.setPageIndex(page);
+        exporter.setConfiguration(configuration);
+
         exporter.exportReport();
 
         return pageImage;


### PR DESCRIPTION
Hi,

These commits update jasperreports to 5.6.1. Jasperreports 5.6.0 introduced a new subreport attribute (overflowType) which can be used to control the overflow behaviour of legend subreports. Where Previously a Large Legend subreport would stretch over other content you now have better control about where large legends land (e.g. another column).

As Jasperreports deprecated the JRExporterParameter API in a way that broke the PDF Exporter in mapfish-print (they changed types on PDF_VERSION) and avoid usage of deprecated functions I've ported mapfish-print to use the new Parameter API.
Basically instead of using a long list of Parameters each exporter now has an ExporterInput, ExporterOutput and ExporterConfiguration object to hold the same information.

The net.sf.jasperreports.repo.RepositoryContext and related methods are now removed in Jasperreports. So I also had to remove those Overriden methods in MapfishPrintRepositoryService.java too.

Regards,
Andre