### PR TITLE
Remove old reports with timer task

### DIFF
--- a/core/src/main/java/org/mapfish/print/config/WorkingDirectories.java
+++ b/core/src/main/java/org/mapfish/print/config/WorkingDirectories.java
@@ -39,7 +39,6 @@ public class WorkingDirectories {
     
     private File working;
     private File reports;
-    private File reportsOldApi;
 
     public final void setWorking(final File working) {
         this.working = working;
@@ -55,7 +54,6 @@ public class WorkingDirectories {
     @PostConstruct
     public final void init() {
         this.reports = new File(this.working, "reports");
-        this.reportsOldApi = new File(this.working, "reports-old-api");
     }
     /**
      * Get the directory where the compiled jasper reports should be put.
@@ -90,14 +88,6 @@ public class WorkingDirectories {
         } catch (IOException e) {
             throw new AssertionError("Unable to create temporary directory in '" + this.working + "'");
         }
-    }
-
-    /**
-     * Get the directory where the reports of the old API servlet are written to.
-     */
-    public final File getReportsOldApi() {
-        createIfMissing(this.reportsOldApi, "Reports-Old-API");
-        return this.reportsOldApi;
     }
 
     /**

--- a/core/src/main/resources/mapfish-spring-application-context.xml
+++ b/core/src/main/resources/mapfish-spring-application-context.xml
@@ -46,6 +46,7 @@
     </bean>
     <bean id="workingDirectories" class="org.mapfish.print.config.WorkingDirectories">
         <property name="working" value="${workingDir}" />
+        <property name="maxAge" value="${fileCleanUpMaxAge}" />
     </bean>
 
     <bean id="configurationFactory" class="org.mapfish.print.config.ConfigurationFactory"/>
@@ -62,6 +63,8 @@
         <property name="timeout" value="600" />
         <!-- Timeout after which a print job is canceled, if the status has not been checked (in seconds). -->
         <property name="abandonedTimeout" value="120" />
+        <property name="oldFileCleanUp" value="${fileCleanUp}" />
+        <property name="oldFileCleanupInterval" value="${fileCleanUpInterval}" />
     </bean>
     <bean id="printJobPrototype" class="org.mapfish.print.servlet.job.FilePrintJob" scope="prototype"/>
     <bean id="fileReportLoader" class="org.mapfish.print.servlet.job.loader.FileReportLoader"/>

--- a/core/src/main/resources/mapfish-spring.properties
+++ b/core/src/main/resources/mapfish-spring.properties
@@ -17,4 +17,14 @@
 # along with MapFish Print.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# the directory in which temporary files but also the finished reports are stored.
 workingDir=${java.io.tmpdir}/mapfish-print
+
+# delete old report files?
+fileCleanUp=true
+
+# the interval at which old reports are deleted (in seconds). Default 86400 s (24 h).
+fileCleanUpInterval=86400
+
+# the max. age for a report before it is deleted (in seconds). Default 86400 s (24 h).
+fileCleanUpMaxAge=86400

--- a/core/src/test/java/org/mapfish/print/config/WorkingDirectoriesTest.java
+++ b/core/src/test/java/org/mapfish/print/config/WorkingDirectoriesTest.java
@@ -1,0 +1,40 @@
+package org.mapfish.print.config;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import org.junit.Test;
+import org.mapfish.print.AbstractMapfishSpringTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class WorkingDirectoriesTest extends AbstractMapfishSpringTest {
+
+    @Autowired
+    private WorkingDirectories workingDirectories;
+
+    @Test
+    public void testCleanUp() throws IOException {
+        File reportDir = this.workingDirectories.getReports();
+
+        long oldDate = new Date().getTime() - 86400;
+
+        // old file, should be deleted
+        new File(reportDir, "1").createNewFile();
+        new File(reportDir, "1").setLastModified(oldDate);
+        // old file, should be deleted
+        new File(reportDir, "2").createNewFile();
+        new File(reportDir, "2").setLastModified(oldDate);
+        // new file, should be kept
+        new File(reportDir, "3").createNewFile();
+
+        int maxAgeInSeconds = 5;
+        this.workingDirectories.new CleanUpTask(maxAgeInSeconds).run();
+
+        assertFalse(new File(reportDir, "1").exists());
+        assertFalse(new File(reportDir, "2").exists());
+        assertTrue(new File(reportDir, "3").exists());
+    }
+}

--- a/core/src/test/java/org/mapfish/print/servlet/fileloader/AbstractConfigLoaderTest.java
+++ b/core/src/test/java/org/mapfish/print/servlet/fileloader/AbstractConfigLoaderTest.java
@@ -60,7 +60,6 @@ public abstract class AbstractConfigLoaderTest extends AbstractMapfishSpringTest
         assertAccessible(this.workingDirectories.getReports());
         assertAccessible(this.workingDirectories.getWorking(configuration));
         assertAccessible(this.workingDirectories.getJasperCompilation(configuration));
-        assertAccessible(this.workingDirectories.getReportsOldApi());
         assertAccessible(this.workingDirectories.getTaskDirectory());
     }
 
@@ -80,7 +79,6 @@ public abstract class AbstractConfigLoaderTest extends AbstractMapfishSpringTest
         assertLoadable(bytes, this.workingDirectories.getReports());
         assertLoadable(bytes, this.workingDirectories.getWorking(configuration));
         assertLoadable(bytes, this.workingDirectories.getJasperCompilation(configuration));
-        assertLoadable(bytes, this.workingDirectories.getReportsOldApi());
         assertLoadable(bytes, this.workingDirectories.getTaskDirectory());
     }
 


### PR DESCRIPTION
Reports created by MFP are currently not deleted, that is at some point the hard-drive might be filled up with old reports.

This PR introduces a clean-up task, which is run every 24h (configurable) and which deletes reports older than 24h (configurable).

The configuration is made in `mapfish-spring.properties`:

    # delete old report files?
    fileCleanUp=true

    # the interval at which old reports are deleted (in seconds). Default 86400 s (24 h).
    fileCleanUpInterval=86400

    # the max. age for a report before it is deleted (in seconds). Default 86400 s (24 h).
    fileCleanUpMaxAge=86400