### PR TITLE
removed protocol from script src in index.html 2 support https

### DIFF
--- a/core/src/main/webapp/index.html
+++ b/core/src/main/webapp/index.html
@@ -20,7 +20,7 @@
 <html>
 <head>
     <link rel="shortcut icon" href="favicon.ico" />
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
     <script type="text/javascript">
         function changeFormat() {
 

--- a/core/src/main/webapp/index.html
+++ b/core/src/main/webapp/index.html
@@ -20,7 +20,7 @@
 <html>
 <head>
     <link rel="shortcut icon" href="favicon.ico" />
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
     <script type="text/javascript">
         function changeFormat() {
 


### PR DESCRIPTION
mapfish-prints index.html does not work on recent browsers when called from https, because they do not allow to load unsecure content http://...jquery....
By removing the protocol part of the URL the browser uses the same Protocol as the main page and therefore uses https to download jquery from googleapis 8which is supported / available by Google.
 See http://www.paulirish.com/2010/the-protocol-relative-url/ for more information about protocol relative URLs.