### PR TITLE
Really abort PDF process when brokenUrlPlaceholder is set to throw

### DIFF
--- a/src/main/java/org/mapfish/print/map/MapChunkDrawer.java
+++ b/src/main/java/org/mapfish/print/map/MapChunkDrawer.java
@@ -214,6 +214,11 @@ public class MapChunkDrawer extends ChunkDrawer {
             //END of the parallel world !!!!!!!!!!!!!!!!!!!!!!!!!!
 
             dc.restoreState();
+            
+            Exception e = parallelMapTileLoader.getException();
+            if (e != null) {
+            	throw new RuntimeException(e);
+            }
         }
 
 

--- a/src/main/java/org/mapfish/print/map/MapTileTask.java
+++ b/src/main/java/org/mapfish/print/map/MapTileTask.java
@@ -73,4 +73,8 @@ public abstract class MapTileTask implements OrderedResultsExecutor.Task<MapTile
             //nothing to do
         }
     }
+    
+    public Exception getException() {
+    	return readException;
+    }
 }

--- a/src/main/java/org/mapfish/print/map/ParallelMapTileLoader.java
+++ b/src/main/java/org/mapfish/print/map/ParallelMapTileLoader.java
@@ -19,6 +19,7 @@
 
 package org.mapfish.print.map;
 
+import org.mapfish.print.Constants;
 import org.mapfish.print.RenderingContext;
 import org.pvalsecc.concurrent.BlockingSimpleTarget;
 import org.pvalsecc.concurrent.OrderedResultsExecutor;
@@ -59,6 +60,11 @@ public class ParallelMapTileLoader implements OrderedResultsExecutor.ResultColle
      * Number of tiles scheduled
      */
     private int nbTiles = 0;
+    
+    /**
+     * Reference to exception causing a failure when brokenUrlPlaceholder is set to 'throw'
+     */
+    private Exception exception = null;
 
     public ParallelMapTileLoader(RenderingContext context, PdfContentByte dc) {
         executor = context.getConfig().getMapRenderingExecutor();
@@ -109,9 +115,20 @@ public class ParallelMapTileLoader implements OrderedResultsExecutor.ResultColle
                         dc.restoreState();
                     }
                 }
+            } else if (context.getConfig().getBrokenUrlPlaceholder().equalsIgnoreCase(Constants.ImagePlaceHolderConstants.THROW)) {
+            	// store exception for current task and skip eventual remaining tasks
+            	exception = mapTileTaskResult.getException();
+            	target.addDone(target.getTarget() - target.getCount());
             }
         } finally {
             target.addDone(1);
         }
+    }
+    
+    /**
+     * The exception causing a failure when brokenUrlPlaceholder is set to 'throw'
+     */
+    public Exception getException() {
+    	return exception;
     }
 }


### PR DESCRIPTION
The documentation is not entirely clear about what the intended result is from the different possible options for `brokenUrlPlaceholder` but it does say "By default, when a url request fails, an error is thrown and the pdf process terminates." which the implementation does not AFAIK. This PR proposes to change the implementation to actually abort the PDF process and give an error response.