### PR TITLE
Config option: layers coming from old api can be processed in the reverse order.

### DIFF
--- a/core/src/main/java/org/mapfish/print/config/Configuration.java
+++ b/core/src/main/java/org/mapfish/print/config/Configuration.java
@@ -113,6 +113,7 @@ public class Configuration {
     private PDFConfig pdfConfig = new PDFConfig();
     private List<HttpCredential> credentials = Lists.newArrayList();
     private CertificateStore certificateStore;
+    private OldApiConfig oldApi = new OldApiConfig();
     private String outputFilename;
     private boolean defaultToSvg = false;
 
@@ -555,5 +556,20 @@ public class Configuration {
 
     public final AccessAssertion getAccessAssertion() {
         return this.accessAssertion;
+    }
+
+    /**
+     * Get the configuration options on how to interpret the request in the form of the old API.
+     */
+    public final OldApiConfig getOldApi() {
+        return this.oldApi;
+    }
+
+    /**
+     * Set the configuration options on how to interpret the request in the form of the old API.
+     * @param oldApi the old api configuration object
+     */
+    public final void setOldApi(final OldApiConfig oldApi) {
+        this.oldApi = oldApi;
     }
 }

--- a/core/src/main/java/org/mapfish/print/config/OldApiConfig.java
+++ b/core/src/main/java/org/mapfish/print/config/OldApiConfig.java
@@ -1,0 +1,32 @@
+package org.mapfish.print.config;
+
+import java.util.List;
+
+/**
+ * Configuration options for how requests to the old api are handled.
+ *
+ * @author Jesse on 6/12/2015.
+ */
+public final class OldApiConfig implements ConfigurationObject {
+    private boolean layersFirstIsBaseLayer = true;
+
+    /**
+     * If true then the first layer in the layers array in the JSON request is the bottom layer of the map.
+     */
+    public boolean isLayersFirstIsBaseLayer() {
+        return this.layersFirstIsBaseLayer;
+    }
+
+    /**
+     * If true then the first layer in the layers array in the JSON request is the bottom layer of the map.
+     * @param layersFirstIsBaseLayer If true then the first layer in the layers array in the JSON request is the bottom layer of the map.
+     */
+    public void setLayersFirstIsBaseLayer(final boolean layersFirstIsBaseLayer) {
+        this.layersFirstIsBaseLayer = layersFirstIsBaseLayer;
+    }
+
+    @Override
+    public void validate(final List<Throwable> validationErrors, final Configuration configuration) {
+        // nothing to do
+    }
+}

--- a/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
+++ b/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
@@ -27,6 +27,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mapfish.print.config.Configuration;
+import org.mapfish.print.config.OldApiConfig;
 import org.mapfish.print.config.Template;
 import org.mapfish.print.processor.Processor;
 import org.mapfish.print.processor.jasper.LegendProcessor;
@@ -153,7 +154,7 @@ public final class OldAPIRequestConverter {
             map.put("center", oldMapPage.getInternalObj().getJSONArray("center"));
             map.put("scale", oldMapPage.getDouble("scale"));
         }
-        setMapLayers(map, oldRequest);
+        setMapLayers(map, oldRequest, template.getConfiguration().getOldApi());
     }
 
     private static CreateMapProcessor getMapProcessor(final Template template) {
@@ -200,7 +201,7 @@ public final class OldAPIRequestConverter {
         return false;
     }
 
-    private static void setMapLayers(final JSONObject map, final PJsonObject oldRequest) throws JSONException {
+    private static void setMapLayers(final JSONObject map, final PJsonObject oldRequest, final OldApiConfig oldApi) throws JSONException {
         final JSONArray layers = new JSONArray();
         map.put("layers", layers);
 
@@ -209,9 +210,17 @@ public final class OldAPIRequestConverter {
         }
 
         PArray oldLayers = oldRequest.getArray("layers");
-        for (int i = oldLayers.size() - 1; i > -1; i--) {
-            PJsonObject oldLayer = (PJsonObject) oldLayers.getObject(i);
-            layers.put(OldAPILayerConverter.convert(oldLayer));
+
+        if (oldApi.isLayersFirstIsBaseLayer()) {
+            for (int i = oldLayers.size() - 1; i > -1; i--) {
+                PJsonObject oldLayer = (PJsonObject) oldLayers.getObject(i);
+                layers.put(OldAPILayerConverter.convert(oldLayer));
+            }
+        } else {
+            for (int i = 0; i < oldLayers.size(); i++) {
+                PJsonObject oldLayer = (PJsonObject) oldLayers.getObject(i);
+                layers.put(OldAPILayerConverter.convert(oldLayer));
+            }
         }
     }
 

--- a/core/src/main/resources/mapfish-spring-config-objects.xml
+++ b/core/src/main/resources/mapfish-spring-config-objects.xml
@@ -31,5 +31,6 @@
     <bean id="!proxy" class="org.mapfish.print.http.HttpProxy" scope="prototype" />
     <bean id="!credential" class="org.mapfish.print.http.HttpCredential" scope="prototype" />
     <bean id="!certificateStore" class="org.mapfish.print.http.CertificateStore" scope="prototype" />
+    <bean id="!oldApi" class="org.mapfish.print.config.OldApiConfig" scope="prototype" />
 
 </beans>

--- a/core/src/test/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverterTest.java
+++ b/core/src/test/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverterTest.java
@@ -210,6 +210,25 @@ public class OldAPIRequestConverterTest extends AbstractMapfishSpringTest {
         assertEquals("tiger:poly_landmarks", wmsLayer2.getString(1));
     }
 
+    @Test
+    public void testReverseLayerOrder() throws IOException, JSONException, NoSuchAppException, URISyntaxException {
+        setUpConfigFiles();
+        Configuration configuration = printerFactory.create("reverseLayers").getConfiguration();
+        final PJsonObject v2ApiRequest = loadRequestDataAsJson("requestData-old-api-all.json");
+        JSONObject request = OldAPIRequestConverter.convert(v2ApiRequest, configuration).getInternalObj();
+
+        assertTrue(request.has("attributes"));
+        JSONObject attributes = request.getJSONObject("attributes");
+
+        JSONArray layers = attributes.getJSONObject("geojsonMap").getJSONArray("layers");
+
+        assertEquals("geojson", layers.getJSONObject(0).getString("type"));
+        assertEquals("geojson", layers.getJSONObject(1).getString("type"));
+        assertEquals("wms", layers.getJSONObject(2).getString("type"));
+        assertEquals("osm", layers.getJSONObject(3).getString("type"));
+        assertEquals(4, layers.length());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConvertInvalidTemplate() throws IOException, JSONException, NoSuchAppException, URISyntaxException {
         setUpConfigFiles();
@@ -222,6 +241,7 @@ public class OldAPIRequestConverterTest extends AbstractMapfishSpringTest {
     private void setUpConfigFiles() throws URISyntaxException {
         final HashMap<String, String> configFiles = Maps.newHashMap();
         configFiles.put("default", getFile(OldAPIMapPrinterServletTest.class, "config-old-api.yaml").getAbsolutePath());
+        configFiles.put("reverseLayers", getFile(OldAPIMapPrinterServletTest.class, "config-old-api-reverse.yaml").getAbsolutePath());
         configFiles.put("wrong-layout", getFile(MapPrinterServletTest.class, "config.yaml").getAbsolutePath());
         printerFactory.setConfigurationFiles(configFiles);
     }

--- a/core/src/test/resources/org/mapfish/print/servlet/oldapi/config-old-api-reverse.yaml
+++ b/core/src/test/resources/org/mapfish/print/servlet/oldapi/config-old-api-reverse.yaml
@@ -1,0 +1,33 @@
+throwErrorOnExtraParameters: true
+oldApi: !oldApi
+  layersFirstIsBaseLayer: false
+
+templates:
+  A4 Portrait: !template
+    reportTemplate: MapOnly_A4-old-api.jrxml
+    attributes:
+      geojsonMap: !map
+        width: 802
+        height: 210
+        maxDpi: 400
+        zoomLevels: !zoomLevels
+          scales: [5000, 10000, 25000, 50000, 100000, 500000, 1000000, 2000000, 5000000, 10000000]
+      entries: !table {}
+      legend1: !legend {}
+      legend2: !legend {}
+    processors:
+    - !reportBuilder # compile all reports in current directory
+        directory: '.'
+    - !createMap
+        inputMapper: {geojsonMap: map}
+        outputMapper: {mapSubReport: geojsonMap}
+    - !prepareTable
+      inputMapper: {entries: table}
+      outputMapper: {table: table}
+    - !prepareLegend
+      inputMapper: {legend1: legend}
+      outputPrefix: legend1
+    - !prepareLegend
+      inputMapper: {legend2: legend}
+      outputPrefix: legend2
+


### PR DESCRIPTION
Add configuration option to allow layers coming from old api to be processed in the reverse order.

Turns out some clients I have encountered submit the layers in the reverse order from expected.