### PR TITLE
Show default values for primitive attributes in capabilities

### DIFF
--- a/core/src/main/java/org/mapfish/print/attribute/PrimitiveAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/PrimitiveAttribute.java
@@ -90,6 +90,9 @@ public abstract class PrimitiveAttribute<Value> implements Attribute {
     public final void printClientConfig(final JSONWriter json, final Template template) throws JSONException {
         json.key(ReflectiveAttribute.JSON_NAME).value(this.configName);
         json.key(ReflectiveAttribute.JSON_ATTRIBUTE_TYPE).value(clientConfigTypeDescription());
+        if (getDefault() != null) {
+            json.key(ReflectiveAttribute.JSON_ATTRIBUTE_DEFAULT).value(getDefault());
+        }
     }
 
     /**

--- a/core/src/test/java/org/mapfish/print/attribute/AbstractAttributeTest.java
+++ b/core/src/test/java/org/mapfish/print/attribute/AbstractAttributeTest.java
@@ -20,6 +20,8 @@
 package org.mapfish.print.attribute;
 
 import com.google.common.collect.Lists;
+
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONWriter;
 import org.junit.Test;
@@ -43,17 +45,20 @@ public abstract class AbstractAttributeTest {
 
     @Test
     public void testPrintClientConfig() throws Exception {
-        final StringWriter jsonOutput = new StringWriter();
-        JSONWriter json = new JSONWriter(jsonOutput);
-        Template template = Mockito.mock(Template.class);
-        // verify there is no error
-        json.object();
         final Attribute attribute = createAttribute();
-        attribute.printClientConfig(json, template);
-        json.endObject();
-        JSONObject capabilities = new JSONObject(jsonOutput.toString());
+        Template template = Mockito.mock(Template.class);
+        JSONObject capabilities = getClientConfig(attribute, template);
         assertTrue("Missing " + JSON_NAME + " in: \n" + capabilities.toString(2), capabilities.has(JSON_NAME));
         assertTrue("Missing " + JSON_ATTRIBUTE_TYPE + " in: \n" + capabilities.toString(2), capabilities.has(JSON_ATTRIBUTE_TYPE));
+    }
+
+    public static JSONObject getClientConfig(Attribute attribute, Template template) throws JSONException {
+        final StringWriter jsonOutput = new StringWriter();
+        JSONWriter json = new JSONWriter(jsonOutput);
+        json.object();
+        attribute.printClientConfig(json, template);
+        json.endObject();
+        return new JSONObject(jsonOutput.toString());
     }
 
     @Test

--- a/core/src/test/java/org/mapfish/print/attribute/BooleanAttributeTest.java
+++ b/core/src/test/java/org/mapfish/print/attribute/BooleanAttributeTest.java
@@ -19,6 +19,7 @@
 
 package org.mapfish.print.attribute;
 
+import org.json.JSONObject;
 import org.junit.Test;
 import org.mapfish.print.AbstractMapfishSpringTest;
 import org.mapfish.print.TestHttpClientFactory;
@@ -57,6 +58,13 @@ public class BooleanAttributeTest extends AbstractMapfishSpringTest {
         assertTrue(values.getBoolean("field1"));
         assertFalse(values.getBoolean("field2"));
         assertFalse(values.getBoolean("field3"));
+
+        JSONObject field2Config = AbstractAttributeTest.getClientConfig(template.getAttributes().get("field2"), template);
+        assertFalse(field2Config.has(ReflectiveAttribute.JSON_ATTRIBUTE_DEFAULT));
+
+        JSONObject field3Config = AbstractAttributeTest.getClientConfig(template.getAttributes().get("field3"), template);
+        assertTrue(field3Config.has(ReflectiveAttribute.JSON_ATTRIBUTE_DEFAULT));
+        assertFalse(field3Config.getBoolean(ReflectiveAttribute.JSON_ATTRIBUTE_DEFAULT));
     }
 
     private PJsonObject loadJsonRequestData() throws IOException {

--- a/core/src/test/resources/org/mapfish/print/processor/map/setparamprocessor/requestData.json
+++ b/core/src/test/resources/org/mapfish/print/processor/map/setparamprocessor/requestData.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
-    "customP1" : 1,
-    "customP2" : 2,
+    "customP1" : "1",
+    "customP2" : "2",
     "map": {
       "center": [-8236566.427097, 4976131.070529],
       "scale": 100000,


### PR DESCRIPTION
Show default values for primitive attributes (string, boolean, boolean, integer) in the capabilities document.

    "attributes": [
      {
      "name": "title",
      "type": "String",
      "default": "Default Title"
      },