### PR TITLE
Better logs in case of errors with WMTS and WFS.

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/GmlLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/GmlLayer.java
@@ -154,7 +154,7 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
             gmlV3Parser.setRootElementType(new QName("http://www.opengis.net/wfs", "FeatureCollection"));
             try {
                 final Object featureCollection = gmlV3Parser.parse(new StringReader(gmlData));
-                if (featureCollection != null) {
+                if (featureCollection != null && featureCollection instanceof SimpleFeatureCollection) {
                     return (SimpleFeatureCollection) featureCollection;
                 }
             } catch (SAXException e) {
@@ -171,7 +171,7 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
             gmlV2Parser.setRootElementType(new QName("http://www.opengis.net/wfs", "FeatureCollection"));
             try {
                 final Object featureCollection = gmlV2Parser.parse(new StringReader(gmlData));
-                if (featureCollection != null) {
+                if (featureCollection != null && featureCollection instanceof SimpleFeatureCollection) {
                     return (SimpleFeatureCollection) featureCollection;
                 }
             } catch (SAXException e) {
@@ -188,7 +188,7 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
             gmlV32Parser.setRootElementType(new QName("http://www.opengis.net/wfs/2.0", "FeatureCollection"));
             try {
                 final Object featureCollection = gmlV32Parser.parse(new StringReader(gmlData));
-                if (featureCollection != null) {
+                if (featureCollection != null && featureCollection instanceof SimpleFeatureCollection) {
                     return (SimpleFeatureCollection) featureCollection;
                 } else {
                     throw new RuntimeException("unable to parse gml: \n\n" + gmlData);

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayerParam.java
@@ -27,6 +27,8 @@ import org.mapfish.print.URIUtils;
 import org.mapfish.print.map.tiled.AbstractWMXLayerParams;
 import org.mapfish.print.parser.HasDefaultValue;
 import org.mapfish.print.wrapper.PObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -36,6 +38,8 @@ import java.net.URISyntaxException;
  * The parameters for configuration a WMTS layer.
  */
 public final class WMTSLayerParam extends AbstractWMXLayerParams {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WMTSLayerParam.class);
+
     /**
      * The ‘ResourceURL’ available in the WMTS capabilities.
      * <p></p>
@@ -165,11 +169,13 @@ public final class WMTSLayerParam extends AbstractWMXLayerParams {
 
         if (RequestEncoding.REST == this.requestEncoding) {
             if (!containsVariables(url)) {
+                LOGGER.warn("URL {} is missing some variables", url);
                 return false;
             }
             try {
                 return WMTSLayer.createRestURI(url, "matrix", 0, 0, this) != null;
             } catch (URISyntaxException exc) {
+                LOGGER.warn("URL {} is invalid: {}", url, exc.getMessage());
                 return false;
             }
         } else {


### PR DESCRIPTION
GeoTools doesn't throw an exception or return NULL in case of error
parsing a WFS FeatureCollection. It returns a Map.

When a WMTS URL was invalid, there was no way to know why. Add logs
to help that.