### PR TITLE
Removed duplicate customParams for tiledwms layer

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/tiled/AbstractTiledLayerParams.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/AbstractTiledLayerParams.java
@@ -19,8 +19,6 @@
 
 package org.mapfish.print.map.tiled;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Multimap;
 import org.mapfish.print.map.AbstractLayerParams;
 import org.mapfish.print.parser.HasDefaultValue;
 
@@ -55,11 +53,7 @@ public abstract class AbstractTiledLayerParams extends AbstractLayerParams {
     /**
      * Create a URL that is common to all image requests for this layer.  It will take the base url and append all mergeable and
      * custom params to the base url.
-     *
-     * @param queryParamCustomization a function that can optionally modify the Multimap passed into the function and returns the
-     *                                Multimap that will contain all the query params that will be part of the URI.  If the function
-     *                                returns null then the original map will be used as the params.
      */
-    public abstract String createCommonUrl(Function<Multimap<String, String>, Multimap<String, String>> queryParamCustomization)
+    public abstract String createCommonUrl()
             throws URISyntaxException, UnsupportedEncodingException;
 }

--- a/core/src/main/java/org/mapfish/print/map/tiled/AbstractWMXLayerParams.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/AbstractWMXLayerParams.java
@@ -19,10 +19,8 @@
 
 package org.mapfish.print.map.tiled;
 
-import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import org.mapfish.print.URIUtils;
 import org.mapfish.print.parser.HasDefaultValue;
 import org.mapfish.print.wrapper.PArray;
 import org.mapfish.print.wrapper.PObject;
