### PR TITLE
The scalebar should be printed in geodetic measure

### DIFF
--- a/core/src/main/java/org/mapfish/print/attribute/ScalebarAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/ScalebarAttribute.java
@@ -98,7 +98,7 @@ public class ScalebarAttribute extends ReflectiveAttribute<ScalebarAttribute.Sca
 
         /**
          * The scalebar type.
-         * 
+         *
          * <p>Available types:</p>
          * <ul>
          *      <li>"line": A simple line with graduations.</li>
@@ -137,6 +137,12 @@ public class ScalebarAttribute extends ReflectiveAttribute<ScalebarAttribute.Sca
          */
         @HasDefaultValue
         public String projection = null;
+
+        /**
+         * Use geodetic measurement calculations for the scalebar.
+         */
+        @HasDefaultValue
+        public boolean geodetic = false;
 
         /**
          * Force that the given unit is used (default: false).

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapBounds.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapBounds.java
@@ -19,9 +19,20 @@
 
 package org.mapfish.print.attribute.map;
 
+import com.vividsolutions.jts.geom.Coordinate;
+
+import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.GeodeticCalculator;
+import org.mapfish.print.map.DistanceUnit;
 import org.mapfish.print.map.Scale;
+import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.Rectangle;
 
@@ -31,6 +42,7 @@ import java.awt.Rectangle;
  */
 public abstract class MapBounds {
     private final CoordinateReferenceSystem projection;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MapBounds.class);
 
     /**
      * Constructor.
@@ -88,6 +100,48 @@ public abstract class MapBounds {
      * @param dpi the dpi of the map
      */
     public abstract Scale getScaleDenominator(final Rectangle paintArea, final double dpi);
