### PR TITLE
Use a default style if no feature schema

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/AbstractFeatureSourceLayerPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/AbstractFeatureSourceLayerPlugin.java
@@ -20,6 +20,8 @@
 package org.mapfish.print.map.geotools;
 
 import com.google.common.collect.Sets;
+import com.vividsolutions.jts.geom.Geometry;
+
 import org.geotools.data.FeatureSource;
 import org.geotools.styling.Style;
 import org.mapfish.print.attribute.map.MapfishMapContext;
@@ -89,7 +91,10 @@ public abstract class AbstractFeatureSourceLayerPlugin<P> implements MapLayerFac
                     throw new IllegalArgumentException("Feature source cannot be null");
                 }
 
-                String geomType = featureSource.getSchema().getGeometryDescriptor().getType().getBinding().getSimpleName();
+                String geomType = Geometry.class.getSimpleName().toLowerCase();
+                if (featureSource.getSchema() != null) {
+                    geomType = featureSource.getSchema().getGeometryDescriptor().getType().getBinding().getSimpleName();
+                }
                 String styleRef = styleString;
 
                 if (styleRef == null) {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeojsonEmptyCollection.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeojsonEmptyCollection.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2014  Camptocamp
+ *
+ * This file is part of MapFish Print
+ *
+ * MapFish Print is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MapFish Print is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MapFish Print.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mapfish.print.processor.map;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.mapfish.print.AbstractMapfishSpringTest;
+import org.mapfish.print.config.Configuration;
+import org.mapfish.print.config.ConfigurationFactory;
+import org.mapfish.print.config.Template;
+import org.mapfish.print.http.MfClientHttpRequestFactoryImpl;
+import org.mapfish.print.output.Values;
+import org.mapfish.print.parser.MapfishParser;
+import org.mapfish.print.test.util.ImageSimilarity;
+import org.mapfish.print.wrapper.json.PJsonObject;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests a GeoJSON layer with an empty FeatureCollection.
+ */
+public class CreateMapProcessorCenterGeojsonEmptyCollection extends AbstractMapfishSpringTest {
+    public static final String BASE_DIR ="center_geojson_empty_collection/";
+
+    @Autowired
+    private ConfigurationFactory configurationFactory;
+    @Autowired
+    private MapfishParser parser;
+    @Autowired
+    private MfClientHttpRequestFactoryImpl httpRequestFactory;
+
+
+    @Test
+    public void testExecute() throws Exception {
+        PJsonObject requestData = loadJsonRequestData();
+        doTest(requestData);
+    }
+
+    private void doTest(PJsonObject requestData) throws IOException, JSONException {
+        final Configuration config = configurationFactory.getConfig(getFile(BASE_DIR + "config.yaml"));
+        final Template template = config.getTemplate("main");
+        Values values = new Values(requestData, template, parser, getTaskDirectory(), this.httpRequestFactory, new File("."));
+        template.getProcessorGraph().createTask(values).invoke();
+
+        @SuppressWarnings("unchecked")
+        List<URI> layerGraphics = (List<URI>) values.getObject("layerGraphics", List.class);
+        assertEquals(1, layerGraphics.size());
+
+        final BufferedImage img = ImageIO.read(new File(layerGraphics.get(0)));
+        ImageIO.write(img, "tiff", new File("/tmp/expectedSimpleImage.tiff"));
+        new ImageSimilarity(img, 2).assertSimilarity(getFile(BASE_DIR + "expectedSimpleImage.tiff"), 30);
+    }
+
+    public static PJsonObject loadJsonRequestData() throws IOException {
+        return parseJSONObjectFromFile(CreateMapProcessorCenterGeojsonEmptyCollection.class, BASE_DIR + "requestData.json");
+    }
+}

--- a/core/src/test/resources/org/mapfish/print/processor/map/center_geojson_empty_collection/config.yaml
+++ b/core/src/test/resources/org/mapfish/print/processor/map/center_geojson_empty_collection/config.yaml
@@ -1,0 +1,19 @@
+throwErrorOnExtraParameters: true
+templates:
+  main: !template
+    reportTemplate: "dummy.jxml"
+    attributes:
+      mapDef: !map
+        width: 555
+        height: 691
+        maxDpi: 400
+        zoomSnapTolerance: 0.025
+        zoomLevelSnapStrategy: CLOSEST_LOWER_SCALE_ON_TIE
+        zoomLevels: !zoomLevels
+          scales: [50000, 100000, 500000, 1000000]
+    processors:
+    - !createMap
+        inputMapper: {mapDef: map}
+        outputMapper: {mapSubReport: mapOut}
+
+

--- a/core/src/test/resources/org/mapfish/print/processor/map/center_geojson_empty_collection/requestData.json
+++ b/core/src/test/resources/org/mapfish/print/processor/map/center_geojson_empty_collection/requestData.json
@@ -1,0 +1,25 @@
+{
+  "outputFormat":"png",
+  "layout":"1 A4 portrait",
+  "attributes":{
+    "title":"",
+    "mapDef":{
+      "center":[ 2617275, 1255000],
+      "scale":100000,
+      "rotation":0,
+      "layers":[
+        {
+          "geoJson": {
+            "features":[
+            ],
+            "type":"FeatureCollection"
+          },
+          "type":"geojson"
+        }
+      ],
+      "projection":"EPSG:2056",
+      "dpi":144
+    },
+    "comment":""
+  }
+}


### PR DESCRIPTION
This is an addition to #247 not to crash on GeoJSON layers with empty feature collections.