### PR TITLE
Make sure all tests are run again

### DIFF
--- a/core/src/main/java/org/mapfish/print/cli/Main.java
+++ b/core/src/main/java/org/mapfish/print/cli/Main.java
@@ -23,9 +23,11 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.util.StatusPrinter;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CharStreams;
 import com.sampullara.cli.Args;
+
 import org.json.JSONWriter;
 import org.mapfish.print.Constants;
 import org.mapfish.print.MapPrinter;
@@ -82,6 +84,18 @@ public final class Main {
      * @throws Exception
      */
     public static void main(final String[] args) throws Exception {
+        runMain(args);
+        System.exit(0);
+    }
+
+    /**
+     * Runs the print.
+     *
+     * @param args the cli arguments
+     * @throws Exception
+     */
+    @VisibleForTesting
+    public static void runMain(final String[] args) throws Exception {
         final CliHelpDefinition helpCli = new CliHelpDefinition();
 
         try {
@@ -120,7 +134,6 @@ public final class Main {
         } finally {
             context.destroy();
         }
-        System.exit(0);
     }
 
     private static void printUsage(final int exitCode) {

--- a/core/src/test/java/org/mapfish/print/cli/MainTest.java
+++ b/core/src/test/java/org/mapfish/print/cli/MainTest.java
@@ -53,7 +53,7 @@ public class MainTest {
                 "-config", this.configFile.getAbsolutePath(),
                 "-spec", this.v3ApiRequestFile.getAbsolutePath(),
                 "-output", this.outputFile.getAbsolutePath()};
-        Main.main(args);
+        Main.runMain(args);
 
         new ImageSimilarity(getFile("expectedV3Image.png"), 1).assertSimilarity(this.outputFile, 70);
     }
@@ -65,7 +65,7 @@ public class MainTest {
                 "-config", this.configFile.getAbsolutePath(),
                 "-spec", this.v2ApiRequestFile.getAbsolutePath(),
                 "-output", this.outputFile.getAbsolutePath()};
-        Main.main(args);
+        Main.runMain(args);
 
         new ImageSimilarity(getFile("expectedV2Image.png"), 1).assertSimilarity(this.outputFile, 70);
     }
@@ -76,7 +76,7 @@ public class MainTest {
                 "-config", this.configFile.getAbsolutePath(),
                 "-spec", this.v2ApiRequestFile.getAbsolutePath(),
                 "-output", this.outputFile.getAbsolutePath()};
-        Main.main(args);
+        Main.runMain(args);
     }
 
     @Test(expected = Exception.class)
@@ -86,6 +86,6 @@ public class MainTest {
                 "-config", this.configFile.getAbsolutePath(),
                 "-spec", this.v3ApiRequestFile.getAbsolutePath(),
                 "-output", this.outputFile.getAbsolutePath()};
-        Main.main(args);
+        Main.runMain(args);
     }
 }


### PR DESCRIPTION
#366 used `System.exit(0)` to stop the program execution when using the CLI client. But this change also made that only 1/3 of our tests were run.