### PR TITLE
Improve file clean-up task

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/job/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/ThreadPoolJobManager.java
@@ -276,7 +276,7 @@ public class ThreadPoolJobManager implements JobManager {
                 }
             });
             this.cleanUpTimer.scheduleAtFixedRate(
-                    this.workingDirectories.getCleanUpTask(), this.oldFileCleanupInterval,
+                    this.workingDirectories.getCleanUpTask(), 0,
                     this.oldFileCleanupInterval, TimeUnit.SECONDS);
         }
     }

--- a/core/src/main/resources/mapfish-spring-application-context.xml
+++ b/core/src/main/resources/mapfish-spring-application-context.xml
@@ -47,7 +47,8 @@
     </bean>
     <bean id="workingDirectories" class="org.mapfish.print.config.WorkingDirectories">
         <property name="working" value="${workingDir}" />
-        <property name="maxAge" value="${fileCleanUpMaxAge}" />
+        <property name="maxAgeReport" value="${fileCleanUpMaxAgeReport}" />
+        <property name="maxAgeTaskDir" value="${fileCleanUpMaxAgeTaskDir}" />
     </bean>
 
     <bean id="configurationFactory" class="org.mapfish.print.config.ConfigurationFactory"/>

--- a/core/src/main/resources/mapfish-spring.properties
+++ b/core/src/main/resources/mapfish-spring.properties
@@ -27,4 +27,11 @@ fileCleanUp=true
 fileCleanUpInterval=86400
 
 # the max. age for a report before it is deleted (in seconds). Default 86400 s (24 h).
-fileCleanUpMaxAge=86400
+fileCleanUpMaxAgeReport=86400
+
+# the max. age for a task directory before it is deleted (in seconds). Default 86400 s (24 h).
+# task directory are removed automatically after a task has finished. but for example when the
+# server is restarted while a task is being processed, the directory might not get deleted.
+# the clean-up process will remove these directories.
+fileCleanUpMaxAgeTaskDir=86400
+

--- a/core/src/test/java/org/mapfish/print/config/WorkingDirectoriesTest.java
+++ b/core/src/test/java/org/mapfish/print/config/WorkingDirectoriesTest.java
@@ -19,6 +19,7 @@ public class WorkingDirectoriesTest extends AbstractMapfishSpringTest {
 
     @Test
     public void testCleanUp() throws IOException {
+        File workingDir = this.workingDirectories.getWorking();
         File reportDir = this.workingDirectories.getReports();
 
         long oldDate = new Date().getTime() - TimeUnit.DAYS.toMillis(1);
@@ -32,15 +33,29 @@ public class WorkingDirectoriesTest extends AbstractMapfishSpringTest {
         // new file, should be kept
         new File(reportDir, "3").createNewFile();
 
+        // old task dir, should be deleted
+        File taskDir1 = new File(workingDir, "task-1tmp");
+        taskDir1.mkdirs();
+        new File(taskDir1, "123.tmp").createNewFile();
+        new File(workingDir, "task-1tmp").setLastModified(oldDate);
+        // new task dir, should be kept
+        File taskDir2 = new File(workingDir, "task-2tmp");
+        taskDir2.mkdirs();
+        new File(taskDir2, "123.tmp").createNewFile();
+
         assertTrue(new File(reportDir, "1").exists());
         assertTrue(new File(reportDir, "2").exists());
         assertTrue(new File(reportDir, "3").exists());
+        assertTrue(taskDir1.exists());
+        assertTrue(taskDir2.exists());
 
         int maxAgeInSeconds = 1000 ;
-        this.workingDirectories.new CleanUpTask(maxAgeInSeconds).run();
+        this.workingDirectories.new CleanUpTask(maxAgeInSeconds, maxAgeInSeconds).run();
 
         assertFalse(new File(reportDir, "1").exists());
         assertFalse(new File(reportDir, "2").exists());
         assertTrue(new File(reportDir, "3").exists());
+        assertFalse(taskDir1.exists());
+        assertTrue(taskDir2.exists());
     }
 }


### PR DESCRIPTION
 * Run the clean-up task on startup.
 * Also remove "abandoned" task directories. Task directory are usually removed automatically after a task has finished. But for example when the server is restarted while a task is being processed, the directory might not get deleted. The clean-up process will remove these directories.