### PR TITLE
Map was printed in a different scale

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
@@ -243,13 +243,13 @@ public final class CreateMapProcessor extends AbstractProcessor<CreateMapProcess
         final double dpi = mapValues.getDpi();
         final double dpiOfRequestor = mapValues.getRequestorDPI();
 
-        MapBounds bounds = mapValues.getMapBounds();
-        bounds = adjustBoundsToScaleAndMapSize(mapValues, dpi, paintArea, bounds);
-
         // if the DPI is higher than the PDF DPI we need to make the image larger so the image put in the PDF is large enough for the
         // higher DPI printer
         final double dpiRatio = dpi / dpiOfRequestor;
         paintArea.setBounds(0, 0, (int) (mapSize.getWidth() * dpiRatio), (int) (mapSize.getHeight() * dpiRatio));
+
+        MapBounds bounds = mapValues.getMapBounds();
+        bounds = adjustBoundsToScaleAndMapSize(mapValues, dpi, paintArea, bounds);
 
         return new MapfishMapContext(bounds, paintArea.getSize(),
                 mapValues.getRotation(), dpi, mapValues.getRequestorDPI(), mapValues.longitudeFirst, mapValues.isDpiSensitiveStyle());

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSRestTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSRestTest.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 import org.mapfish.print.AbstractMapfishSpringTest;
 import org.mapfish.print.TestHttpClientFactory;
+import org.mapfish.print.attribute.map.MapfishMapContext;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.config.ConfigurationFactory;
 import org.mapfish.print.config.Template;
@@ -123,6 +124,9 @@ public class CreateMapProcessorFixedScaleAndCenterWMTSRestTest extends AbstractM
         @SuppressWarnings("unchecked")
         List<URI> layerGraphics = (List<URI>) values.getObject("layerGraphics", List.class);
         assertEquals(2, layerGraphics.size());
+
+        MapfishMapContext mapContext = values.getObject("mapContext", MapfishMapContext.class);
+        assertEquals(110000.0, mapContext.getScale().getDenominator(), 1E-6);
 
         final BufferedImage referenceImage = ImageSimilarity.mergeImages(layerGraphics, 630, 294);
         // ImageIO.write(referenceImage, "tif", new File("/tmp/expectedSimpleImage.tiff"));

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmDpiTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmDpiTest.java
@@ -21,9 +21,11 @@ package org.mapfish.print.processor.map;
 
 import com.google.common.base.Predicate;
 import com.google.common.io.Files;
+
 import org.junit.Test;
 import org.mapfish.print.AbstractMapfishSpringTest;
 import org.mapfish.print.TestHttpClientFactory;
+import org.mapfish.print.attribute.map.MapfishMapContext;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.config.ConfigurationFactory;
 import org.mapfish.print.config.Template;
@@ -108,6 +110,9 @@ public class CreateMapProcessorFixedScaleCenterOsmDpiTest extends AbstractMapfis
         @SuppressWarnings("unchecked")
         List<URI> layerGraphics = (List<URI>) values.getObject("layerGraphics", List.class);
         assertEquals(2, layerGraphics.size());
+
+        MapfishMapContext mapContext = values.getObject("mapContext", MapfishMapContext.class);
+        assertEquals(25000.0, mapContext.getScale().getDenominator(), 1E-6);
 
 //        Files.copy(new File(layerGraphics.get(0)), new File("/tmp/0_"+getClass().getSimpleName()+".tiff"));
 //        Files.copy(new File(layerGraphics.get(1)), new File("/tmp/1_"+getClass().getSimpleName()+".tiff"));


### PR DESCRIPTION
When requesting a print with center and scale, the scale used for the print could differ slightly (for example 1:26.012 instead of 1:26.000) when the DPI was not 72.

The problem was the following: Center/scale is converted to bounding-box map bounds using the size of paint area. Later when the scale is requested again, it is calculated from the map bounds and the size of the paint area. This works fine as long as the DPI is 72.

When the DPI is > 72 the bounding-box map bounds are calculated with the original size of the paint area. Then the paint area is adjusted using the DPI ratio. Now when requesting the scale value, it is calculated with the map bounds (calculated from the original paint area size) and the adjusted paint area size (and not the original size!). This can lead to rounding errors because the size of the paint area is in pixels/integer.

This PR fixes the problem by first adjusting the size of the paint area. Then using the adjusted size the map bounds are calculated and also later the scale.

Related issue: https://github.com/camptocamp/baselstadt_mapbs/issues/33