### PR TITLE
Fix logging to use only one lib: slf4j

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -66,11 +66,16 @@ configurations {
     }
     jasper {
         description = 'Dependencies for the jasper reports generation'
-}
+    }
+
+    //want to use the slf4j bridge instead
+    all*.exclude group: 'commons-logging'
 }
 
 dependencies {
     def springSecurityVersion = "3.2.5.RELEASE"
+    def slf4jVersion = '1.7.6'
+
     compile (
             "org.springframework:spring-context:$project.springVersion",
             "org.springframework:spring-web:$project.springVersion",
@@ -107,7 +112,8 @@ dependencies {
     compile fileTree(dir: "$projectDir/libs", include: '*.jar')
     compile (
             "com.google.guava:guava:16.0.1",
-            'org.slf4j:slf4j-api:1.7.6',
+            "org.slf4j:slf4j-api:${slf4jVersion}",
+            "org.slf4j:jcl-over-slf4j:${slf4jVersion}",
             'org.json:json:20080701',
             'ch.qos.logback:logback-classic:1.1.1',
             'org.yaml:snakeyaml:1.13',

--- a/core/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/core/src/main/webapp/WEB-INF/classes/logback.xml
@@ -21,9 +21,9 @@
 <configuration>
 
     <appender name="standardOut" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <appender name="File" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -36,13 +36,14 @@
             <maxHistory>30</maxHistory>
         </rollingPolicy>
 
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <logger name="org.mapfish" level="INFO" />
-    <logger name="org.springframework" level="OFF" />
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.apache" level="WARN" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.spec" level="OFF" />
     <!-- Set ValuesLogger to INFO to show all template parameters -->

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -21,16 +21,17 @@
 <configuration>
 
     <appender name="standardOut" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <logger name="org.mapfish" level="ALL" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.BaseMapServlet.spec" level="OFF" />
     <logger name="com.codahale.metrics.JmxReporter" level="INFO" />
-
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.apache" level="WARN" />
 
     <root level="ALL">
         <appender-ref ref="standardOut" />


### PR DESCRIPTION
Spring was using commons-logging instead of slf4j. That was making the
filtering, formatting and backend configuration for spring messages
not applied at all.

I took the upportunity to fix the default logging configuration to not use
deprecated XML elements.