+
+    /**
+     * Calculate and return the geodetic scale of the map bounds.
+     *
+     * @param paintArea the paint area of the map.
+     * @param dpi the dpi of the map
+     */
+    public final Scale getGeodeticScaleDenominator(final Rectangle paintArea, final double dpi) {
+
+        DistanceUnit projUnit = DistanceUnit.fromProjection(getProjection());
+
+        if (projUnit == DistanceUnit.DEGREES) {
+            return getScaleDenominator(paintArea, dpi);
+        }
+
+        try {
+            final ReferencedEnvelope bboxAdjustedToScreen = toReferencedEnvelope(paintArea, dpi);
+
+            final GeodeticCalculator calculator = new GeodeticCalculator(getProjection());
+            final double centerY = bboxAdjustedToScreen.centre().y;
+
+            final MathTransform transform = CRS.findMathTransform(getProjection(),
+                    GenericMapAttribute.parseProjection("EPSG:4326", true));
+            final Coordinate start = JTS.transform(new Coordinate(bboxAdjustedToScreen.getMinX(), centerY), null, transform);
+            final Coordinate end = JTS.transform(new Coordinate(bboxAdjustedToScreen.getMaxX(), centerY), null, transform);
+            calculator.setStartingGeographicPoint(start.x, start.y);
+            calculator.setDestinationGeographicPoint(end.x, end.y);
+            final double geoWidthInEllipsoidUnits = calculator.getOrthodromicDistance();
+            final DistanceUnit ellipsoidUnit = DistanceUnit.fromString(calculator.getEllipsoid().getAxisUnit().toString());
+
+            final double geoWidthInInches = ellipsoidUnit.convertTo(geoWidthInEllipsoidUnits, DistanceUnit.IN);
+            return new Scale(geoWidthInInches * (dpi / paintArea.getWidth()));
+        } catch (FactoryException e) {
+            LOGGER.error("Unable to do the geodetic calculation on the scale", e);
+        } catch (TransformException e) {
+            LOGGER.error("Unable to do the geodetic calculation on the scale", e);
+        }
+
+        // fall back
+        return getScaleDenominator(paintArea, dpi);
+    }
+
 
     /**
      * In case a rotation is used for the map, the bounds have to be adjusted so that all

--- a/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
@@ -85,8 +85,13 @@ public class ScalebarGraphic {
         }
 
         final DistanceUnit mapUnit = getUnit(bounds);
-        // to calculate the scale the requestor DPI is used , because the paint area is already adjusted
-        final Scale scale = bounds.getScaleDenominator(paintArea, mapParams.getRequestorDPI());
+        Scale scale;
+        if (scalebarParams.geodetic) {
+            // to calculate the scale the requestor DPI is used , because the paint area is already adjusted
+            scale = bounds.getGeodeticScaleDenominator(paintArea, mapParams.getRequestorDPI());
+        } else {
+            scale = bounds.getScaleDenominator(paintArea, mapParams.getRequestorDPI());
+        }
 
         DistanceUnit scaleUnit = scalebarParams.getUnit();
         if (scaleUnit == null) {

--- a/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
@@ -60,7 +60,7 @@ public class ScalebarGraphic {
 
     /**
      * Render the scalebar.
-     *  @param mapParams        The parameters of the map for which the scalebar is created.
+     * @param mapParams         The parameters of the map for which the scalebar is created.
      * @param scalebarParams    The scalebar parameters.
      * @param tempFolder        The directory in which the graphic file is created.
      * @param template          The template that containts the scalebar processor
@@ -99,7 +99,7 @@ public class ScalebarGraphic {
         final int maxLengthInPixelAdjusted = (scalebarParams.getOrientation().isHorizontal()) ?
                 maxWidthInPixelAdjusted : maxHeightInPixelAdjusted;
 
-        final double maxIntervalLengthInWorldUnits = DistanceUnit.PX.convertTo(maxLengthInPixelAdjusted, scaleUnit) 
+        final double maxIntervalLengthInWorldUnits = DistanceUnit.PX.convertTo(maxLengthInPixelAdjusted, scaleUnit)
                 * scale.getDenominator() / scalebarParams.intervals;
         final double niceIntervalLengthInWorldUnits =
                 getNearestNiceValue(maxIntervalLengthInWorldUnits, scaleUnit, scalebarParams.lockUnits);

--- a/core/src/test/java/org/mapfish/print/attribute/map/CenterScaleMapBoundsTest.java
+++ b/core/src/test/java/org/mapfish/print/attribute/map/CenterScaleMapBoundsTest.java
@@ -36,11 +36,13 @@ import static org.junit.Assert.assertEquals;
  */
 public class CenterScaleMapBoundsTest {
     static final double OPENLAYERS_2_DPI = 72;
+    public static final CoordinateReferenceSystem SPHERICAL_MERCATOR;
     public static final CoordinateReferenceSystem CH1903;
     public static final CoordinateReferenceSystem LAMBERT;
 
     static {
         try {
+            SPHERICAL_MERCATOR = CRS.decode("EPSG:3857");
             CH1903 = CRS.decode("EPSG:21781");
             LAMBERT = CRS.decode("EPSG:2154");
         } catch (Throwable e) {
@@ -104,7 +106,7 @@ public class CenterScaleMapBoundsTest {
         final CenterScaleMapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 0.0, 0.0, scale);
         final Rectangle paintArea = new Rectangle(400, 200);
         final ReferencedEnvelope envelope = bounds.toReferencedEnvelope(paintArea, OPENLAYERS_2_DPI);
-        
+
         CenterScaleMapBounds newBounds = bounds.zoomOut(1);
         ReferencedEnvelope newEnvelope = newBounds.toReferencedEnvelope(paintArea, OPENLAYERS_2_DPI);
 
@@ -113,7 +115,7 @@ public class CenterScaleMapBoundsTest {
         assertEquals(envelope.getMaxX(), newEnvelope.getMaxX(), delta);
         assertEquals(envelope.getMinY(), newEnvelope.getMinY(), delta);
         assertEquals(envelope.getMaxY(), newEnvelope.getMaxY(), delta);
-        
+
         newBounds = bounds.zoomOut(2);
         newEnvelope = newBounds.toReferencedEnvelope(paintArea, OPENLAYERS_2_DPI);
 
@@ -131,4 +133,15 @@ public class CenterScaleMapBoundsTest {
         assertEquals(CH1903, bounds.getProjection());
     }
 
+    @Test
+    public void geodetic() throws Exception {
+        final Scale scale = new Scale(15432.0);
+        final CenterScaleMapBounds centerBounds = new CenterScaleMapBounds(SPHERICAL_MERCATOR, 682433.0, 6379270.0, scale);
+        assertEquals(
+                centerBounds.getScaleDenominator(new Rectangle(715, 395), 254).getDenominator(),
+                15432.0, 1.0);
+        assertEquals(
+                centerBounds.getGeodeticScaleDenominator(new Rectangle(715, 395), 254).getDenominator(),
+                10019.0, 1.0);
+    }
 }


### PR DESCRIPTION
Original issue:
https://github.com/Geoportail-Luxembourg/geoportailv3/issues/689

We can also add an option but for all the world projections it's required !