### PR TITLE
Add labelOutlineColor and labelOutlineWidth support in the JSON style formats

### DIFF
--- a/core/src/main/java/org/mapfish/print/config/OldApiConfig.java
+++ b/core/src/main/java/org/mapfish/print/config/OldApiConfig.java
@@ -9,6 +9,7 @@ import java.util.List;
  */
 public final class OldApiConfig implements ConfigurationObject {
     private boolean layersFirstIsBaseLayer = true;
+    private boolean wmsReverseLayers = false;
 
     /**
      * If true then the first layer in the layers array in the JSON request is the bottom layer of the map.
@@ -28,5 +29,21 @@ public final class OldApiConfig implements ConfigurationObject {
     @Override
     public void validate(final List<Throwable> validationErrors, final Configuration configuration) {
         // nothing to do
+    }
+
+    /**
+     * If true then the layer order coming from the old API client will be reversed for the layers within a WMS request.
+     */
+    public boolean isWmsReverseLayers() {
+        return this.wmsReverseLayers;
+    }
+
+    /**
+     * Set if the layer order coming from the old API client will be reversed for the layers within a WMS request.
+     *
+     * @param wmsReverseLayers if true then the layer order will be reversed
+     */
+    public void setWmsReverseLayers(final boolean wmsReverseLayers) {
+        this.wmsReverseLayers = wmsReverseLayers;
     }
 }