@@ -32,7 +30,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Iterator;
-import javax.annotation.Nullable;
 
 /**
  * An abstract layers params class for WM* layers (e.g. WMS or WMTS).
@@ -118,22 +115,9 @@ public abstract class AbstractWMXLayerParams extends AbstractTiledLayerParams {
     //CSOFF: DesignForExtension
     @Override
     //CSON: DesignForExtension
-    public String createCommonUrl(
-            @Nullable final Function<Multimap<String, String>, Multimap<String, String>> queryParamCustomization)
+    public String createCommonUrl()
             throws URISyntaxException, UnsupportedEncodingException {
-        Multimap<String, String> queryParams = HashMultimap.create();
-
-        queryParams.putAll(getCustomParams());
-        queryParams.putAll(getMergeableParams());
-
-        if (queryParamCustomization != null) {
-            Multimap<String, String> result = queryParamCustomization.apply(queryParams);
-            if (result != null) {
-                queryParams = result;
-            }
-        }
-        final URI baseUri = new URI(getBaseUrl());
-        return URIUtils.addParams(getBaseUrl(), queryParams, URIUtils.getParameters(baseUri).keySet());
+        return getBaseUrl();
     }
 
     /**

--- a/core/src/main/java/org/mapfish/print/map/tiled/TileCacheInformation.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/TileCacheInformation.java
@@ -19,8 +19,6 @@
 
 package org.mapfish.print.map.tiled;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Multimap;
 import com.vividsolutions.jts.geom.Coordinate;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.mapfish.print.attribute.map.MapBounds;
@@ -97,13 +95,6 @@ public abstract class TileCacheInformation {
             throws Exception;
 
     /**
-     * Adds the query parameters common to every tile.
-     *
-     * @param result the query params added because of customParams or mergeableQueryParams.
-     */
-    protected abstract void customizeQueryParams(Multimap<String, String> result);
-
-    /**
      * Get the scale that the layer uses for its calculations.  The map isn't always at a resolution that a tiled layer
      * supports so a scale is chosen for the layer that is close to the map scale. This method returns the layer's scale.
      * <p/>
@@ -174,14 +165,7 @@ public abstract class TileCacheInformation {
     // CSOFF:DesignForExtension
     protected String createCommonUrl() throws URISyntaxException, UnsupportedEncodingException {
         // CSOFF:DesignForExtension
-        return this.params.createCommonUrl(new Function<Multimap<String, String>, Multimap<String, String>>() {
-            @Nullable
-            @Override
-            public Multimap<String, String> apply(@Nullable final Multimap<String, String> input) {
-                customizeQueryParams(input);
-                return input;
-            }
-        });
+        return this.params.createCommonUrl();
     }
 
     /**

--- a/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayer.java
@@ -19,7 +19,6 @@
 
 package org.mapfish.print.map.tiled.osm;
 
-import com.google.common.collect.Multimap;
 import jsr166y.ForkJoinPool;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -136,11 +135,6 @@ public final class OsmLayer extends AbstractTiledLayer {
             }
 
             return httpRequestFactory.createRequest(uri, HttpMethod.GET);
-        }
-
-        @Override
-        protected void customizeQueryParams(final Multimap<String, String> result) {
-            //not much query params for this protocol...
         }
 
         @Override

--- a/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayerParam.java
@@ -19,9 +19,7 @@
 
 package org.mapfish.print.map.tiled.osm;
 
-import com.google.common.base.Function;
 import com.google.common.base.Strings;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.util.Assert;
@@ -145,8 +143,7 @@ public final class OsmLayerParam extends AbstractTiledLayerParams {
     }
 
     @Override
-    public String createCommonUrl(
-            final Function<Multimap<String, String>, Multimap<String, String>> function) {
+    public String createCommonUrl() {
         return getBaseUrl();
     }
 

--- a/core/src/main/java/org/mapfish/print/map/tiled/wms/TiledWmsLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wms/TiledWmsLayer.java
@@ -19,7 +19,6 @@
 
 package org.mapfish.print.map.tiled.wms;
 
-import com.google.common.collect.Multimap;
 import jsr166y.ForkJoinPool;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -104,11 +103,6 @@ public final class TiledWmsLayer extends AbstractTiledLayer {
                     makeWmsGetLayerRequest(httpRequestFactory, TiledWmsLayer.this.param,
                             new URI(commonUrl), tileSizeOnScreen, this.dpi, tileBounds);
             return httpRequestFactory.createRequest(uri, HttpMethod.GET);
-        }
-
-        @Override
-        protected void customizeQueryParams(final Multimap<String, String> result) {
-            //not much query params for this protocol...
         }
 
         @Override

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
@@ -163,11 +163,6 @@ public class WMTSLayer extends AbstractTiledLayer {
         }
 
         @Override
-        protected void customizeQueryParams(final Multimap<String, String> result) {
-            //no common params for this protocol.
-        }
-
-        @Override
         public Scale getScale() {
             return new Scale(this.matrix.scaleDenominator);
         }

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayerParam.java
@@ -19,20 +19,21 @@
 
 package org.mapfish.print.map.tiled.wmts;
 
-import com.google.common.base.Function;
 import com.google.common.base.Strings;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.vividsolutions.jts.util.Assert;
 
 import org.mapfish.print.Constants;
+import org.mapfish.print.URIUtils;
 import org.mapfish.print.map.tiled.AbstractWMXLayerParams;
 import org.mapfish.print.parser.HasDefaultValue;
 import org.mapfish.print.wrapper.json.PJsonObject;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.annotation.Nullable;
 
 /**
  * The parameters for configuration a WMTS layer.
@@ -143,15 +144,19 @@ public final class WMTSLayerParam extends AbstractWMXLayerParams {
         Assert.isTrue(validateBaseUrl(), "invalid baseURL");
     }
 
-
     @Override
-    public String createCommonUrl(
-            @Nullable final Function<Multimap<String, String>, Multimap<String, String>> queryParamCustomization)
+    public String createCommonUrl()
             throws URISyntaxException, UnsupportedEncodingException {
         if (RequestEncoding.REST == this.requestEncoding) {
             return getBaseUrl();
         } else {
-            return super.createCommonUrl(queryParamCustomization);
+            Multimap<String, String> queryParams = HashMultimap.create();
+
+            queryParams.putAll(getCustomParams());
+            queryParams.putAll(getMergeableParams());
+
+            final URI baseUri = new URI(getBaseUrl());
+            return URIUtils.addParams(getBaseUrl(), queryParams, URIUtils.getParameters(baseUri).keySet());
         }
     }
 


### PR DESCRIPTION
This is going to fix #287.

For some reason the duplicate customParams in the tiledwms request wasn't an issue when testing with the Geoserver examples shipped with mapfish. Still this was an issue for our server...
The duplicate params were added both when building the base url and when adding the custom params.
I removed the duplicate added during the base url build-up.
Also removed the params customization functions present in Oms, Wms and Wmts which were not used, this allowed to streamline the common Url creation interface.