### PR TITLE
Keep at least one thread in the pool of the "old file cleaner"

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/job/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/ThreadPoolJobManager.java
@@ -267,7 +267,7 @@ public class ThreadPoolJobManager implements JobManager {
                 PostResultToRegistryTask.CHECK_INTERVAL, TimeUnit.MILLISECONDS);
 
         if (this.oldFileCleanUp) {
-            this.cleanUpTimer = Executors.newScheduledThreadPool(0, new ThreadFactory() {
+            this.cleanUpTimer = Executors.newScheduledThreadPool(1, new ThreadFactory() {
                 @Override
                 public Thread newThread(final Runnable timerTask) {
                     final Thread thread = new Thread(timerTask, "Clean up old files");


### PR DESCRIPTION
Otherwise `newThread` of the pool will be executed constantly, which will bring the CPU to 150%.

Closes #299