### PR TITLE
Fix and improve logging

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
@@ -40,7 +40,7 @@ public abstract class BaseMapServlet {
     /**
      * A logger for logging the print specifications.
      */
-    protected static final Logger SPEC_LOGGER = LoggerFactory.getLogger(BaseMapServlet.class.getPackage().toString() + ".spec");
+    protected static final Logger SPEC_LOGGER = LoggerFactory.getLogger(BaseMapServlet.class.getPackage().getName() + ".spec");
 
     /**
      * Remove commas and whitespace from a string.

--- a/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
@@ -132,6 +132,7 @@ public abstract class PrintJob implements Callable<PrintJobStatus> {
         PJsonObject spec = null;
         MapPrinter mapPrinter = null;
         try {
+            LOGGER.info("Starting print job " + this.referenceId);
             spec = PrintJob.this.requestData;
             mapPrinter = PrintJob.this.mapPrinterFactory.create(getAppId());
             final MapPrinter finalMapPrinter = mapPrinter;
@@ -143,7 +144,8 @@ public abstract class PrintJob implements Callable<PrintJobStatus> {
             });
 
             this.metricRegistry.counter(getClass().getName() + "success").inc();
-            LOGGER.debug("Successfully completed print job" + this.referenceId + "\n" + this.requestData);
+            LOGGER.info("Successfully completed print job " + this.referenceId);
+            LOGGER.debug("Job " + this.referenceId + "\n" + this.requestData);
             String fileName = getFileName(mapPrinter, spec);
 
             final OutputFormat outputFormat = mapPrinter.getOutputFormat(spec);

--- a/core/src/main/java/org/mapfish/print/servlet/job/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/ThreadPoolJobManager.java
@@ -324,6 +324,7 @@ public class ThreadPoolJobManager implements JobManager {
             pendingPrintJob.assertAccess();
             pendingPrintJob.store(this.registry, this.assertionPersister);
             this.registry.put(LAST_POLL + job.getReferenceId(), new Date().getTime());
+            LOGGER.info("Submitted print job " + job.getReferenceId());
         } catch (JSONException e) {
             throw ExceptionUtils.getRuntimeException(e);
         } finally {

--- a/core/src/main/resources/shell-default-log.xml
+++ b/core/src/main/resources/shell-default-log.xml
@@ -28,7 +28,7 @@
 
     <logger name="org.mapfish" level="DEBUG" />
     <!-- Set spec logger to INFO to log all print spec json data -->
-    <logger name="org.mapfish.print.servlet.BaseMapServlet.spec" level="OFF" />
+    <logger name="org.mapfish.print.servlet.spec" level="OFF" />
 
 
     <root level="DEBUG">

--- a/core/src/main/resources/shell-default-log.xml
+++ b/core/src/main/resources/shell-default-log.xml
@@ -29,6 +29,8 @@
     <logger name="org.mapfish" level="DEBUG" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.spec" level="OFF" />
+    <!-- Set ValuesLogger to INFO to show all template parameters -->
+    <logger name="org.mapfish.print.output.ValuesLogger" level="OFF" />
 
 
     <root level="DEBUG">

--- a/core/src/main/resources/shell-info-log.xml
+++ b/core/src/main/resources/shell-info-log.xml
@@ -28,7 +28,7 @@
 
     <logger name="org.mapfish" level="INFO" />
     <!-- Set spec logger to INFO to log all print spec json data -->
-    <logger name="org.mapfish.print.servlet.BaseMapServlet.spec" level="OFF" />
+    <logger name="org.mapfish.print.servlet.spec" level="OFF" />
 
 
     <root level="INFO">

--- a/core/src/main/resources/shell-info-log.xml
+++ b/core/src/main/resources/shell-info-log.xml
@@ -29,6 +29,8 @@
     <logger name="org.mapfish" level="INFO" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.spec" level="OFF" />
+    <!-- Set ValuesLogger to INFO to show all template parameters -->
+    <logger name="org.mapfish.print.output.ValuesLogger" level="OFF" />
 
 
     <root level="INFO">

--- a/core/src/main/resources/shell-quiet-log.xml
+++ b/core/src/main/resources/shell-quiet-log.xml
@@ -28,7 +28,7 @@
 
     <logger name="org.mapfish" level="WARN" />
     <!-- Set spec logger to INFO to log all print spec json data -->
-    <logger name="org.mapfish.print.servlet.BaseMapServlet.spec" level="OFF" />
+    <logger name="org.mapfish.print.servlet.spec" level="OFF" />
 
 
     <root level="WARN">

--- a/core/src/main/resources/shell-quiet-log.xml
+++ b/core/src/main/resources/shell-quiet-log.xml
@@ -29,6 +29,8 @@
     <logger name="org.mapfish" level="WARN" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.spec" level="OFF" />
+    <!-- Set ValuesLogger to INFO to show all template parameters -->
+    <logger name="org.mapfish.print.output.ValuesLogger" level="OFF" />
 
 
     <root level="WARN">

--- a/core/src/main/resources/shell-verbose-log.xml
+++ b/core/src/main/resources/shell-verbose-log.xml
@@ -29,6 +29,8 @@
     <logger name="org.mapfish" level="ALL" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.spec" level="OFF" />
+    <!-- Set ValuesLogger to INFO to show all template parameters -->
+    <logger name="org.mapfish.print.output.ValuesLogger" level="OFF" />
 
 
     <root level="ALL">

--- a/core/src/main/resources/shell-verbose-log.xml
+++ b/core/src/main/resources/shell-verbose-log.xml
@@ -28,7 +28,7 @@
 
     <logger name="org.mapfish" level="ALL" />
     <!-- Set spec logger to INFO to log all print spec json data -->
-    <logger name="org.mapfish.print.servlet.BaseMapServlet.spec" level="OFF" />
+    <logger name="org.mapfish.print.servlet.spec" level="OFF" />
 
 
     <root level="ALL">

--- a/core/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/core/src/main/webapp/WEB-INF/classes/logback.xml
@@ -44,7 +44,7 @@
     <logger name="org.mapfish" level="INFO" />
     <logger name="org.springframework" level="OFF" />
     <!-- Set spec logger to INFO to log all print spec json data -->
-    <logger name="org.mapfish.print.servlet.BaseMapServlet.spec" level="OFF" />
+    <logger name="org.mapfish.print.servlet.spec" level="OFF" />
     <logger name="com.codahale.metrics" level="INFO" />
     <logger name="com.codahale.metrics.JmxReporter" level="INFO" />
 

--- a/core/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/core/src/main/webapp/WEB-INF/classes/logback.xml
@@ -45,6 +45,8 @@
     <logger name="org.springframework" level="OFF" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.spec" level="OFF" />
+    <!-- Set ValuesLogger to INFO to show all template parameters -->
+    <logger name="org.mapfish.print.output.ValuesLogger" level="OFF" />
     <logger name="com.codahale.metrics" level="INFO" />
     <logger name="com.codahale.metrics.JmxReporter" level="INFO" />
 


### PR DESCRIPTION
* Fix the spec logger (the name was wrong), see #292. The logging of the specs is now turned off by default.
* Turn the logger for the template parameters off by default.
* Log the start and end of a print job.

closes #292