### PR TITLE
CLI freeze when exiting.

### DIFF
--- a/core/src/main/java/org/mapfish/print/cli/Main.java
+++ b/core/src/main/java/org/mapfish/print/cli/Main.java
@@ -120,6 +120,7 @@ public final class Main {
         } finally {
             context.destroy();
         }
+        System.exit(0);
     }
 
     private static void printUsage(final int exitCode) {

--- a/docs/src/main/groovy/GenerateDocs.groovy
+++ b/docs/src/main/groovy/GenerateDocs.groovy
@@ -115,6 +115,7 @@ class GenerateDocs {
                 strings.append("\n}")
             }
         }
+        System.exit(0)
     }
     static void write (Collection<Record> records, PrintWriter printWriter, PrintWriter strings, String varName) {
         printWriter.append("docs.")


### PR DESCRIPTION
For some reason, the CLI was freezing when exiting (some AWT and Batik threads
leftover). I've added a System.exit(0) at the end to force the stopping.

I had the same problem when build docs. Same solution.