--- a/core/src/main/java/org/mapfish/print/map/style/json/JsonStyleParserHelper.java
+++ b/core/src/main/java/org/mapfish/print/map/style/json/JsonStyleParserHelper.java
@@ -99,6 +99,8 @@ public final class JsonStyleParserHelper {
     static final String JSON_HALO_RADIUS = "haloRadius";
     static final String JSON_HALO_COLOR = "haloColor";
     static final String JSON_HALO_OPACITY = "haloOpacity";
+    static final String JSON_LABEL_OUTLINE_COLOR = "labelOutlineColor";
+    static final String JSON_LABEL_OUTLINE_WIDTH = "labelOutlineWidth";
     static final String JSON_FONT_COLOR = "fontColor";
     static final String JSON_FONT_OPACITY = "fontOpacity";
     static final String JSON_GRAPHIC_FORMAT = "graphicFormat";
@@ -334,7 +336,9 @@ public final class JsonStyleParserHelper {
 
         if (!Strings.isNullOrEmpty(styleJson.optString(JSON_HALO_RADIUS)) ||
             !Strings.isNullOrEmpty(styleJson.optString(JSON_HALO_COLOR)) ||
-            !Strings.isNullOrEmpty(styleJson.optString(JSON_HALO_OPACITY))) {
+            !Strings.isNullOrEmpty(styleJson.optString(JSON_HALO_OPACITY)) ||
+            !Strings.isNullOrEmpty(styleJson.optString(JSON_LABEL_OUTLINE_WIDTH)) ||
+            !Strings.isNullOrEmpty(styleJson.optString(JSON_LABEL_OUTLINE_COLOR))) {
             textSymbolizer.setHalo(createHalo(styleJson));
         }
 
@@ -530,6 +534,19 @@ public final class JsonStyleParserHelper {
                 fill = addFill(styleJson.optString(JSON_HALO_COLOR, "white"), styleJson.optString(JSON_HALO_OPACITY, "1.0"));
                 return this.styleBuilder.createHalo(fill, radius);
             }
+        }
+
+        // labelOutlineColor and labelOutlineWidth are aliases for halo that is used by some V2 Clients
+        if (styleJson.has(JSON_LABEL_OUTLINE_COLOR) || styleJson.has(JSON_LABEL_OUTLINE_WIDTH)) {
+            Expression radius = parseExpression(1.0, styleJson, JSON_LABEL_OUTLINE_WIDTH, new Function<String, Double>() {
+                @Nullable
+                @Override
+                public Double apply(final String input) {
+                    return Double.parseDouble(input);
+                }
+            });
+            Fill fill = addFill(styleJson.optString(JSON_LABEL_OUTLINE_COLOR, "white"), "1.0");
+            return this.styleBuilder.createHalo(fill, radius);
         }
 
         return null;

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -148,10 +148,10 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                             final File tempTaskDirectory) throws IOException, URISyntaxException, JRException {
         int insertNameIndex = legendList.size();
         final URL[] icons = legendAttributes.icons;
-        if (icons != null) {
-            for (URL icon : icons) {
-                BufferedImage image = null;
                 Closer closer = Closer.create();
+                if (icons != null) {
+                    for (URL icon : icons) {
+                        BufferedImage image = null;
                 try {
                     checkCancelState(context);
                     final ClientHttpRequest request = clientHttpRequestFactory.createRequest(icon.toURI(), HttpMethod.GET);
@@ -175,6 +175,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                     image = this.getMissingImage();
                 }
 
+                        ImageIO.write(image, "png", new File("E:\\tmp\\examples_test\\baselstadt\\expected_output\\legend.png"));
                 String report = null;
                 if (this.maxWidth != null) {
                     // if a max width is given, create a sub-report containing the cropped graphic

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -96,6 +96,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
      * If this parameter is set, the legend graphics are cropped to the given maximum
      * width. In this case a sub-report is created containing the graphic.
      * For reference see the example `legend_dynamic`.
+     *
      * @param maxWidth The max. width.
      */
     public void setMaxWidth(final Integer maxWidth) {
@@ -105,6 +106,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
     /**
      * The DPI value that is used for the legend graphics.
      * Note: This parameter is only considered when `maxWidth` is set.
+     *
      * @param dpi The DPI value.
      */
     public void setDpi(final Double dpi) {
@@ -148,10 +150,10 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                             final File tempTaskDirectory) throws IOException, URISyntaxException, JRException {
         int insertNameIndex = legendList.size();
         final URL[] icons = legendAttributes.icons;
-                Closer closer = Closer.create();
-                if (icons != null) {
-                    for (URL icon : icons) {
-                        BufferedImage image = null;
+        Closer closer = Closer.create();
+        if (icons != null) {
+            for (URL icon : icons) {
+                BufferedImage image = null;
                 try {
                     checkCancelState(context);
                     final ClientHttpRequest request = clientHttpRequestFactory.createRequest(icon.toURI(), HttpMethod.GET);
@@ -197,7 +199,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
     }
 
     private URI createSubReport(final BufferedImage originalImage,
-            final File tempTaskDirectory) throws IOException, JRException {
+                                final File tempTaskDirectory) throws IOException, JRException {
         assert (this.maxWidth != null);
 
         double scaleFactor = getScaleFactor();

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -175,7 +175,6 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                     image = this.getMissingImage();
                 }
 
-                        ImageIO.write(image, "png", new File("E:\\tmp\\examples_test\\baselstadt\\expected_output\\legend.png"));
                 String report = null;
                 if (this.maxWidth != null) {
                     // if a max width is given, create a sub-report containing the cropped graphic

--- a/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
+++ b/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
@@ -214,12 +214,12 @@ public final class OldAPIRequestConverter {
         if (oldApi.isLayersFirstIsBaseLayer()) {
             for (int i = oldLayers.size() - 1; i > -1; i--) {
                 PJsonObject oldLayer = (PJsonObject) oldLayers.getObject(i);
-                layers.put(OldAPILayerConverter.convert(oldLayer));
+                layers.put(OldAPILayerConverter.convert(oldLayer, oldApi));
             }
         } else {
             for (int i = 0; i < oldLayers.size(); i++) {
                 PJsonObject oldLayer = (PJsonObject) oldLayers.getObject(i);
-                layers.put(OldAPILayerConverter.convert(oldLayer));
+                layers.put(OldAPILayerConverter.convert(oldLayer, oldApi));
             }
         }
     }

--- a/core/src/test/java/org/mapfish/print/map/style/json/JsonStyleParserHelperTest.java
+++ b/core/src/test/java/org/mapfish/print/map/style/json/JsonStyleParserHelperTest.java
@@ -252,6 +252,28 @@ public class JsonStyleParserHelperTest {
     }
 
     @Test
+    public void testHaloAliasLabelOutline() throws Exception {
+        final String haloColor = "#123456";
+        final String haloRadius = "3.0";
+
+
+        JSONObject style = new JSONObject();
+        style.put("label", "name");
+        style.put(JsonStyleParserHelper.JSON_LABEL_OUTLINE_COLOR, haloColor);
+        style.put(JsonStyleParserHelper.JSON_LABEL_OUTLINE_WIDTH, haloRadius);
+
+        final PJsonObject pStyle = new PJsonObject(style, null);
+        TextSymbolizer symbolizer = helper.createTextSymbolizer(pStyle);
+        assertNotNull(symbolizer);
+
+        transformer.transform(symbolizer);  // test that it can be written to xml correctly
+
+        Halo halo = symbolizer.getHalo();
+        assertFill(1.0, haloColor, halo.getFill());
+        assertEquals(haloRadius, valueOf(halo.getRadius()).toString());
+    }
+
+    @Test
     public void testCreateStroke_DashStyle() throws Exception {
 
         assertDashStyle("5 4 3 4", new float[]{5f, 4f, 3f, 4f});

--- a/core/src/test/resources/org/mapfish/print/servlet/oldapi/wms-layer-order.json
+++ b/core/src/test/resources/org/mapfish/print/servlet/oldapi/wms-layer-order.json
@@ -10,8 +10,8 @@
       "opacity" : 1,
       "type":"WMS",
       "layers": [
-        "tiger:poly_landmarks",
-        "nurc:Img_Sample"
+        "nurc:Img_Sample",
+        "tiger:poly_landmarks"
       ],
       "format": "image/png",
       "singleTile": true,
@@ -21,8 +21,8 @@
       "opacity" : 1,
       "type":"WMS",
       "layers": [
-        "tiger:poi",
-        "tiger:tiger_roads"
+        "tiger:tiger_roads",
+        "tiger:poi"
       ],
       "format": "image/png",
       "singleTile": true,

--- a/examples/src/test/resources/examples/printwms_tyger_ny_EPSG_900913_old_api/oldApi-requestData-multi-layer.json
+++ b/examples/src/test/resources/examples/printwms_tyger_ny_EPSG_900913_old_api/oldApi-requestData-multi-layer.json
@@ -10,10 +10,10 @@
       "opacity" : 1,
       "type":"WMS",
       "layers": [
-        "tiger:poi",
-        "tiger:tiger_roads",
+        "nurc:Img_Sample",
         "tiger:poly_landmarks",
-        "nurc:Img_Sample"
+        "tiger:tiger_roads",
+        "tiger:poi"
       ],
       "format": "image/png",
       "singleTile": true,


### PR DESCRIPTION
labelOutlineColor and labelOutlineWidth are aliases for halo that is used by some V2 Clients.

This PR adds support for these two keys as aliases for haloRadius and haloColor