### PR TITLE
Support `maxLength` for string attributes

### DIFF
--- a/core/src/main/java/org/mapfish/print/attribute/PrimitiveAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/PrimitiveAttribute.java
@@ -79,6 +79,13 @@ public abstract class PrimitiveAttribute<Value> implements Attribute {
         // no checks required
     }
 
+    /**
+     * Validation of the value from a request.
+     * @param value The value from a request.
+     */
+    public void validateValue(final Object value) {
+    }
+
     @Override
     public final void printClientConfig(final JSONWriter json, final Template template) throws JSONException {
         json.key(ReflectiveAttribute.JSON_NAME).value(this.configName);

--- a/core/src/main/java/org/mapfish/print/attribute/StringAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/StringAttribute.java
@@ -25,10 +25,37 @@ package org.mapfish.print.attribute;
  */
 public class StringAttribute extends PrimitiveAttribute<String> {
 
+    private int maxLength = -1;
+
     /**
      * Constructor.
      */
     public StringAttribute() {
         super(String.class);
+    }
+
+    /**
+     * The maximum number of characters allowed for this field (default: unlimited).
+     *
+     * @param maxLength Maximum number of characters.
+     */
+    public final void setMaxLength(final int maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    public final int getMaxLength() {
+        return this.maxLength;
+    }
+
+    @Override
+    public final void validateValue(final Object value) {
+        if (this.maxLength >= 0) {
+            if (value instanceof String) {
+                String text = (String) value;
+                if (text.length() > this.maxLength) {
+                    throw new IllegalArgumentException("text contains more than " + this.maxLength + " characters");
+                }
+            }
+        }
     }
 }

--- a/core/src/main/java/org/mapfish/print/output/Values.java
+++ b/core/src/main/java/org/mapfish/print/output/Values.java
@@ -161,7 +161,7 @@ public final class Values {
                     PObject[] pValues = new PObject[]{requestJsonAttributes, new PJsonObject(obj, "default_" + attributeName)};
                     jsonToUse = new PMultiObject(pValues);
                 }
-                value = parser.parsePrimitive(attributeName, pAtt.getValueClass(), jsonToUse);
+                value = parser.parsePrimitive(attributeName, pAtt, jsonToUse);
             } else if (attribute instanceof DataSourceAttribute) {
                 DataSourceAttribute dsAttribute = (DataSourceAttribute) attribute;
                 value = dsAttribute.parseAttribute(parser, template, requestJsonAttributes.optArray(attributeName));

--- a/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
+++ b/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
@@ -22,9 +22,11 @@ package org.mapfish.print.parser;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.mapfish.print.ExceptionUtils;
 import org.mapfish.print.ExtraPropertyException;
 import org.mapfish.print.MissingPropertyException;
+import org.mapfish.print.attribute.PrimitiveAttribute;
 import org.mapfish.print.wrapper.ObjectMissingException;
 import org.mapfish.print.wrapper.PArray;
 import org.mapfish.print.wrapper.PObject;
@@ -317,13 +319,15 @@ public final class MapfishParser {
     /**
      * Get the value of a primitive type from the request data.
      *
-     * @param fieldName   the name of th attribute to get from the request data.
-     * @param valueClass  the type to get
-     * @param requestData the data to retrieve the value from
+     * @param fieldName     the name of the attribute to get from the request data.
+     * @param pAtt          the primitive attribute.
+     * @param requestData   the data to retrieve the value from.
      */
-    public Object parsePrimitive(final String fieldName, final Class valueClass, final PObject requestData) {
+    public Object parsePrimitive(final String fieldName, final PrimitiveAttribute<?> pAtt, final PObject requestData) {
+        Class<?> valueClass = pAtt.getValueClass();
+        Object value;
         try {
-            return parseValue(false, new String[0], valueClass, fieldName, requestData);
+            value = parseValue(false, new String[0], valueClass, fieldName, requestData);
         } catch (UnsupportedTypeException e) {
             String type = e.type.getName();
             if (e.type.isArray()) {
@@ -334,6 +338,9 @@ public final class MapfishParser {
                                        + "\n\nTo support more types add the type to " +
                                        "parseValue and parseArrayValue in this class and add a test to the test class", e);
         }
+        pAtt.validateValue(value);
+
+        return value;
     }
 
     /**

--- a/core/src/test/java/org/mapfish/print/attribute/StringAttributeTest.java
+++ b/core/src/test/java/org/mapfish/print/attribute/StringAttributeTest.java
@@ -19,10 +19,58 @@
 
 package org.mapfish.print.attribute;
 
-public class StringAttributeTest extends AbstractAttributeTest {
+import static org.junit.Assert.assertEquals;
 
-    @Override
-    protected Attribute createAttribute() {
-        return new StringAttribute();
+import java.io.IOException;
+
+import org.junit.Test;
+import org.mapfish.print.AbstractMapfishSpringTest;
+import org.mapfish.print.TestHttpClientFactory;
+import org.mapfish.print.config.Configuration;
+import org.mapfish.print.config.ConfigurationFactory;
+import org.mapfish.print.config.Template;
+import org.mapfish.print.output.Values;
+import org.mapfish.print.parser.MapfishParser;
+import org.mapfish.print.wrapper.json.PJsonObject;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class StringAttributeTest extends AbstractMapfishSpringTest {
+
+    private static final String BASE_DIR = "string/";
+
+    @Autowired
+    private ConfigurationFactory configurationFactory;
+    @Autowired
+    private TestHttpClientFactory httpClientFactory;
+    @Autowired
+    private MapfishParser parser;
+
+    @Test
+    public void testParsableByValues() throws Exception {
+        final Configuration config = configurationFactory.getConfig(getFile(BASE_DIR + "config.yaml"));
+        PJsonObject requestData = loadJsonRequestData();
+
+        Template template = config.getTemplate("main");
+        Values values = new Values(requestData, template, this.parser, config.getDirectory(), httpClientFactory, config.getDirectory());
+
+        assertEquals("a loooooooooooooooooooong text", values.getString("field1"));
+        assertEquals("a short text", values.getString("field2"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testParsableByValuesError() throws Exception {
+        final Configuration config = configurationFactory.getConfig(getFile(BASE_DIR + "config.yaml"));
+        PJsonObject requestData = loadJsonRequestDataError();
+
+        Template template = config.getTemplate("main");
+        new Values(requestData, template, this.parser, config.getDirectory(), httpClientFactory, config.getDirectory());
+    }
+
+    private PJsonObject loadJsonRequestData() throws IOException {
+        return parseJSONObjectFromFile(StringArrayAttributeTest.class, BASE_DIR + "requestData.json");
+    }
+
+    private PJsonObject loadJsonRequestDataError() throws IOException {
+        return parseJSONObjectFromFile(StringArrayAttributeTest.class, BASE_DIR + "requestDataError.json");
     }
 }

--- a/core/src/test/resources/org/mapfish/print/attribute/string/config.yaml
+++ b/core/src/test/resources/org/mapfish/print/attribute/string/config.yaml
@@ -1,0 +1,12 @@
+throwErrorOnExtraParameters: true
+templates:
+  main: !template
+    reportTemplate: simple-map.jrxml
+    attributes:
+      field1: !string {}
+      field2: !string {maxLength: 15}
+    processors:
+    - !reportBuilder
+        directory: "."
+
+

--- a/core/src/test/resources/org/mapfish/print/attribute/string/requestData.json
+++ b/core/src/test/resources/org/mapfish/print/attribute/string/requestData.json
@@ -1,0 +1,8 @@
+{
+  "layout": "main",
+  "outputFormat": "pdf",
+  "attributes": {
+    "field1": "a loooooooooooooooooooong text",
+    "field2": "a short text"
+  }
+}

--- a/core/src/test/resources/org/mapfish/print/attribute/string/requestDataError.json
+++ b/core/src/test/resources/org/mapfish/print/attribute/string/requestDataError.json
@@ -1,0 +1,8 @@
+{
+  "layout": "main",
+  "outputFormat": "pdf",
+  "attributes": {
+    "field1": "a loooooooooooooooooooong text",
+    "field2": "a loooooooooooooooooooong text"
+  }
+}


### PR DESCRIPTION
Check if the text given for a string attribute exceeds a certain limit.

Example configuration:

    attributes:
      field1: !string {}
      field2: !string {maxLength: 15}