### PR TITLE
Add cancelSpecificAppId to MapPrinterServlet

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -299,6 +299,22 @@ public class MapPrinterServlet extends BaseMapServlet {
 
     /**
      * Cancel a job.
+     *
+     * Even if a job was already finished, subsequent status requests will
+     * return that the job was canceled.
+     *
+     * @param referenceId    the job reference
+     * @param statusResponse the response object
+     */
+    @RequestMapping(value = "/{appId}" + CANCEL_URL + "/{referenceId:\\S+}", method = RequestMethod.DELETE)
+    public final void cancelSpecificAppId(
+            @PathVariable final String referenceId,
+            final HttpServletResponse statusResponse) {
+        cancel(referenceId, statusResponse);
+    }
+
+    /**
+     * Cancel a job.
      * 
      * Even if a job was already finished, subsequent status requests will
      * return that the job was canceled.


### PR DESCRIPTION
This adds a `cancelSpecificAppId` method to the `MapPrinterServlet`. This method allows using a cancel URL with an `appId`. This is consistent with the `getStatusSpecificAppId` method that already exists.

(I haven't done any Java in years, so please be indulgent :)

Fixes https://github.com/mapfish/mapfish-print/issues/260.