### PR TITLE
Ensure that the TIFF extension is loaded for ImageIO

### DIFF
--- a/core/src/main/java/org/mapfish/print/MapPrinter.java
+++ b/core/src/main/java/org/mapfish/print/MapPrinter.java
@@ -20,6 +20,7 @@
 package org.mapfish.print;
 
 import com.google.common.io.Files;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONWriter;
@@ -41,6 +42,9 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import javax.annotation.PostConstruct;
+import javax.imageio.ImageIO;
+
 /**
  * The main class for printing maps. Will parse the spec, create the PDF
  * document and generate it.
@@ -59,6 +63,15 @@ public class MapPrinter {
     private File configFile;
     @Autowired
     private WorkingDirectories workingDirectories;
+
+    /**
+     * Ensure that extensions for ImageIO (like the reader and writer for TIFF) are registered.
+     * This is required for certain Windows systems.
+     */
+    @PostConstruct
+    public final void initImageIO() {
+        ImageIO.scanForPlugins();
+    }
 
     /**
      * Set the configuration file and update the configuration for this printer.


### PR DESCRIPTION
This PR aims to fix an issue with the scalebar processor on certain Windows systems. When trying to use a scalebar in a report, the error message `JRException: Image read failed` turned up  (see #277).

The problem was that ImageIO didn't know how to write TIFF files. Apparently the plugin for TIFF is not registered properly on these Windows system. To fix the issue, this PR proposes to call `ImageIO.scanForPlugins()` on applications startup.