### PR TITLE
Add configuration option for WMS layer ordering to allow support more old clients.

### DIFF
--- a/core/src/main/java/org/mapfish/print/config/OldApiConfig.java
+++ b/core/src/main/java/org/mapfish/print/config/OldApiConfig.java
@@ -9,6 +9,7 @@ import java.util.List;
  */
 public final class OldApiConfig implements ConfigurationObject {
     private boolean layersFirstIsBaseLayer = true;
+    private boolean wmsReverseLayers = false;
 
     /**
      * If true then the first layer in the layers array in the JSON request is the bottom layer of the map.
@@ -28,5 +29,21 @@ public final class OldApiConfig implements ConfigurationObject {
     @Override
     public void validate(final List<Throwable> validationErrors, final Configuration configuration) {
         // nothing to do
+    }
+
+    /**
+     * If true then the layer order coming from the old API client will be reversed for the layers within a WMS request.
+     */
+    public boolean isWmsReverseLayers() {
+        return this.wmsReverseLayers;
+    }
+
+    /**
+     * Set if the layer order coming from the old API client will be reversed for the layers within a WMS request.
+     *
+     * @param wmsReverseLayers if true then the layer order will be reversed
+     */
+    public void setWmsReverseLayers(final boolean wmsReverseLayers) {
+        this.wmsReverseLayers = wmsReverseLayers;
     }
 }

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -148,10 +148,10 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                             final File tempTaskDirectory) throws IOException, URISyntaxException, JRException {
         int insertNameIndex = legendList.size();
         final URL[] icons = legendAttributes.icons;
-        if (icons != null) {
-            for (URL icon : icons) {
-                BufferedImage image = null;
                 Closer closer = Closer.create();
+                if (icons != null) {
+                    for (URL icon : icons) {
+                        BufferedImage image = null;
                 try {
                     checkCancelState(context);
                     final ClientHttpRequest request = clientHttpRequestFactory.createRequest(icon.toURI(), HttpMethod.GET);
@@ -175,6 +175,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                     image = this.getMissingImage();
                 }
 
+                        ImageIO.write(image, "png", new File("E:\\tmp\\examples_test\\baselstadt\\expected_output\\legend.png"));
                 String report = null;
                 if (this.maxWidth != null) {
                     // if a max width is given, create a sub-report containing the cropped graphic

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -96,6 +96,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
      * If this parameter is set, the legend graphics are cropped to the given maximum
      * width. In this case a sub-report is created containing the graphic.
      * For reference see the example `legend_dynamic`.
+     *
      * @param maxWidth The max. width.
      */
     public void setMaxWidth(final Integer maxWidth) {
@@ -105,6 +106,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
     /**
      * The DPI value that is used for the legend graphics.
      * Note: This parameter is only considered when `maxWidth` is set.
+     *
      * @param dpi The DPI value.
      */
     public void setDpi(final Double dpi) {
@@ -148,10 +150,10 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                             final File tempTaskDirectory) throws IOException, URISyntaxException, JRException {
         int insertNameIndex = legendList.size();
         final URL[] icons = legendAttributes.icons;
-                Closer closer = Closer.create();
-                if (icons != null) {
-                    for (URL icon : icons) {
-                        BufferedImage image = null;
+        Closer closer = Closer.create();
+        if (icons != null) {
+            for (URL icon : icons) {
+                BufferedImage image = null;
                 try {
                     checkCancelState(context);
                     final ClientHttpRequest request = clientHttpRequestFactory.createRequest(icon.toURI(), HttpMethod.GET);
@@ -197,7 +199,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
     }
 
     private URI createSubReport(final BufferedImage originalImage,
-            final File tempTaskDirectory) throws IOException, JRException {
+                                final File tempTaskDirectory) throws IOException, JRException {
         assert (this.maxWidth != null);
 
         double scaleFactor = getScaleFactor();

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -175,7 +175,6 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                     image = this.getMissingImage();
                 }
 
-                        ImageIO.write(image, "png", new File("E:\\tmp\\examples_test\\baselstadt\\expected_output\\legend.png"));
                 String report = null;
                 if (this.maxWidth != null) {
                     // if a max width is given, create a sub-report containing the cropped graphic

--- a/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
+++ b/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
@@ -214,12 +214,12 @@ public final class OldAPIRequestConverter {
         if (oldApi.isLayersFirstIsBaseLayer()) {
             for (int i = oldLayers.size() - 1; i > -1; i--) {
                 PJsonObject oldLayer = (PJsonObject) oldLayers.getObject(i);
-                layers.put(OldAPILayerConverter.convert(oldLayer));
+                layers.put(OldAPILayerConverter.convert(oldLayer, oldApi));
             }
         } else {
             for (int i = 0; i < oldLayers.size(); i++) {
                 PJsonObject oldLayer = (PJsonObject) oldLayers.getObject(i);
-                layers.put(OldAPILayerConverter.convert(oldLayer));
+                layers.put(OldAPILayerConverter.convert(oldLayer, oldApi));
             }
         }
     }

--- a/core/src/test/resources/org/mapfish/print/servlet/oldapi/wms-layer-order.json
+++ b/core/src/test/resources/org/mapfish/print/servlet/oldapi/wms-layer-order.json
@@ -10,8 +10,8 @@
       "opacity" : 1,
       "type":"WMS",
       "layers": [
-        "tiger:poly_landmarks",
-        "nurc:Img_Sample"
+        "nurc:Img_Sample",
+        "tiger:poly_landmarks"
       ],
       "format": "image/png",
       "singleTile": true,
@@ -21,8 +21,8 @@
       "opacity" : 1,
       "type":"WMS",
       "layers": [
-        "tiger:poi",
-        "tiger:tiger_roads"
+        "tiger:tiger_roads",
+        "tiger:poi"
       ],
       "format": "image/png",
       "singleTile": true,

--- a/examples/src/test/resources/examples/printwms_tyger_ny_EPSG_900913_old_api/oldApi-requestData-multi-layer.json
+++ b/examples/src/test/resources/examples/printwms_tyger_ny_EPSG_900913_old_api/oldApi-requestData-multi-layer.json
@@ -10,10 +10,10 @@
       "opacity" : 1,
       "type":"WMS",
       "layers": [
-        "tiger:poi",
-        "tiger:tiger_roads",
+        "nurc:Img_Sample",
         "tiger:poly_landmarks",
-        "nurc:Img_Sample"
+        "tiger:tiger_roads",
+        "tiger:poi"
       ],
       "format": "image/png",
       "singleTile": true,


### PR DESCRIPTION
I have a couple of existing clients and they order the WMS layers differently from one another.  It is in direct violation of the old V2 but none the less they have demanded support ...  Well they pay the bills and it is not a big deal to add this option.