### PR TITLE
List fonts service

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -24,6 +24,7 @@ import com.google.common.base.Strings;
 import com.google.common.io.Files;
 
 import org.jfree.util.Log;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONWriter;
@@ -762,18 +763,16 @@ public class MapPrinterServlet extends BaseMapServlet {
     /**
      * List the available fonts on the system.
      *
-     * @return the list of available fonts in the system.
+     * @return the list of available fonts in the system.  The result is a JSON Array that just lists the font family names available.
      */
     @RequestMapping(value = FONTS_URL)
     @ResponseBody
     public final String listAvailableFonts() {
         GraphicsEnvironment e = GraphicsEnvironment.getLocalGraphicsEnvironment();
-        StringBuilder availableFonts = new StringBuilder();
-        availableFonts.append("<html><body><h2>Available Fonts</h2><ul>");
+        JSONArray availableFonts = new JSONArray();
         for (String font : e.getAvailableFontFamilyNames()) {
-            availableFonts.append("<li>").append(font).append("</li>");
+            availableFonts.put(font);
         }
-        availableFonts.append("</ul></body></html>");
         return availableFonts.toString();
     }
 

--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -53,7 +53,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.awt.GraphicsEnvironment;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -116,6 +118,10 @@ public class MapPrinterServlet extends BaseMapServlet {
      * The url path to create a print task and to get a finished print.
      */
     public static final String REPORT_URL = "/report";
+    /**
+     * The url path to create a print task and to get a finished print.
+     */
+    public static final String FONTS_URL = "/fonts";
 
     /* Registry keys */
 
@@ -751,6 +757,24 @@ public class MapPrinterServlet extends BaseMapServlet {
                 writer.close();
             }
         }
+    }
+
+    /**
+     * List the available fonts on the system.
+     *
+     * @return the list of available fonts in the system.
+     */
+    @RequestMapping(value = FONTS_URL)
+    @ResponseBody
+    public final String listAvailableFonts() {
+        GraphicsEnvironment e = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        StringBuilder availableFonts = new StringBuilder();
+        availableFonts.append("<html><body><h2>Available Fonts</h2><ul>");
+        for (String font : e.getAvailableFontFamilyNames()) {
+            availableFonts.append("<li>").append(font).append("</li>");
+        }
+        availableFonts.append("</ul></body></html>");
+        return availableFonts.toString();
     }
 
     /**

--- a/core/src/main/webapp/index.html
+++ b/core/src/main/webapp/index.html
@@ -218,6 +218,8 @@
                     onclick="openOldApiCapabilities()">Old API Info (Capabilities)</button>
         </p>
     </form>
+    <button id="list-fonts" type="button" onclick="window.open('print/fonts', '_fonts')">List available fonts</button>
+
     <h2>Performance and Health Metrics:</h2>
     <p>
         <button id="metrics" type="button" onclick="window.open('metrics/metrics?pretty=true', '_metrics')">Metrics</button>

--- a/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
+++ b/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
@@ -302,7 +302,8 @@ public class MapPrinterServletTest extends AbstractMapfishSpringTest {
     @Test
     public void testListFonts() throws Exception {
         String fonts = servlet.listAvailableFonts();
-        assertTrue(fonts, fonts.split("<li>").length > 0);
+        JSONArray fontsJson = new JSONArray(fonts);
+        assertTrue(fonts, fontsJson.length() > 0);
     }
 
     private String doCreateAndPollAndGetReport(Function<MockHttpServletRequest, MockHttpServletResponse> createReport, boolean checkJsonp)

--- a/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
+++ b/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
@@ -299,6 +299,12 @@ public class MapPrinterServletTest extends AbstractMapfishSpringTest {
         assertArrayEquals(new Object[]{"CookieValue", "CookieValue2"}, request.getHeaders().get("Cookies").toArray());
     }
 
+    @Test
+    public void testListFonts() throws Exception {
+        String fonts = servlet.listAvailableFonts();
+        assertTrue(fonts, fonts.split("<li>").length > 0);
+    }
+
     private String doCreateAndPollAndGetReport(Function<MockHttpServletRequest, MockHttpServletResponse> createReport, boolean checkJsonp)
             throws URISyntaxException, IOException, InterruptedException, ServletException {
         setUpConfigFiles();

--- a/docs/src/main/resources/long-strings/tocApiDesc.html
+++ b/docs/src/main/resources/long-strings/tocApiDesc.html
@@ -288,3 +288,23 @@
   Request URI: <code>DELETE /cancel/15179fee-618d-4356-8114-cfd8f146e273</code>
 </p>
 
+
+<h3 id="listFonts">List Available Fonts</h3>
+<p>
+  List fonts installed in Java Runtime on server.  This lists the fonts that can be put in the Jasper Report Templates
+</p>
+<h4>URI</h4>
+<p>
+  <code>GET /fonts</code>
+</p>
+
+<h4>Response</h4>
+<p>
+  A JSON array containing all the available fonts face names on the server that can be used in Jasper Report Templates
+</p>
+
+<h4>Request Sample</h4>
+<p>
+  Request URI: <code>GET /fonts</code>
+</p>
+


### PR DESCRIPTION
Add a new service to list all of the fonts available (for use in templates typically).

This is important because often templates are built on windows using Jasper Studio where there are different fonts available than on the server (often on linux machines).  This allows the template builders to see what fonts are available on the server so they can build correct templates.