### PR TITLE
Improve Attribute Value error message

### DIFF
--- a/core/src/main/java/org/mapfish/print/output/AttributeParsingException.java
+++ b/core/src/main/java/org/mapfish/print/output/AttributeParsingException.java
@@ -1,0 +1,20 @@
+package org.mapfish.print.output;
+
+/**
+ * An exception that is thrown if an unexpected error occurs while parsing attributes into the Values object.
+ *
+ * @author Jesse on 9/25/2015.
+ * @see Values#populateFromAttributes(org.mapfish.print.config.Template, org.mapfish.print.parser.MapfishParser, java.util.Map,
+ * org.mapfish.print.wrapper.PObject)
+ */
+public final class AttributeParsingException extends RuntimeException {
+
+    /**
+     * Constructor.
+     * @param errorMsg the message with debug info.
+     * @param cause the exception that was thrown.
+     */
+    public AttributeParsingException(final String errorMsg, final Throwable cause) {
+        super(errorMsg, cause);
+    }
+}

--- a/core/src/main/java/org/mapfish/print/output/Values.java
+++ b/core/src/main/java/org/mapfish/print/output/Values.java
@@ -37,6 +37,7 @@ import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.http.MfClientHttpRequestFactoryImpl;
 import org.mapfish.print.parser.MapfishParser;
 import org.mapfish.print.servlet.MapPrinterServlet;
+import org.mapfish.print.wrapper.ObjectMissingException;
 import org.mapfish.print.wrapper.PObject;
 import org.mapfish.print.wrapper.json.PJsonArray;
 import org.mapfish.print.wrapper.json.PJsonObject;
@@ -199,6 +200,10 @@ public final class Values {
                     throw new IllegalArgumentException("Unsupported attribute type: " + attribute);
                 }
                 put(attributeName, value);
+            } catch (ObjectMissingException e) {
+                throw e;
+            } catch (IllegalArgumentException e) {
+                throw e;
             } catch (Throwable e) {
                 String templateName = "unknown";
                 for (Map.Entry<String, Template> entry : template.getConfiguration().getTemplates().entrySet()) {
@@ -217,7 +222,7 @@ public final class Values {
                 String errorMsg = "An error occurred when creating a value from the '" + attributeName + "' attribute for the '" +
                                   templateName + "' template.\n\nThe JSON is: \n" + requestJsonAttributes + defaults;
 
-                throw new RuntimeException(errorMsg, e);
+                throw new AttributeParsingException(errorMsg, e);
             }
         }
     }

--- a/core/src/test/java/org/mapfish/print/output/ValuesTest.java
+++ b/core/src/test/java/org/mapfish/print/output/ValuesTest.java
@@ -139,4 +139,18 @@ public class ValuesTest extends AbstractMapfishSpringTest {
         Template template = config.getTemplates().values().iterator().next();
         new Values(requestData, template, this.parser, new File("tmp"), this.httpRequestFactory, new File("."));
     }
+
+
+    @Test(expected = AttributeParsingException.class)
+    public void testUnexpectedParseError() throws Exception {
+
+        PJsonObject requestData = parseJSONObjectFromFile(ValuesTest.class, BASE_DIR + "requestData.json");
+        requestData.getJSONObject("attributes").getJSONObject("legend").getInternalObj().remove("name");
+        final Configuration config = configurationFactory.getConfig(getFile(BASE_DIR + "config-bad-defaults.yaml"));
+
+        Template template = config.getTemplates().values().iterator().next();
+        new Values(requestData, template, this.parser, new File("tmp"), this.httpRequestFactory, new File("."));
+   }
+
+
 }

--- a/core/src/test/resources/org/mapfish/print/output/values/config-bad-defaults.yaml
+++ b/core/src/test/resources/org/mapfish/print/output/values/config-bad-defaults.yaml
@@ -1,0 +1,19 @@
+throwErrorOnExtraParameters: true
+templates:
+  main: !template
+    reportTemplate: simple-map.jrxml
+    attributes:
+      legend: !legend
+        default:
+          name: {}
+      title: !string {}
+      count: !integer {}
+      ratio: !float {}
+      datasource: !datasource
+        attributes:
+          table: !table {}
+          name: !string {}
+          count: !integer {}
+
+
+


### PR DESCRIPTION
Improve the error message when an error occurs during the creation of values from attributes.

Previously if an error occurred during the population of the Values object from the attributes, then the error message was sometimes very obscure.  For example if an array is passed where a string was expected then the error message would be a ClassCastException with no explanation of what attribute.  This change is intended to capture those errors and add information for debugging the problem