### PR TITLE
Add configuration which allows the correct JDBC drivers to be loaded.

### DIFF
--- a/core/src/main/java/org/mapfish/print/config/Configuration.java
+++ b/core/src/main/java/org/mapfish/print/config/Configuration.java
@@ -576,7 +576,7 @@ public class Configuration {
      * @param jdbcDrivers the set of JDBC drivers to load before performing a print (this ensures they are
      *                    registered with the JVM)
      */
-    public void setJdbcDrivers(Set<String> jdbcDrivers) {
+    public final void setJdbcDrivers(final Set<String> jdbcDrivers) {
         this.jdbcDrivers = jdbcDrivers;
     }
 

--- a/core/src/main/java/org/mapfish/print/config/Configuration.java
+++ b/core/src/main/java/org/mapfish/print/config/Configuration.java
@@ -566,6 +566,13 @@ public class Configuration {
      * </code>
      * </pre>
      *
+     * or
+     *
+     * <pre><code>
+     *     jdbcDrivers:
+     *       - org.postgresql.Driver
+     * </code></pre>
+     *
      * @param jdbcDrivers the set of JDBC drivers to load before performing a print (this ensures they are
      *                    registered with the JVM)
      */

--- a/core/src/main/java/org/mapfish/print/config/Configuration.java
+++ b/core/src/main/java/org/mapfish/print/config/Configuration.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.LinearRing;
@@ -67,6 +68,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -115,6 +117,7 @@ public class Configuration {
     private CertificateStore certificateStore;
     private String outputFilename;
     private boolean defaultToSvg = false;
+    private Set<String> jdbcDrivers = Sets.newHashSet();
 
     @Autowired
     private StyleParser styleParser;
@@ -486,6 +489,19 @@ public class Configuration {
         List<Throwable> validationErrors = Lists.newArrayList();
         this.accessAssertion.validate(validationErrors, this);
 
+        for (String jdbcDriver : this.jdbcDrivers) {
+            try {
+                Class.forName(jdbcDriver);
+            } catch (ClassNotFoundException e) {
+                try {
+                    Configuration.class.getClassLoader().loadClass(jdbcDriver);
+                } catch (ClassNotFoundException e1) {
+                    validationErrors.add(new ConfigurationException("Unable to load JDBC driver: " + jdbcDriver +
+                                                                    " ensure that the web application has the jar on its classpath"));
+                }
+            }
+        }
+
         if (this.configurationFile == null) {
             validationErrors.add(new ConfigurationException("Configuration file is field on configuration object is null"));
         }
@@ -533,6 +549,28 @@ public class Configuration {
      */
     public final void setFileLoaderManager(final ConfigFileLoaderManager fileLoaderManager) {
         this.fileLoaderManager = fileLoaderManager;
+    }
+
+    /**
+     * Set the JDBC drivers that are required to connect to the databases in the configuration.  JDBC drivers are needed (for example)
+     * when database sources are used in templates.  For example if in one of the template you have:
+     *
+     * <pre><code>
+     *     jdbcUrl: "jdbc:postgresql://localhost:5432/morges_dpfe"
+     * </code></pre>
+     *
+     * then you need to add:
+     *
+     * <pre><code>
+     *     jdbcDrivers: [org.postgresql.Driver]
+     * </code>
+     * </pre>
+     *
+     * @param jdbcDrivers the set of JDBC drivers to load before performing a print (this ensures they are
+     *                    registered with the JVM)
+     */
+    public void setJdbcDrivers(Set<String> jdbcDrivers) {
+        this.jdbcDrivers = jdbcDrivers;
     }
 
     /**

--- a/core/src/test/java/org/mapfish/print/config/ConfigurationTest.java
+++ b/core/src/test/java/org/mapfish/print/config/ConfigurationTest.java
@@ -21,6 +21,7 @@ package org.mapfish.print.config;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.geotools.styling.AbstractStyleVisitor;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.LineSymbolizer;
@@ -38,6 +39,7 @@ import org.json.JSONObject;
 import org.json.JSONWriter;
 import org.junit.After;
 import org.junit.Test;
+import org.mapfish.print.AbstractMapfishSpringTest;
 import org.mapfish.print.Constants;
 import org.mockito.Mockito;
 import org.springframework.security.access.AccessDeniedException;
@@ -49,6 +51,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
@@ -348,6 +351,29 @@ public class ConfigurationTest {
         assertTrue(config.renderAsSvg(null));
         assertFalse(config.renderAsSvg(false));
         assertTrue(config.renderAsSvg(true));
+    }
+
+    @Test
+    public void testJdbcDrivers() throws Exception {
+        final Configuration config = new Configuration();
+        Map<String, Template> templates = new HashMap<String, Template>();
+        config.setTemplates(templates);
+        config.setConfigurationFile(AbstractMapfishSpringTest.getFile(ConfigurationTest.class, "/org/mapfish/print/config/config-test-application-context.xml"));
+        List<Throwable> errors = config.validate();
+
+        assertEquals(1, errors.size()); // no templates error
+
+        config.setJdbcDrivers(Sets.newHashSet("non.existant.driver.Driver"));
+        errors = config.validate();
+
+        assertEquals(2, errors.size());
+
+        config.setJdbcDrivers(Sets.newHashSet("org.hsqldb.jdbc.JDBCDriver"));
+        errors = config.validate();
+
+        assertEquals(1, errors.size());
+
+
     }
 
     private void assertStyleType(Class<?> expectedSymbolizerType, Style style) {


### PR DESCRIPTION
In order to get a database connection with JDBC the JDBC drivers classes need to loaded before the connection is obtained.  Typically loading a connection is as follows:

    Class.forName("org.postgresql.Driver");
    DriverManager.getConnection("jdbc:postgres://localhost;5432/database", "username", "password");

In Template#validate we check that the jdbc connection in the template can be loaded but we don't load the JDBC class.  In order to do this I have added a configuration section `jdbcDrivers` where you can list the jdbc drivers that need to be loaded before the template's jdbcUrl can be loaded.

Example in config.yaml:

    jdbcDrivers: [org.postgresql.Driver]

Or:

    jdbcDrivers: 
      - org.postgresql.Driver
