### PR TITLE
Add matches to HTTP processors.

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/http/AbstractClientHttpRequestFactoryProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/AbstractClientHttpRequestFactoryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Camptocamp
+ * Copyright (C) 2014-2015  Camptocamp
  *
  * This file is part of MapFish Print
  *
@@ -19,8 +19,12 @@
 
 package org.mapfish.print.processor.http;
 
+import org.mapfish.print.config.Configuration;
 import org.mapfish.print.processor.AbstractProcessor;
+import org.mapfish.print.processor.http.matcher.URIMatcher;
+import org.mapfish.print.processor.http.matcher.UriMatchers;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -31,11 +35,56 @@ public abstract class AbstractClientHttpRequestFactoryProcessor
         implements HttpProcessor<ClientHttpFactoryProcessorParam> {
 
     /**
+     * The matchers that choose if the processor is applied or not.
+     */
+    protected final UriMatchers matchers = new UriMatchers();
+
+    /**
      * Constructor.
      */
     protected AbstractClientHttpRequestFactoryProcessor() {
         super(ClientHttpFactoryProcessorParam.class);
     }
+
+    /**
+     * The matchers used to select the urls that are going to be modified by the processor.
+     * For example:
+     * <pre><code>
+     * - !restrictUris
+     *   matchers:
+     *     - !localMatch
+     *       dummy: true
+     *     - !ipMatch
+     *     ip: www.camptocamp.org
+     *     - !dnsMatch
+     *       host: mapfish-geoportal.demo-camptocamp.com
+     *       port: 80
+     *     - !dnsMatch
+     *       host: labs.metacarta.com
+     *       port: 80
+     *     - !dnsMatch
+     *       host: terraservice.net
+     *       port: 80
+     *     - !dnsMatch
+     *       host: tile.openstreetmap.org
+     *       port: 80
+     *     - !dnsMatch
+     *       host: www.geocat.ch
+     *       port: 80
+     * </code></pre>
+     *
+     * @param matchers the list of matcher to use to check if a url is permitted
+     */
+    public final void setMatchers(final List<? extends URIMatcher> matchers) {
+        this.matchers.setMatchers(matchers);
+    }
+
+    //CSOFF: DesignForExtension
+    @Override
+    protected void extraValidation(final List<Throwable> validationErrors, final Configuration configuration) {
+        this.matchers.validate(validationErrors);
+    }
+    //CSON: DesignForExtension
 
     @Nullable
     @Override

--- a/core/src/main/java/org/mapfish/print/processor/http/AddHeadersProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/AddHeadersProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Camptocamp
+ * Copyright (C) 2014-2015  Camptocamp
  *
  * This file is part of MapFish Print
  *
@@ -42,6 +42,9 @@ import java.util.Map;
  *     Cookie : [cookie-value, cookie-value2]
  *     Header2 : header2-value
  * </code></pre>
+ *
+ * Can be applied conditionally using matchers, like in {@link RestrictUrisProcessor} (!restrictUris).
+ *
  * @author Jesse on 6/26/2014.
  */
 public final class AddHeadersProcessor extends AbstractClientHttpRequestFactoryProcessor {
@@ -73,6 +76,7 @@ public final class AddHeadersProcessor extends AbstractClientHttpRequestFactoryP
 
     @Override
     protected void extraValidation(final List<Throwable> validationErrors, final Configuration configuration) {
+        super.extraValidation(validationErrors, configuration);
         if (this.headers.isEmpty()) {
             validationErrors.add(new IllegalStateException("There are no headers defined."));
         }
@@ -81,7 +85,7 @@ public final class AddHeadersProcessor extends AbstractClientHttpRequestFactoryP
     @Override
     public MfClientHttpRequestFactory createFactoryWrapper(final ClientHttpFactoryProcessorParam clientHttpFactoryProcessorParam,
                                                          final MfClientHttpRequestFactory requestFactory) {
-        return new AbstractMfClientHttpRequestFactoryWrapper(requestFactory) {
+        return new AbstractMfClientHttpRequestFactoryWrapper(requestFactory, matchers, false) {
             @Override
             protected ClientHttpRequest createRequest(final URI uri,
                                                       final HttpMethod httpMethod,

--- a/core/src/main/java/org/mapfish/print/processor/http/MapUriProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/MapUriProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Camptocamp
+ * Copyright (C) 2014-2015  Camptocamp
  *
  * This file is part of MapFish Print
  *
@@ -44,6 +44,9 @@ import java.util.regex.Pattern;
  * - !mapUri
  *   mapping: {(http)://myhost.com(.*) : "$1://localhost$2"}
  * </code></pre>
+ *
+ * Can be applied conditionally using matchers, like in {@link RestrictUrisProcessor} (!restrictUris).
+ *
  * @author Jesse on 6/25/2014.
  */
 public final class MapUriProcessor extends AbstractClientHttpRequestFactoryProcessor {
@@ -59,7 +62,7 @@ public final class MapUriProcessor extends AbstractClientHttpRequestFactoryProce
     public void setMapping(final Map<String, String> mapping) {
         this.uriMapping.clear();
         for (Map.Entry<String, String> entry: mapping.entrySet()) {
-           Pattern pattern = Pattern.compile(entry.getKey());
+            Pattern pattern = Pattern.compile(entry.getKey());
             this.uriMapping.put(pattern, entry.getValue());
         }
     }
@@ -67,7 +70,7 @@ public final class MapUriProcessor extends AbstractClientHttpRequestFactoryProce
     @Override
     public MfClientHttpRequestFactory createFactoryWrapper(final ClientHttpFactoryProcessorParam clientHttpFactoryProcessorParam,
                                                          final MfClientHttpRequestFactory requestFactory) {
-        return new AbstractMfClientHttpRequestFactoryWrapper(requestFactory) {
+        return new AbstractMfClientHttpRequestFactoryWrapper(requestFactory, matchers, false) {
             @Override
             protected ClientHttpRequest createRequest(final URI uri,
                                                       final HttpMethod httpMethod,
@@ -91,6 +94,7 @@ public final class MapUriProcessor extends AbstractClientHttpRequestFactoryProce
 
     @Override
     protected void extraValidation(final List<Throwable> validationErrors, final Configuration configuration) {
+        super.extraValidation(validationErrors, configuration);
         if (this.uriMapping.isEmpty()) {
             validationErrors.add(new IllegalArgumentException("No uri mappings were defined"));
         }

--- a/core/src/main/java/org/mapfish/print/processor/http/UseHttpForHttpsProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/UseHttpForHttpsProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Camptocamp
+ * Copyright (C) 2014-2015  Camptocamp
  *
  * This file is part of MapFish Print
  *
@@ -49,6 +49,8 @@ import java.util.regex.Pattern;
  *     8443 : 8443
  * </code></pre>
  *
+ * Can be applied conditionally using matchers, like in {@link RestrictUrisProcessor} (!restrictUris).
+ *
  * @author Jesse on 6/25/2014.
  */
 public final class UseHttpForHttpsProcessor extends AbstractClientHttpRequestFactoryProcessor {
@@ -71,6 +73,7 @@ public final class UseHttpForHttpsProcessor extends AbstractClientHttpRequestFac
 
     @Override
     protected void extraValidation(final List<Throwable> validationErrors, final Configuration configuration) {
+        super.extraValidation(validationErrors, configuration);
         if (this.hosts.isEmpty()) {
             validationErrors.add(new IllegalArgumentException("No hosts are registered"));
         }
@@ -79,7 +82,7 @@ public final class UseHttpForHttpsProcessor extends AbstractClientHttpRequestFac
     @Override
     public MfClientHttpRequestFactory createFactoryWrapper(final ClientHttpFactoryProcessorParam clientHttpFactoryProcessorParam,
                                                          final MfClientHttpRequestFactory requestFactory) {
-        return new AbstractMfClientHttpRequestFactoryWrapper(requestFactory) {
+        return new AbstractMfClientHttpRequestFactoryWrapper(requestFactory, matchers, false) {
             @Override
             protected ClientHttpRequest createRequest(final URI uri,
                                                       final HttpMethod httpMethod,

--- a/core/src/main/java/org/mapfish/print/processor/http/matcher/MatchInfo.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/matcher/MatchInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Camptocamp
+ * Copyright (C) 2014-2015  Camptocamp
  *
  * This file is part of MapFish Print
  *
@@ -117,6 +117,9 @@ public final class MatchInfo {
             try {
                 newPort = uri.toURL().getDefaultPort();
             } catch (MalformedURLException e) {
+                newPort = ANY_PORT;
+            } catch (IllegalArgumentException e) {
+                //the URL is relative
                 newPort = ANY_PORT;
             }
         }

--- a/core/src/main/java/org/mapfish/print/processor/http/matcher/UriMatchers.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/matcher/UriMatchers.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015  Camptocamp
+ *
+ * This file is part of MapFish Print
+ *
+ * MapFish Print is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MapFish Print is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MapFish Print.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mapfish.print.processor.http.matcher;
+
+import org.springframework.http.HttpMethod;
+
+import java.net.MalformedURLException;
+import java.net.SocketException;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Hold a list of {@link URIMatcher} and implement the logic to see if any matches an URI.
+ */
+public final class UriMatchers {
+    private List<? extends URIMatcher> matchers = Collections.singletonList(new AcceptAllMatcher());
+
+    /**
+     * Set the matchers.
+     * @param matchers the new list.
+     */
+    public void setMatchers(final List<? extends URIMatcher> matchers) {
+        this.matchers = matchers;
+    }
+
+    /**
+     * @param uri the URI to create a request for
+     * @param httpMethod the HTTP method to execute
+     * @return true if it's matching.
+     */
+    public boolean matches(final URI uri, final HttpMethod httpMethod)
+            throws SocketException, UnknownHostException, MalformedURLException {
+        for (URIMatcher matcher : this.matchers) {
+            if (matcher.matches(MatchInfo.fromUri(uri, httpMethod))) {
+                return !matcher.isReject();
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Validate the configuration.
+     * @param validationErrors where to put the errors.
+     */
+    public void validate(final List<Throwable> validationErrors) {
+        if (this.matchers == null) {
+            validationErrors.add(new IllegalArgumentException(
+                    "Matchers cannot be null.  There should be at least a !acceptAll matcher"));
+        }
+        if (this.matchers != null && this.matchers.isEmpty()) {
+            validationErrors.add(new IllegalArgumentException(
+                    "There are no url matchers defined.  There should be at least a " +
+                    "!acceptAll matcher"));
+        }
+    }
+}

--- a/core/src/test/java/org/mapfish/print/processor/http/AddHeadersProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/http/AddHeadersProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Camptocamp
+ * Copyright (C) 2014-2015  Camptocamp
  *
  * This file is part of MapFish Print
  *
@@ -53,21 +53,29 @@ public class AddHeadersProcessorTest extends AbstractHttpProcessorTest {
         @Nullable
         @Override
         public Void execute(TestParam values, ExecutionContext context) throws Exception {
+            matching(values);
+            notMatching(values);
+            return null;
+        }
+
+        private void matching(TestParam values) throws Exception {
             final URI uri = new URI("http://localhost:8080/path?query#fragment");
             final ClientHttpRequest request = values.clientHttpRequestFactory.createRequest(uri, HttpMethod.GET);
             final URI finalUri = request.getURI();
-
-            assertEquals("http", finalUri.getScheme());
-            assertEquals("localhost", finalUri.getHost());
-            assertEquals("/path", finalUri.getPath());
-            assertEquals(8080, finalUri.getPort());
-            assertEquals("query", finalUri.getQuery());
-            assertEquals("fragment", finalUri.getFragment());
+            assertEquals(uri, finalUri);
 
             assertEquals(2, request.getHeaders().size());
             assertArrayEquals(new Object[]{"cookie-value", "cookie-value2"}, request.getHeaders().get("Cookie").toArray());
             assertArrayEquals(new Object[]{"header2-value"}, request.getHeaders().get("Header2").toArray());
-            return null;
+        }
+
+        private void notMatching(TestParam values) throws Exception {
+            final URI uri = new URI("http://195.176.255.226:8080/path?query#fragment");
+            final ClientHttpRequest request = values.clientHttpRequestFactory.createRequest(uri, HttpMethod.GET);
+            final URI finalUri = request.getURI();
+            assertEquals(uri, finalUri);
+
+            assertEquals(0, request.getHeaders().size());
         }
     }
 }

--- a/core/src/test/resources/org/mapfish/print/processor/http/add-headers/config.yaml
+++ b/core/src/test/resources/org/mapfish/print/processor/http/add-headers/config.yaml
@@ -4,6 +4,8 @@ templates:
     processors:
       - !addHeadersTestProcessor {}
       - !addHeaders
+        matchers:
+        - !localMatch {}
         headers:
           Cookie : [cookie-value, cookie-value2]
           Header2 : [header2-value]


### PR DESCRIPTION
Now, every HTTP processors can have a "matches" section to enable it.
The default is !acceptAll to make it backward compatible.

This closes #347.