### PR TITLE
Wmts bounds overflow

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/Matrix.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/Matrix.java
@@ -36,7 +36,7 @@ public class Matrix {
     /**
      * A 2 dimensional array containing number of tiles in the matrix for the columns (0) and rows (1).
      */
-    public int[] matrixSize;
+    public double[] matrixSize;
     /**
      * The scale of the matrix.
      */

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/Matrix.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/Matrix.java
@@ -36,7 +36,7 @@ public class Matrix {
     /**
      * A 2 dimensional array containing number of tiles in the matrix for the columns (0) and rows (1).
      */
-    public double[] matrixSize;
+    public long[] matrixSize;
     /**
      * The scale of the matrix.
      */

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
@@ -19,6 +19,7 @@
 
 package org.mapfish.print.map.tiled.wmts;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimap;
 import jsr166y.ForkJoinPool;
 import org.geotools.coverage.grid.GridCoverage2D;
@@ -73,7 +74,8 @@ public class WMTSLayer extends AbstractTiledLayer {
         return new WMTSTileCacheInfo(bounds, paintArea, dpi);
     }
 
-    private final class WMTSTileCacheInfo extends TileCacheInformation {
+    @VisibleForTesting
+    final class WMTSTileCacheInfo extends TileCacheInformation {
         private Matrix matrix;
 
         public WMTSTileCacheInfo(final MapBounds bounds, final Rectangle paintArea, final double dpi) {
@@ -106,8 +108,10 @@ public class WMTSLayer extends AbstractTiledLayer {
         protected ReferencedEnvelope getTileCacheBounds() {
             double scaleDenominator = new Scale(this.matrix.scaleDenominator).toResolution(this.bounds.getProjection(), getLayerDpi());
             double minX = this.matrix.topLeftCorner[0];
-            double minY = this.matrix.topLeftCorner[1] - (this.matrix.getTileHeight() * this.matrix.matrixSize[1] * scaleDenominator);
-            double maxX = this.matrix.topLeftCorner[0] + (this.matrix.getTileWidth() * this.matrix.matrixSize[0] * scaleDenominator);
+            double tileHeight = this.matrix.getTileHeight();
+            double minY = this.matrix.topLeftCorner[1] - (tileHeight * this.matrix.matrixSize[1] * scaleDenominator);
+            double tileWidth = this.matrix.getTileWidth();
+            double maxX = this.matrix.topLeftCorner[0] + (tileWidth * this.matrix.matrixSize[0] * scaleDenominator);
             double maxY = this.matrix.topLeftCorner[1];
             return new ReferencedEnvelope(minX, maxX, minY, maxY, bounds.getProjection());
         }

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
@@ -109,9 +109,11 @@ public class WMTSLayer extends AbstractTiledLayer {
             double scaleDenominator = new Scale(this.matrix.scaleDenominator).toResolution(this.bounds.getProjection(), getLayerDpi());
             double minX = this.matrix.topLeftCorner[0];
             double tileHeight = this.matrix.getTileHeight();
-            double minY = this.matrix.topLeftCorner[1] - (tileHeight * this.matrix.matrixSize[1] * scaleDenominator);
+            double numYTiles = this.matrix.matrixSize[1];
+            double minY = this.matrix.topLeftCorner[1] - (tileHeight * numYTiles * scaleDenominator);
             double tileWidth = this.matrix.getTileWidth();
-            double maxX = this.matrix.topLeftCorner[0] + (tileWidth * this.matrix.matrixSize[0] * scaleDenominator);
+            double numXTiles = this.matrix.matrixSize[0];
+            double maxX = this.matrix.topLeftCorner[0] + (tileWidth * numXTiles * scaleDenominator);
             double maxY = this.matrix.topLeftCorner[1];
             return new ReferencedEnvelope(minX, maxX, minY, maxY, bounds.getProjection());
         }

--- a/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
+++ b/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
@@ -201,6 +201,8 @@ public final class MapfishParser {
             value = layer.getString(name);
         } else if (type == Integer.class || type == int.class) {
             value = layer.getInt(name);
+        } else if (type == Long.class || type == long.class) {
+            value = layer.getLong(name);
         } else if (type == Double.class || type == double.class) {
             value = layer.getDouble(name);
         } else if (type == Float.class || type == float.class) {
@@ -283,6 +285,8 @@ public final class MapfishParser {
             value = array.getString(i);
         } else if (type == Integer.class || type == int.class) {
             value = array.getInt(i);
+        } else if (type == Long.class || type == long.class) {
+            value = array.getLong(i);
         } else if (type == Double.class || type == double.class) {
             value = array.getDouble(i);
         } else if (type == Float.class || type == float.class) {

--- a/core/src/main/java/org/mapfish/print/wrapper/PAbstractObject.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/PAbstractObject.java
@@ -86,6 +86,28 @@ public abstract class PAbstractObject extends PElement implements PObject {
     }
 
     /**
+     * Get a property as an long or throw an exception.
+     * @param key the property name
+     */
+    @Override
+    public final long getLong(final String key) {
+        Long result = optLong(key);
+        if (result == null) {
+            throw new ObjectMissingException(this, key);
+        }
+        return result;
+    }
+    /**
+     * Get a property as an long or default value.
+     * @param key the property name
+     * @param defaultValue the default value
+     */
+    @Override
+    public final long optLong(final String key, final long defaultValue) {
+        Long result = optLong(key);
+        return result == null ? defaultValue : result;
+    }
+    /**
      * Get a property as a double or throw an exception.
      * @param key the property name
      */

--- a/core/src/main/java/org/mapfish/print/wrapper/PArray.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/PArray.java
@@ -50,6 +50,12 @@ public interface PArray {
     int getInt(final int i);
 
     /**
+     * Get the element at the index as a long.
+     * @param i the index of the element to access
+     */
+    long getLong(final int i);
+
+    /**
      * Get the element at the index as a float.
      * @param i the index of the element to access
      */

--- a/core/src/main/java/org/mapfish/print/wrapper/PJoinedArray.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/PJoinedArray.java
@@ -60,6 +60,11 @@ public final class PJoinedArray implements PArray {
     }
 
     @Override
+    public long getLong(final int i) {
+        return (Long) get(i);
+    }
+
+    @Override
     public float getFloat(final int i) {
         return (Float) get(i);
     }

--- a/core/src/main/java/org/mapfish/print/wrapper/PObject.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/PObject.java
@@ -73,7 +73,23 @@ public interface PObject {
      * @param defaultValue the default value
      */
     Integer optInt(final String key, final Integer defaultValue);
+    /**
+     * Get a property as a long or throw an exception.
+     * @param key the property name
+     */
+     long getLong(String key);
+    /**
+     * Get a property as a long or MIN_VALUE.
+     * @param key the property name
+     */
+    Long optLong(final String key);
 
+    /**
+     * Get a property as a long or default value.
+     * @param key the property name
+     * @param defaultValue the default value
+     */
+    long optLong(final String key, final long defaultValue);
     /**
      * Get a property as a double or throw an exception.
      * @param key the property name

--- a/core/src/main/java/org/mapfish/print/wrapper/json/PJsonArray.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/json/PJsonArray.java
@@ -110,6 +110,15 @@ public class PJsonArray extends PElement implements PArray {
         return val;
     }
 
+    @Override
+    public final long getLong(final int i) {
+        long val = this.array.optLong(i, Long.MIN_VALUE);
+        if (val == Long.MIN_VALUE) {
+            throw new ObjectMissingException(this, "[" + i + "]");
+        }
+        return val;
+    }
+
     /**
      * Get the element at the index as a float.
      * @param i the index of the element to access

--- a/core/src/main/java/org/mapfish/print/wrapper/json/PJsonObject.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/json/PJsonObject.java
@@ -81,6 +81,12 @@ public class PJsonObject extends PAbstractObject {
         return result == Integer.MIN_VALUE ? null : result;
     }
 
+    @Override
+    public final Long optLong(final String key) {
+        final long result = this.obj.optLong(key, Long.MIN_VALUE);
+        return result == Long.MIN_VALUE ? null : result;
+    }
+
     /**
      * Get a property as a double or null.
      * @param key the property name

--- a/core/src/main/java/org/mapfish/print/wrapper/multi/PMultiObject.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/multi/PMultiObject.java
@@ -102,6 +102,17 @@ public class PMultiObject extends PAbstractObject {
     }
 
     @Override
+    public final Long optLong(final String key) {
+        for (PObject obj : this.objs) {
+            Long result = obj.optLong(key);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @Override
     public final Double optDouble(final String key) {
         for (PObject obj : this.objs) {
             Double result = obj.optDouble(key);

--- a/core/src/main/java/org/mapfish/print/wrapper/yaml/PYamlArray.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/yaml/PYamlArray.java
@@ -86,6 +86,11 @@ public class PYamlArray extends PElement implements PArray {
     }
 
     @Override
+    public final long getLong(final int i) {
+        return (Long) this.array.get(i);
+    }
+
+    @Override
     public final float getFloat(final int i) {
         Number result = (Number) this.array.get(i);
         return result.floatValue();

--- a/core/src/main/java/org/mapfish/print/wrapper/yaml/PYamlArray.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/yaml/PYamlArray.java
@@ -87,7 +87,8 @@ public class PYamlArray extends PElement implements PArray {
 
     @Override
     public final long getLong(final int i) {
-        return (Long) this.array.get(i);
+        Number result = (Number) this.array.get(i);
+        return result.longValue();
     }
 
     @Override

--- a/core/src/main/java/org/mapfish/print/wrapper/yaml/PYamlObject.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/yaml/PYamlObject.java
@@ -90,6 +90,11 @@ public class PYamlObject extends PAbstractObject {
     }
 
     @Override
+    public final Long optLong(final String key) {
+        return (Long) this.obj.get(key);
+    }
+
+    @Override
     public final Double optDouble(final String key) {
         Number result = (Number) this.obj.get(key);
         return result == null ? null : result.doubleValue();

--- a/core/src/test/java/org/mapfish/print/map/tiled/wmts/WMTSLayerTest.java
+++ b/core/src/test/java/org/mapfish/print/map/tiled/wmts/WMTSLayerTest.java
@@ -21,7 +21,7 @@ public class WMTSLayerTest {
     public void testTileBoundsCalculation() throws Exception {
         WMTSLayerParam params = new WMTSLayerParam();
         Matrix matrix = new Matrix();
-        matrix.matrixSize = new double[]{67108864, 67108864};
+        matrix.matrixSize = new long[]{67108864, 67108864};
         matrix.tileSize = new int[]{256, 256};
         matrix.topLeftCorner = new double[]{420000, 350000};
         matrix.scaleDenominator = 7500;

--- a/core/src/test/java/org/mapfish/print/map/tiled/wmts/WMTSLayerTest.java
+++ b/core/src/test/java/org/mapfish/print/map/tiled/wmts/WMTSLayerTest.java
@@ -1,13 +1,55 @@
 package org.mapfish.print.map.tiled.wmts;
 
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.junit.Test;
+import org.mapfish.print.attribute.map.CenterScaleMapBounds;
+import org.mapfish.print.attribute.map.MapBounds;
+import org.mapfish.print.map.Scale;
+
+import java.awt.Rectangle;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Jesse on 5/11/2015.
  */
 public class WMTSLayerTest {
+    @Test
+    public void testTileBoundsCalculation() throws Exception {
+        WMTSLayerParam params = new WMTSLayerParam();
+        Matrix matrix = new Matrix();
+        matrix.matrixSize = new double[]{67108864, 67108864};
+        matrix.tileSize = new int[]{256, 256};
+        matrix.topLeftCorner = new double[]{420000, 350000};
+        matrix.scaleDenominator = 7500;
+        params.matrices = new Matrix[] {matrix};
+
+        WMTSLayer wmtsLayer = new WMTSLayer(null, null, params);
+
+        Rectangle paintArea = new Rectangle(0,0,256,256);
+        MapBounds bounds = new CenterScaleMapBounds(CRS.decode("EPSG:21781"), 595217.02, 236708.54, new Scale(7500));
+        WMTSLayer.WMTSTileCacheInfo tileInformation =
+                (WMTSLayer.WMTSTileCacheInfo) wmtsLayer.createTileInformation(bounds, paintArea, 256, false);
+
+        ReferencedEnvelope tileCacheBounds = tileInformation.getTileCacheBounds();
+
+        assertEquals(tileCacheBounds.getMinX(), 420000, 0.00001);
+        assertFalse ("" + tileCacheBounds.getMinX(), Double.isInfinite(tileCacheBounds.getMinX()));
+        assertFalse("" + tileCacheBounds.getMinX(), Double.isNaN(tileCacheBounds.getMinX()));
+        assertTrue("" + tileCacheBounds.getMinY(), tileCacheBounds.getMinY() < 350000);
+        assertFalse ("" + tileCacheBounds.getMinY(), Double.isInfinite(tileCacheBounds.getMinY()));
+        assertFalse("" + tileCacheBounds.getMinY(), Double.isNaN(tileCacheBounds.getMinY()));
+        assertTrue("" + tileCacheBounds.getMaxX(), tileCacheBounds.getMaxX() > 420000);
+        assertFalse ("" + tileCacheBounds.getMaxX(), Double.isInfinite(tileCacheBounds.getMaxX()));
+        assertFalse("" + tileCacheBounds.getMaxX(), Double.isNaN(tileCacheBounds.getMaxX()));
+        assertEquals(tileCacheBounds.getMaxY(), 350000, 0.00001);
+        assertFalse ("" + tileCacheBounds.getMaxY(), Double.isInfinite(tileCacheBounds.getMaxY()));
+        assertFalse("" + tileCacheBounds.getMaxY(), Double.isNaN(tileCacheBounds.getMaxY()));
+
+    }
 
     @Test
     public void testCreateRestURI() throws Exception {


### PR DESCRIPTION
The wmts bounds calculation could overflow and become negative.

The tilecache bounds calculation in wmts was performed as an integer which is too small to contain all possible, this calculation is now done as a double.
