### PR TITLE
Header names should be case-insensitive

### DIFF
--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -60,6 +60,7 @@ import javax.annotation.Nullable;
  * @author Jesse on 9/3/2014.
  */
 public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequestFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MfClientHttpRequestFactoryImpl.class);
     private static final ThreadLocal<Configuration> CURRENT_CONFIGURATION = new InheritableThreadLocal<Configuration>();
 
     @Nullable
@@ -147,11 +148,13 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
         protected Response executeInternal(@Nonnull final HttpHeaders headers) throws IOException {
             CURRENT_CONFIGURATION.set(this.configuration);
 
+            LOGGER.debug("Preparing request " + this.getMethod() + " -- " + this.getURI());
             for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
                 String headerName = entry.getKey();
                 if (!headerName.equalsIgnoreCase(HTTP.CONTENT_LEN) &&
                     !headerName.equalsIgnoreCase(HTTP.TRANSFER_ENCODING)) {
                     for (String headerValue : entry.getValue()) {
+                        LOGGER.debug("Setting header: " + headerName + " : " + headerValue);
                         this.request.addHeader(headerName, headerValue);
                     }
                 }

--- a/core/src/main/java/org/mapfish/print/processor/http/ForwardHeadersProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/ForwardHeadersProcessor.java
@@ -21,14 +21,17 @@ package org.mapfish.print.processor.http;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.mapfish.print.attribute.HttpRequestHeadersAttribute;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.processor.AbstractProcessor;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.Nullable;
 
 /**
@@ -67,7 +70,12 @@ public final class ForwardHeadersProcessor
      * @param names the header names.
      */
     public void setHeaders(final Set<String> names) {
-        this.headerNames = names;
+        // transform to lower-case because header names should be case-insensitive
+        Set<String> lowerCaseNames = new HashSet<String>();
+        for (String name : names) {
+            lowerCaseNames.add(name.toLowerCase());
+        }
+        this.headerNames = lowerCaseNames;
     }
 
     /**
@@ -96,7 +104,8 @@ public final class ForwardHeadersProcessor
         Map<String, Object> headers = Maps.newHashMap();
 
         for (Map.Entry<String, List<String>> entry : param.requestHeaders.getHeaders().entrySet()) {
-            if (ForwardHeadersProcessor.this.forwardAll || ForwardHeadersProcessor.this.headerNames.contains(entry.getKey())) {
+            if (ForwardHeadersProcessor.this.forwardAll ||
+                    ForwardHeadersProcessor.this.headerNames.contains(entry.getKey().toLowerCase())) {
                 headers.put(entry.getKey(), entry.getValue());
             }
         }

--- a/core/src/test/resources/org/mapfish/print/processor/http/forward-headers/config.yaml
+++ b/core/src/test/resources/org/mapfish/print/processor/http/forward-headers/config.yaml
@@ -4,4 +4,4 @@ templates:
     processors:
       - !forwardHeadersTestProcessor {}
       - !forwardHeaders
-        headers: [header1, header2]
+        headers: [header1, Header2]


### PR DESCRIPTION
Forwarding headers *sometimes* did not work. As it turns out, Tomcat returns the header names in lower-case while for example Jetty keeps the original header name (which could be in upper-case). With this change the header names are now case-insensitive. That is, if the `forwardHeaders` processor is configured with `headers: [Host]`, the headers `Host`, `host`, `HoSt`, ... will be forwarded.

cc @arnaud-morvan