### PR TITLE
Don't forward host header

### DIFF
--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -152,7 +152,8 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
             for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
                 String headerName = entry.getKey();
                 if (!headerName.equalsIgnoreCase(HTTP.CONTENT_LEN) &&
-                    !headerName.equalsIgnoreCase(HTTP.TRANSFER_ENCODING)) {
+                    !headerName.equalsIgnoreCase(HTTP.TRANSFER_ENCODING) &&
+                    !headerName.equalsIgnoreCase(HTTP.TARGET_HOST)) {
                     for (String headerValue : entry.getValue()) {
                         LOGGER.debug("Setting header: " + headerName + " : " + headerValue);
                         this.request.addHeader(headerName, headerValue);


### PR DESCRIPTION
If the host header is forwarded, the host header in the request doesn't
contain the proper value. For instance, if we forward 'Host:
mapserver.local', the host header in the request will be 'Host:
localhost:8080' which is incorrect and may provok the request to fail
with 404.