### PR TITLE
Add a cache for XSDs when parsing GML.

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/CachingUrihandler.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/CachingUrihandler.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016  Camptocamp
+ *
+ * This file is part of MapFish Print
+ *
+ * MapFish Print is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MapFish Print is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MapFish Print.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mapfish.print.map.geotools;
+
+import org.eclipse.emf.common.util.URI;
+import org.geotools.xml.impl.HTTPURIHandler;
+import org.geotools.xml.resolver.SchemaCache;
+import org.geotools.xml.resolver.SchemaResolver;
+import org.mapfish.print.config.WorkingDirectories;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+
+/**
+ * An {@link org.eclipse.emf.ecore.resource.URIHandler} for caching XSDs or using local copies.
+ */
+class CachingUrihandler extends HTTPURIHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GmlLayer.class);
+
+    @Autowired
+    private WorkingDirectories workingDirectories;
+
+    private SchemaResolver resolver;
+
+    @PostConstruct
+    public final void init() {
+        this.resolver = new SchemaResolver(new SchemaCache(getCacheLocation(), true, true));
+    }
+
+    private File getCacheLocation() {
+        return new File(this.workingDirectories.getWorking(), "xsdCache");
+    }
+
+    @Override
+    public boolean canHandle(final URI uri) {
+        return super.canHandle(uri) && uri.path().endsWith(".xsd");
+    }
+
+    @Override
+    public InputStream createInputStream(final URI uri, final Map<?, ?> options) throws IOException {
+        final String resolved = this.resolver.resolve(uri.toString());
+        LOGGER.debug("Resolved {} to {}", uri, resolved);
+        final URI resolvedUri = URI.createURI(resolved);
+        if (super.canHandle(resolvedUri)) {
+            return super.createInputStream(resolvedUri, options);
+        } else {
+            return new FileInputStream(resolved);
+        }
+    }
+}

--- a/core/src/main/resources/mapfish-spring-layer-parser.xml
+++ b/core/src/main/resources/mapfish-spring-layer-parser.xml
@@ -29,4 +29,6 @@
     <bean id="osmLayerParser" class="org.mapfish.print.map.tiled.osm.OsmLayerParserPlugin" />
     <bean id="gridLayerParser" class="org.mapfish.print.map.geotools.grid.GridLayerPlugin" />
     <bean id="featureLayerParser" class="org.mapfish.print.map.geotools.FeatureLayer$Plugin" />
+
+    <bean id="cachingUrihandler" class="org.mapfish.print.map.geotools.CachingUrihandler" />
 </beans>

--- a/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/OGC-exception.xsd
+++ b/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/OGC-exception.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+   targetNamespace="http://www.opengis.net/ogc"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.0.0.3">
+   
+   <!--
+      WFS is an OGC Standard.
+      Copyright (c) 2002,2010 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+   -->
+
+   <xsd:element name="ServiceExceptionReport">
+      <xsd:annotation>
+         <xsd:documentation>
+            The ServiceExceptionReport element contains one
+            or more ServiceException elements that describe
+            a service exception.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:sequence>
+            <xsd:element name="ServiceException"
+                         type="ogc:ServiceExceptionType"
+                         minOccurs="0" maxOccurs="unbounded">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The Service exception element is used to describe 
+                     a service exception.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+         </xsd:sequence>
+         <xsd:attribute name="version" type="xsd:string" fixed="1.2.0"/>
+      </xsd:complexType>
+   </xsd:element>
+
+   <xsd:complexType name="ServiceExceptionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The ServiceExceptionType type defines the ServiceException
+            element.  The content of the element is an exception message
+            that the service wished to convey to the client application.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="code" type="xsd:string">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     A service may associate a code with an exception
+                     by using the code attribute.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="locator" type="xsd:string">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The locator attribute may be used by a service to
+                     indicate to a client where in the client's request
+                     an exception was encountered.  If the request included
+                     a 'handle' attribute, this may be used to identify the
+                     offending component of the request.  Otherwise the 
+                     service may try to use other means to locate the 
+                     exception such as line numbers or byte offset from the
+                     begining of the request, etc ...
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>

--- a/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/WFS-basic.xsd
+++ b/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/WFS-basic.xsd
@@ -1,0 +1,320 @@
+<?xml version="1.0"?>
+<xsd:schema 
+   targetNamespace="http://www.opengis.net/wfs"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.0.0.3">
+   
+   <!--
+      WFS is an OGC Standard.
+      Copyright (c) 2002,2010 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+   -->
+   
+   <!-- ==============================================================
+        Includes and Imports
+        ============================================================== -->
+   <xsd:include schemaLocation="./wfs.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/ogc" schemaLocation="http://schemas.opengis.net/filter/1.0.0/filter.xsd"/>
+
+   <!-- ==============================================================
+        REQUEST MESSAGES 
+        ============================================================== -->
+   <xsd:element name="GetCapabilities" type="wfs:GetCapabilitiesType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The GetCapapbilities element is used to request that a Web Feature
+            Service generate an XML document describing the organization
+            providing the service, the WFS operations that the service
+            supports, a list of feature types that the service can operate
+            on and list of filtering capabilities that the service support.
+            Such an XML document is called a capabilities document.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="DescribeFeatureType" type="wfs:DescribeFeatureTypeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The DescribeFeatureType element is used to request that a Web
+            Feature Service generate a document describing one or more 
+            feature types.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="GetFeature" type="wfs:GetFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The GetFeature element is used to request that a Web Feature
+            Service return feature instances of one or more feature types.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+
+   <!-- ==============================================================
+        RESPONSE MESSAGES 
+        ============================================================== -->
+   <xsd:element name="FeatureCollection"
+                type="wfs:FeatureCollectionType"
+                substitutionGroup="gml:_FeatureCollection">
+      <xsd:annotation>
+         <xsd:documentation>
+            This element is a container for the response to a GetFeature
+            or GetFeatureWithLock (WFS-transaction.xsd) request.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+
+   <!-- ==============================================================
+        COMMON ATTRIBUTES DOCUMENTATION
+        ==============================================================
+        VERSION:
+           The version attribute is used to indicate to which version
+           of the Web Feature Service Implementation Specification a
+           request conforms.
+
+        SERVICE:
+           The service attribute is used to indicate which service
+           should process an operation.  This attribute is particularly
+           useful in the case where a single server implements multiple
+           services (e.g. WMS, WFS, WCS, etc ...).
+
+        HANDLE:
+           The purpose of the handle attribute is to allow a client app
+           to associate a mnemonic name with a request for error handling
+           purposes.  If a "handle" is specified, and an exception occurs,
+           a Web Feature Service may use the handle to identify the
+           offending element.
+
+        TYPENAME:
+           The typeName attribute is used to specify the name of the
+           feature type to be queried.  The term "feature type" is a
+           term used by convention to refer to the container storing 
+           feature instances.  It does not mean type in the programmatic 
+           sense.  The typeName attribute should, instead, be thought
+           of as the feature name. -->
+
+   <!-- ==============================================================
+        TYPES
+        ============================================================== -->
+   <!-- GETCAPABILITIES -->
+   <xsd:complexType name="GetCapabilitiesType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This type defines the GetCapabilities operation.  In response
+            to a GetCapabilities request, a Web Feature Service must 
+            generate a capabilities XML document that validates against
+            the schemas defined in WFS-capabilities.xsd.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="optional" fixed="1.0.0"/>
+      <xsd:attribute name="service"
+                     type="xsd:string" use="required" fixed="WFS"/>
+   </xsd:complexType>
+   <!-- DESCRIBEFEATURETYPE -->
+   <xsd:complexType name="DescribeFeatureTypeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The DescribeFeatureType operation allows a client application
+            to request that a Web Feature Service describe one or more
+            feature types.   A Web Feature Service must be able to generate
+            feature descriptions as valid GML2 application schemas.
+
+            The schemas generated by the DescribeFeatureType operation can
+            be used by a client application to validate the output.
+
+            Feature instances within the WFS interface must be specified
+            using GML2.  The schema of feature instances specified within
+            the WFS interface must validate against the feature schemas 
+            generated by the DescribeFeatureType request.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="TypeName" type="xsd:QName"
+                      minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The TypeName element is used to enumerate the feature types
+                  to be described.  If no TypeName elements are specified
+                  then all features should be described.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="required" fixed="1.0.0"/>
+      <xsd:attribute name="service"
+                     type="xsd:string" use="required" fixed="WFS"/>
+      <xsd:attribute name="outputFormat"
+                     type="xsd:string" use="optional" default="XMLSCHEMA">
+         <xsd:annotation>
+            <xsd:documentation>
+               The outputFormat attribute is used to specify what schema
+               description language should be used to describe features.
+               The default value of XMLSCHEMA means that the Web Feature
+               Service must generate a GML2 application schema that can
+               be used to validate the GML2 output of a GetFeature request
+               or feature instances specified in Transaction operations.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <!-- GETFEATURE -->
+   <xsd:complexType name="GetFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            A GetFeature element contains one or more Query elements
+            that describe a query operation on one feature type.  In
+            response to a GetFeature request, a Web Feature Service
+            must be able to generate a GML2 response that validates
+            using a schema generated by the DescribeFeatureType request.
+            A Web Feature Service may support other possibly non-XML
+            (and even binary) output formats as long as those formats
+            are advertised in the capabilities document.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="wfs:Query" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="required" fixed="1.0.0"/>
+      <xsd:attribute name="service"
+                     type="xsd:string" use="required" fixed="WFS"/>
+      <xsd:attribute name="handle"
+                     type="xsd:string" use="optional"/>
+      <xsd:attribute name="outputFormat"
+                     type="xsd:string" use="optional" default="GML2">
+         <xsd:annotation>
+            <xsd:documentation>
+               The outputFormat attribute is used to specify the output
+               format that the Web Feature Service should generate in
+               response to a GetFeature or GetFeatureWithLock element.
+               The default value of GML2 indicates that the output is an
+               XML document that conforms to the Geography Markup Language
+               (GML) Implementation Specification V2.0.
+
+               Other values may be used to specify other formats as long
+               as those values are advertised in the capabilities document.
+               For example, the value WKB may be used to indicate that a 
+               Well Known Binary format be used to encode the output.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="maxFeatures" type="xsd:positiveInteger"
+                     use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The maxFeatures attribute is used to specify the maximum
+               number of features that a GetFeature operation should
+               generate (regardless of the actual number of query hits).
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:element name="Query" type="wfs:QueryType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Query element is used to describe a single query.
+            One or more Query elements can be specified inside a
+            GetFeature element so that multiple queries can be 
+            executed in one request.  The output from the various
+            queries are combined in a wfs:FeatureCollection element
+            to form the response to the request.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="QueryType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Query element is of type QueryType.
+         </xsd:documentation>
+      </xsd:annotation>
+     <xsd:sequence>
+       <xsd:element ref="ogc:PropertyName" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+             <xsd:documentation>
+                The PropertyName element is used to specify one or more
+                properties of a feature whose values are to be retrieved
+                by a Web Feature Service.  
+                
+                While a Web Feature Service should endeavour to satisfy
+                the exact request specified, in some instance this may
+                not be possible.  Specifically, a Web Feature Service
+                must generate a valid GML2 response to a Query operation.
+                The schema used to generate the output may include 
+                properties that are mandatory.  In order that the output
+                validates, these mandatory properties must be specified
+                in the request.  If they are not, a Web Feature Service
+                may add them automatically to the Query before processing
+                it.  Thus a client application should, in general, be
+                prepared to receive more properties than it requested.
+
+                Of course, using the DescribeFeatureType request, a client
+                application can determine which properties are mandatory
+                and request them in the first place.
+             </xsd:documentation>
+          </xsd:annotation>
+       </xsd:element>
+       <xsd:element ref="ogc:Filter" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+             <xsd:documentation>
+                The Filter element is used to define spatial and/or non-spatial
+                constraints on query.  Spatial constrains use GML2 to specify
+                the constraining geometry.  A full description of the Filter
+                element can be found in the Filter Encoding Implementation
+                Specification.
+             </xsd:documentation>
+          </xsd:annotation>
+       </xsd:element>
+     </xsd:sequence>
+     <xsd:attribute name="handle"
+                    type="xsd:string" use="optional"/>
+     <xsd:attribute name="typeName"
+                    type="xsd:QName" use="required"/>
+     <xsd:attribute name="featureVersion"
+                    type="xsd:string" use="optional">
+        <xsd:annotation>
+           <xsd:documentation>
+              For systems that implement versioning, the featureVersion
+              attribute is used to specify which version of a particular
+              feature instance is to be retrieved.  A value of ALL means
+              that all versions should be retrieved.  An integer value
+              'i', means that the ith version should be retrieve if it
+              exists or the most recent version otherwise.
+           </xsd:documentation>
+        </xsd:annotation>
+     </xsd:attribute>
+   </xsd:complexType>
+   <!-- RESPONSE TYPE -->
+   <xsd:complexType name="FeatureCollectionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This type defines a container for the response to a 
+            GetFeature or GetFeatureWithLock request.  If the
+            request is GetFeatureWithLock, the lockId attribute
+            must be populated.  The lockId attribute can otherwise
+            be safely ignored.
+         </xsd:documentation>
+      </xsd:annotation>
+     <xsd:complexContent>
+       <xsd:extension base="gml:AbstractFeatureCollectionType">
+         <xsd:attribute name="lockId" type="xsd:string" use="optional">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The value of the lockId attribute is an identifier
+                  that a Web Feature Service generates and which a
+                  client application can use in subsequent operations
+                  (such as a Transaction request) to reference the set
+                  of locked features.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+       </xsd:extension>
+     </xsd:complexContent>
+   </xsd:complexType>
+</xsd:schema>

--- a/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/WFS-capabilities.xsd
+++ b/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/WFS-capabilities.xsd
@@ -1,0 +1,359 @@
+<?xml version="1.0" ?>
+<xsd:schema
+   targetNamespace="http://www.opengis.net/wfs"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="1.0.0.3">
+   
+   <!--
+      WFS is an OGC Standard.
+      Copyright (c) 2002,2010 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+   -->
+   
+   <!-- Comments in this document may impose additional constraints
+        beyond those codified in the schema syntax.  A conformant
+        Web Feature Server must provide Capabilities XML that
+           (1) validates against this schema
+           (2) does not violate the constraints stated in
+               comments herein. -->
+
+   <!-- ==============================================================
+        Imports ...
+        ============================================================== -->
+   <xsd:import namespace="http://www.opengis.net/ogc" schemaLocation="http://schemas.opengis.net/filter/1.0.0/filterCapabilities.xsd" />
+
+   <!-- ==============================================================
+        Global elements and attributes
+        ============================================================== -->
+   <!-- A descriptive narrative for more
+        information about this server. -->
+   <xsd:element name="Abstract" type="xsd:string"/>
+   <!-- Elements containing text blocks indicating what 
+        fees or access constraints are imposed by the 
+        service provider on the service or data retrieved
+        from the server. The reserved keyword "NONE" 
+        indicates no constraint exists. -->
+   <xsd:element name="AccessConstraints" type="xsd:string"/>
+   <xsd:element name="Fees" type="xsd:string"/>
+   <!-- Short words to help catalog searching.
+        Currently, no controlled vocabulary has
+        been defined. -->
+   <xsd:element name="Keywords" type="xsd:string"/>
+   <!-- The top-level HTTP URL of this service. 
+        Typically the URL of a "home page" for
+        the service.  See also the onlineResource
+        attributes of <DCPType> children, below.
+        Currently, no non-HTTP platforms have been
+        specified. -->
+   <xsd:element name="OnlineResource"/>
+   <xsd:element name="SRS" type="xsd:string"/>
+   <!-- A human-readable title to briefly identify
+        this server in menus. -->
+   <xsd:element name="Title" type="xsd:string"/>
+
+   <xsd:element name="Query"  type="wfs:EmptyType"/>
+   <xsd:element name="Insert" type="wfs:EmptyType"/>
+   <xsd:element name="Update" type="wfs:EmptyType"/>
+   <xsd:element name="Delete" type="wfs:EmptyType"/>
+   <xsd:element name="Lock"   type="wfs:EmptyType"/>
+
+   <!-- REDEFINE THIS ELEMENT AS NEEDED IN YOUR XML  -->
+   <xsd:element name="VendorSpecificCapabilities" type="xsd:string"/>
+
+   <!-- ==============================================================
+        Root element
+        ============================================================== -->
+   <!-- The parent element of the Capabilities document includes as
+        children a Service element with general information about the
+        server, a Capability element with specific information about
+        the kinds of functionality offered by the server, a FeatureTypeList
+        element defining the list of all feature types available from
+        this server and a FeatureCapabilities element describing the
+        filter capabilities of the server. -->
+   <xsd:element name="WFS_Capabilities" type="wfs:WFS_CapabilitiesType"/>
+
+   <!-- ==============================================================
+        Types
+        ============================================================== -->
+   <xsd:complexType name="WFS_CapabilitiesType">
+      <xsd:sequence>
+         <!-- The Service element provides metadata for
+              the service as a whole. -->
+         <xsd:element name="Service" type="wfs:ServiceType"/>
+
+         <!-- A Capability lists available request
+              types, how exceptions may be reported, and
+              whether any vendor-specific capabilities
+              are defined.  It also lists all the
+              feature types available from this feature 
+              server. -->
+         <xsd:element name="Capability" type="wfs:CapabilityType"/>
+         <xsd:element name="FeatureTypeList" type="wfs:FeatureTypeListType"/>
+         <xsd:element ref="ogc:Filter_Capabilities" />
+      </xsd:sequence>
+
+      <!-- The version attribute specifies the specification revision
+           to which this schema applies.  Its format is one,t two or three
+           integers separated by periods: "x", or "x.y", or "x.y.z",
+           with the most significant number appearing first.  Future
+           revisions are guaranteed to be numbered in monotonically
+           increasing fashion, though gaps may appear in the sequence. -->
+      <xsd:attribute name="version"
+                     type="xsd:string" fixed="1.0.0"/>
+
+      <!-- The updateSequence attribute is a sequence number for
+           managing propagation of the contents of this document.
+           For example, if a Feature Server adds some data feature
+           types it can increment the update sequence to inform
+           catalog servers that their previously cached versions
+           are now stale. The format is a positive integer. -->
+      <xsd:attribute name="updateSequence"
+                     type="xsd:nonNegativeInteger" default="0"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="ServiceType">
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:string"/>
+         <xsd:element ref="wfs:Title"/>
+         <xsd:element ref="wfs:Abstract" minOccurs="0"/>
+         <xsd:element ref="wfs:Keywords" minOccurs="0"/>
+         <xsd:element ref="wfs:OnlineResource"/>
+         <xsd:element ref="wfs:Fees" minOccurs="0"/>
+         <xsd:element ref="wfs:AccessConstraints" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <xsd:complexType name="CapabilityType">
+      <xsd:sequence>
+         <xsd:element name="Request" type="wfs:RequestType"/>
+         <!-- The optional VendorSpecificCapabilities element lists any
+              capabilities unique to a particular server.  Because the
+              information is not known a priori, it cannot be constrained
+              by this particular schema document.  A vendor-specific schema
+              fragment must be supplied at the start of the XML capabilities
+              document, after the reference to the general WFS_Capabilities
+              schema. -->
+         <xsd:element ref="wfs:VendorSpecificCapabilities" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeatureTypeListType">
+      <xsd:sequence>
+         <xsd:element name="Operations"
+                      type="wfs:OperationsType" minOccurs="0"/>
+         <xsd:element name="FeatureType"
+                      type="wfs:FeatureTypeType" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <!-- Available WFS-defined request types are listed here. At
+        least one of the values is required, but more than one
+        may be given. -->
+   <xsd:complexType name="RequestType">
+      <xsd:choice maxOccurs="unbounded">
+         <xsd:element name="GetCapabilities"
+                      type="wfs:GetCapabilitiesType"/>
+         <xsd:element name="DescribeFeatureType"
+                      type="wfs:DescribeFeatureTypeType"/>
+         <xsd:element name="Transaction"
+                      type="wfs:TransactionType"/>
+         <xsd:element name="GetFeature"
+                      type="wfs:GetFeatureTypeType"/>
+         <xsd:element name="GetFeatureWithLock"
+                      type="wfs:GetFeatureTypeType"/>
+         <xsd:element name="LockFeature"
+                      type="wfs:LockFeatureTypeType"/>
+      </xsd:choice>
+   </xsd:complexType>
+   <xsd:complexType name="GetCapabilitiesType">
+      <xsd:sequence>
+         <xsd:element name="DCPType"
+                      type="wfs:DCPTypeType" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DescribeFeatureTypeType">
+      <xsd:sequence>
+         <xsd:element name="SchemaDescriptionLanguage"
+                      type="wfs:SchemaDescriptionLanguageType"/>
+         <xsd:element name="DCPType"
+                      type="wfs:DCPTypeType" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionType">
+      <xsd:sequence>
+         <xsd:element name="DCPType"
+                      type="wfs:DCPTypeType" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GetFeatureTypeType">
+      <xsd:sequence>
+         <xsd:element name="ResultFormat"
+                      type="wfs:ResultFormatType"/>
+         <xsd:element name="DCPType"
+                      type="wfs:DCPTypeType" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LockFeatureTypeType">
+      <xsd:sequence>
+         <xsd:element name="DCPType"
+                      type="wfs:DCPTypeType" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <!-- Available Distributed Computing Platforms (DCPs) are
+        listed here.  At present, only HTTP is defined. -->
+   <xsd:complexType name="DCPTypeType">
+      <xsd:sequence>
+         <xsd:element name="HTTP" type="wfs:HTTPType"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <!-- A list of feature types available from
+        this server.  The following table
+        specifies the number and source of the
+        various elements that are available for
+        describing a feature type.
+   
+        element             number    comments
+        =================   =======   ======================================
+        Name                    1     this is the Name of the feature type
+   
+        Title                 0/1     an optional Meaningful title for the
+                                      feature type  (e.g. "Ontario Roads"
+                                      for ROADL_1M")
+
+        Abstract              0/1     optional; no Default
+   
+        Keywords              0/1     optional; no Default
+   
+        SRS                     1     the SRS that should be used
+                                      when specifying the state of
+                                      the feature
+
+        Operations            0/1     a list of available operations for
+                                      the feature type
+      
+        LatLongBoundingBox      1+    bounding box(s) of data
+      
+        MetadataURL           0/1+    optional; no default
+   -->
+   <xsd:complexType name="FeatureTypeType">
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:QName"/>
+         <xsd:element ref="wfs:Title" minOccurs="0"/>
+         <xsd:element ref="wfs:Abstract" minOccurs="0"/>
+         <xsd:element ref="wfs:Keywords" minOccurs="0"/>
+         <xsd:element ref="wfs:SRS"/>
+         <xsd:element name="Operations"
+                      type="wfs:OperationsType" minOccurs="0"/>
+         <xsd:element name="LatLongBoundingBox"
+                      type="wfs:LatLongBoundingBoxType"
+                      minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="MetadataURL"
+                      type="wfs:MetadataURLType"
+                      minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GetType">
+      <xsd:attribute name="onlineResource" type="xsd:string" use="required"/>
+   </xsd:complexType>
+
+   <!-- Available HTTP request methods. -->
+   <xsd:complexType name="HTTPType">
+      <xsd:choice maxOccurs="unbounded">
+         <!-- HTTP request methods.  The onlineResourc attribute
+              indicates the URL prefix for HTTP GET requests
+              (everything before the question mark and query string:
+              http://hostname[:port]/path/scriptname); for HTTP POST
+              requests, onlineResource is the complete URL. -->
+         <xsd:element name="Get" type="wfs:GetType"/>
+         <xsd:element name="Post" type="wfs:PostType"/>
+      </xsd:choice>
+   </xsd:complexType>
+
+   <!-- The LatLongBoundingBox element is used to indicate the edges of 
+        an enclosing rectangle in the SRS of the associated feature type.
+        Its purpose is to facilitate geographic searches  by indicating
+        where instances of the particular feature type exist.  Since multiple
+        LatLongBoundingBoxes can be specified, a WFS can indicate where 
+        various clusters of data may exist.  This knowledge aids client 
+        applications by letting them know where they should query in order 
+        to have a high probability of finding data. -->
+   <xsd:complexType name="LatLongBoundingBoxType">
+      <xsd:attribute name="minx" type="xsd:string" use="required"/>
+      <xsd:attribute name="miny" type="xsd:string" use="required"/>
+      <xsd:attribute name="maxx" type="xsd:string" use="required"/>
+      <xsd:attribute name="maxy" type="xsd:string" use="required"/>
+   </xsd:complexType>
+
+   <!-- A Web Feature Server MAY use zero or more MetadataURL
+        elements to offer detailed, standardized metadata about
+        the data underneath a particular feature type.  The type
+        attribute indicates the standard to which the metadata
+        complies; the format attribute indicates how the metadata is
+        structured.  Two types are defined at present:
+        'TC211' = ISO TC211 19115; 
+        'FGDC'  = FGDC CSDGM. -->
+   <xsd:complexType name="MetadataURLType">
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="type" use="required">
+               <xsd:simpleType>
+                  <xsd:restriction base="xsd:NMTOKEN">
+                     <xsd:enumeration value="TC211"/>
+                     <xsd:enumeration value="FGDC"/>
+                  </xsd:restriction>
+               </xsd:simpleType>
+            </xsd:attribute>
+            <xsd:attribute name="format" use="required">
+               <xsd:simpleType>
+                  <xsd:restriction base="xsd:NMTOKEN">
+                     <xsd:enumeration value="XML"/>
+                     <xsd:enumeration value="SGML"/>
+                     <xsd:enumeration value="TXT"/>
+                  </xsd:restriction>
+               </xsd:simpleType>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OperationsType">
+      <xsd:choice maxOccurs="unbounded">
+         <xsd:element ref="wfs:Insert"/>
+         <xsd:element ref="wfs:Update"/>
+         <xsd:element ref="wfs:Delete"/>
+         <xsd:element ref="wfs:Query"/>
+         <xsd:element ref="wfs:Lock"/>
+      </xsd:choice>
+   </xsd:complexType>
+   <xsd:complexType name="PostType">
+      <xsd:attribute name="onlineResource" type="xsd:string" use="required"/>
+   </xsd:complexType>
+
+   <!-- The ResultFormatType type defines the output formats that the
+        web feature server can generate.  The mandatory format "GML2"
+        must always be available.  Individual servers can define
+        additional elements representing other output formats. -->
+   <xsd:element name="GML2" type="wfs:EmptyType"/>
+   <xsd:complexType name="ResultFormatType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element ref="wfs:GML2"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <!-- The SchemaDescriptionLanguageType type defines the schema languages
+        that a feature server is capable of using to describe the schema
+        of a feature.  Individual servers can define additional elements
+        representing other schema languages but XMLSCHEMA must always
+        be defined. -->
+   <xsd:element name="XMLSCHEMA" type="wfs:EmptyType"/>
+   <xsd:complexType name="SchemaDescriptionLanguageType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element ref="wfs:XMLSCHEMA"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EmptyType" />
+</xsd:schema>

--- a/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/WFS-transaction.xsd
+++ b/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/WFS-transaction.xsd
@@ -1,0 +1,593 @@
+<?xml version="1.0"?>
+<xsd:schema
+   targetNamespace="http://www.opengis.net/wfs"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   elementFormDefault="qualified"
+   version="1.0.0.3">
+   
+   <!--
+      WFS is an OGC Standard.
+      Copyright (c) 2002,2010 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+   -->
+   
+   <!-- ==============================================================
+        Includes and Imports
+        ============================================================== -->
+   <xsd:include schemaLocation="./wfs.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/ogc" schemaLocation="http://schemas.opengis.net/filter/1.0.0/filter.xsd"/>
+
+   <!-- ==============================================================
+         REQUEST MESSAGES
+         ============================================================== -->
+   <xsd:element name="GetFeatureWithLock" type="wfs:GetFeatureWithLockType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This is the root element for the GetFeatureWithLock request.
+            The GetFeatureWithLock operation performs identically to a
+            GetFeature request except that the GetFeatureWithLock request
+            locks all the feature instances in the result set and returns
+            a lock identifier to a client application in the response.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="LockFeature" type="wfs:LockFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This is the root element for a LockFeature request.
+            The LockFeature request can be used to lock one or
+            more feature instances.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="Transaction" type="wfs:TransactionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This is the root element for a Transaction request.
+            A transaction request allows insert, update and 
+            delete operations to be performed to create, change
+            or remove feature instances.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+
+   <!-- ==============================================================
+         RESPONSE MESSAGES
+         ============================================================== -->
+   <xsd:element name="WFS_LockFeatureResponse"
+                type="wfs:WFS_LockFeatureResponseType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The WFS_LockFeatureResponse element contains a report
+            about the completion status of a LockFeature request.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="WFS_TransactionResponse"
+                type="wfs:WFS_TransactionResponseType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The WFS_TransactionResponse element contains a report
+            about the completion status of a Transaction operation.  
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+
+   <!-- ==============================================================
+         COMMON ATTRIBUTE DOCUMENTATION
+         ============================================================== 
+         EXPIRY:
+            The expiry attribute value is specified in minutes. It
+            indicates how long a Web Feature Service should wait to
+            receive a request from the client application that locked
+            the feature instances.  If the specified time elapses and
+            no request has been received by a Web Feature Service that
+            references the lockId given to the client application, then
+            the locks maintained by the Web Feature Service shall be
+            released and the lockId that references the locked features
+            shall now be invalid.  If the expiry attribute is not specified,
+            then the feature instances shall be locked indefinitely and the
+            intervention of an administrator may be required to release
+            the locks. -->
+
+   <!-- ==============================================================
+         TYPES
+         ============================================================== -->
+   <!-- GETFEATUREWITHLOCK -->
+   <xsd:complexType name="GetFeatureWithLockType">
+      <xsd:annotation>
+         <xsd:documentation>
+            A GetFeatureWithLock request operates identically to a
+            GetFeature request expect that it attempts to lock the
+            feature instances in the result set and includes a lock
+            identifier in its response to a client.  A lock identifier
+            is an identifier generated by a Web Feature Service that 
+            a client application can use, in subsequent operations,
+            to reference the locked set of feature instances.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="wfs:Query" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="required" fixed="1.0.0"/>
+      <xsd:attribute name="service"
+                     type="xsd:string" use="required" fixed="WFS"/>
+      <xsd:attribute name="handle"
+                     type="xsd:string" use="optional"/>
+      <xsd:attribute name="expiry"
+                     type="xsd:positiveInteger" use="optional"/>
+      <xsd:attribute name="outputFormat"
+                     type="xsd:string" use="optional" default="GML2"/>
+      <xsd:attribute name="maxFeatures"
+                     type="xsd:positiveInteger" use="optional"/>
+   </xsd:complexType>
+   <!-- LOCKFEATURE -->
+   <xsd:complexType name="LockFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This type defines the LockFeature operation.  The LockFeature
+            element contains one or more Lock elements that define
+            which features of a particular type should be locked.  A lock
+            identifier (lockId) is returned to the client application which
+            can be used by subsequent operations to reference the locked
+            features.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="Lock" type="wfs:LockType" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The lock element is used to indicate which feature 
+                  instances of particular type are to be locked.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="required" fixed="1.0.0"/>
+      <xsd:attribute name="service"
+                     type="xsd:string" use="required" fixed="WFS"/>
+      <xsd:attribute name="expiry"
+                     type="xsd:positiveInteger" use="optional"/>
+      <xsd:attribute name="lockAction"
+                     type="wfs:AllSomeType" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The lockAction attribute is used to indicate what
+               a Web Feature Service should do when it encounters
+               a feature instance that has already been locked by
+               another client application.
+
+               Valid values are ALL or SOME.
+
+               ALL means that the Web Feature Service must acquire
+               locks on all the requested feature instances.  If it
+               cannot acquire those locks then the request should
+               fail.  In this instance, all locks acquired by the
+               operation should be released.
+ 
+               SOME means that the Web Feature Service should lock
+               as many of the requested features as it can.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:complexType name="LockType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This type defines the Lock element.  The Lock element
+            defines a locking operation on feature instances of 
+            a single type. An OGC Filter is used to constrain the
+            scope of the operation.  Features to be locked can be
+            identified individually by using their feature identifier
+            or they can be locked by satisfying the spatial and 
+            non-spatial constraints defined in the filter.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="ogc:Filter" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="handle" 
+                     type="xsd:string" use="optional"/>
+      <xsd:attribute name="typeName" 
+                     type="xsd:QName" use="required"/>
+   </xsd:complexType>
+   <!-- TRANSACTION -->
+   <xsd:complexType name="TransactionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The TranactionType defines the Transaction operation.  A
+            Transaction element contains one or more Insert, Update
+            Delete and Native elements that allow a client application
+            to create, modify or remove feature instances from the 
+            feature repository that a Web Feature Service controls.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="wfs:LockId" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  In order for a client application to operate upon locked
+                  feature instances, the Transaction request must include
+                  the LockId element.  The content of this element must be
+                  the lock identifier the client application obtained from
+                  a previous GetFeatureWithLock or LockFeature operation.
+
+                  If the correct lock identifier is specified the Web
+                  Feature Service knows that the client application may
+                  operate upon the locked feature instances.
+
+                  No LockId element needs to be specified to operate upon
+                  unlocked features.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element ref="wfs:Insert"/>
+            <xsd:element ref="wfs:Update"/>
+            <xsd:element ref="wfs:Delete"/>
+            <xsd:element ref="wfs:Native"/>
+         </xsd:choice>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="required" fixed="1.0.0"/>
+      <xsd:attribute name="service"
+                     type="xsd:string" use="required" fixed="WFS"/>
+      <xsd:attribute name="handle"
+                     type="xsd:string" use="optional"/>
+      <xsd:attribute name="releaseAction"
+                     type="wfs:AllSomeType" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The releaseAction attribute is used to control how a Web
+               Feature service releases locks on feature instances after
+               a Transaction request has been processed.
+
+               Valid values are ALL or SOME.
+
+               A value of ALL means that the Web Feature Service should
+               release the locks of all feature instances locked with the
+               specified lockId, regardless or whether or not the features
+               were actually modified.
+
+               A value of SOME means that the Web Feature Service will 
+               only release the locks held on feature instances that 
+               were actually operated upon by the transaction.  The lockId
+               that the client application obtained shall remain valid and
+               the other, unmodified, feature instances shall remain locked.
+               If the expiry attribute was specified in the original operation 
+               that locked the feature instances, then the expiry counter
+               will be reset to give the client application that same amount
+               of time to post subsequent transactions against the locked
+               features.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:element name="LockId" type="xsd:string">
+      <xsd:annotation>
+         <xsd:documentation>
+            The LockId element contains the value of the lock identifier
+            obtained by a client application from a previous GetFeatureWithLock
+            or LockFeature request.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="Insert" type="wfs:InsertElementType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Insert element is used to indicate that the Web Feature
+            Service should create a new instance of a feature type.  The
+            feature instance is specified using GML2 and one or more 
+            feature instances to be created can be contained inside the
+            Insert element.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="InsertElementType">
+      <xsd:sequence>
+         <xsd:element ref="gml:_Feature" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional"/>
+   </xsd:complexType>
+   <xsd:element name="Update" type="wfs:UpdateElementType">
+      <xsd:annotation>
+         <xsd:documentation>
+            One or more existing feature instances can be changed by
+            using the Update element.  Changing a feature instance
+            means that the current value of one or more properties of
+            the feature are replaced with new values.  The Update
+            element contains  one or more Property elements.  A
+            Property element contains the name or a feature property
+            who's value is to be changed and the replacement value
+            for that property.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="UpdateElementType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:Property" maxOccurs="unbounded" />
+         <xsd:element ref="ogc:Filter" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Filter element is used to constrain the scope
+                  of the update operation to those features identified
+                  by the filter.  Feature instances can be specified
+                  explicitly and individually using the identifier of
+                  each feature instance OR a set of features to be
+                  operated on can be identified by specifying spatial
+                  and non-spatial constraints in the filter.
+                  If no filter is specified, then the update operation 
+                  applies to all feature instances.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional"/>
+      <xsd:attribute name="typeName" type="xsd:QName" use="required"/>
+   </xsd:complexType>
+   <xsd:element name="Delete" type="wfs:DeleteElementType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Delete element is used to indicate that one or more
+            feature instances should be removed from the feature
+            repository.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="DeleteElementType">
+      <xsd:sequence>
+         <xsd:element ref="ogc:Filter" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Filter element is used to constrain the scope
+                  of the delete operation to those features identified
+                  by the filter.  Feature instances can be specified
+                  explicitly and individually using the identifier of
+                  each feature instance OR a set of features to be
+                  operated on can be identified by specifying spatial
+                  and non-spatial constraints in the filter.
+                  If no filter is specified then an exception should
+                  be raised since it is unlikely that a client application
+                  intends to delete all feature instances.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional"/>
+      <xsd:attribute name="typeName" type="xsd:QName" use="required"/>
+   </xsd:complexType>
+   <xsd:element name="Native" type="wfs:NativeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            Many times, a Web Feature Service interacts with a repository
+            that may have special vendor specific capabilities.  The native
+            element allows vendor specific command to be passed to the
+            repository via the Web Feature Service.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="NativeType">
+      <xsd:attribute name="vendorId" type="xsd:string" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               The vendorId attribute is used to specify the name of
+               vendor who's vendor specific command the client
+               application wishes to execute.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="safeToIgnore" type="xsd:boolean" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               In the event that a Web Feature Service does not recognize
+               the vendorId or does not recognize the vendor specific command,
+               the safeToIgnore attribute is used to indicate whether the 
+               exception can be safely ignored.  A value of TRUE means that
+               the Web Feature Service may ignore the command.  A value of
+               FALSE means that a Web Feature Service cannot ignore the
+               command and an exception should be raised if a problem is 
+               encountered.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+
+   <!-- define structure to specify a property value -->
+   <xsd:element name="Property" type="wfs:PropertyType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Property element is used to specify the new
+            value of a feature property inside an Update element.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="PropertyType">
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:string">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Name element contains the name of a feature property
+                  to be updated.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Value" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Value element contains the replacement value for the
+                  named property.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <!-- RESPONSE TYPES -->
+   <xsd:complexType name="WFS_LockFeatureResponseType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The WFS_LockFeatureResponseType is used to define an
+            element to contains the response to a LockFeature
+            operation.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="wfs:LockId">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The WFS_LockFeatureResponse includes a LockId element
+                  that contains a lock identifier.  The lock identifier
+                  can be used by a client, in subsequent operations, to
+                  operate upon the locked feature instances.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="FeaturesLocked"
+                      type="wfs:FeaturesLockedType" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The LockFeature or GetFeatureWithLock operations
+                  identify and attempt to lock a set of feature 
+                  instances that satisfy the constraints specified 
+                  in the request.  In the event that the lockAction
+                  attribute (on the LockFeature or GetFeatureWithLock
+                  elements) is set to SOME, a Web Feature Service will
+                  attempt to lock as many of the feature instances from
+                  the result set as possible.
+
+                  The FeaturesLocked element contains list of ogc:FeatureId
+                  elements enumerating the feature instances that a WFS
+                  actually managed to lock.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="FeaturesNotLocked"
+                      type="wfs:FeaturesNotLockedType" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  In contrast to the FeaturesLocked element, the
+                  FeaturesNotLocked element contains a list of 
+                  ogc:Filter elements identifying feature instances
+                  that a WFS did not manage to lock because they were
+                  already locked by another process.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeaturesLockedType">
+     <xsd:sequence maxOccurs="unbounded">
+       <xsd:element ref="ogc:FeatureId"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeaturesNotLockedType">
+     <xsd:sequence maxOccurs="unbounded">
+       <xsd:element ref="ogc:FeatureId"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WFS_TransactionResponseType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The WFS_TransactionResponseType defines the format of
+            the XML document that a Web Feature Service generates 
+            in response to a Transaction request.  The response 
+            includes the completion status of the transaction 
+            and the feature identifiers of any newly created
+            feature instances.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="InsertResult"
+                      type="wfs:InsertResultType"
+                      minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The InsertResult element contains a list of ogc:FeatureId
+                  elements that identify any newly created feature instances.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="TransactionResult"
+                      type="wfs:TransactionResultType">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The TransactionResult element contains a Status element
+                  indicating the completion status of a transaction.  In
+                  the event that the transaction fails, additional element
+                  may be included to help locate which part of the transaction
+                  failed and why.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="required" fixed="1.0.0"/>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionResultType">
+      <xsd:sequence>
+         <xsd:element name="Status" type="wfs:StatusType">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Status element contains an element indicating the
+                  completion status of a transaction.  The SUCCESS element
+                  is used to indicate successful completion.  The FAILED
+                  element is used to indicate that an exception was 
+                  encountered.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Locator" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  In the event that an exception was encountered while 
+                  processing a transaction, a Web Feature Service may
+                  use the Locator element to try and identify the part
+                  of the transaction that failed.  If the element(s)
+                  contained in a Transaction element included a handle
+                  attribute, then a Web Feature Service may report the
+                  handle to identify the offending element.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Message" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Message element may contain an exception report
+                  generated by a Web Feature Service when an exception
+                  is encountered.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional"/>
+   </xsd:complexType>
+   <xsd:complexType name="InsertResultType">
+      <xsd:sequence>
+         <xsd:element ref="ogc:FeatureId" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional"/>
+   </xsd:complexType>
+   <xsd:complexType name="StatusType">
+      <xsd:choice>
+         <xsd:element ref="wfs:SUCCESS"/>
+         <xsd:element ref="wfs:FAILED"/>
+         <xsd:element ref="wfs:PARTIAL"/>
+      </xsd:choice>
+   </xsd:complexType>
+   <xsd:element name="SUCCESS" type="wfs:EmptyType"/>
+   <xsd:element name="FAILED" type="wfs:EmptyType"/>
+   <xsd:element name="PARTIAL" type="wfs:EmptyType"/>
+   <!-- MISC TYPES -->
+   <xsd:complexType name="EmptyType"/>
+   <xsd:simpleType name="AllSomeType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="ALL"/>
+         <xsd:enumeration value="SOME"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+</xsd:schema>

--- a/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/wfs.xsd
+++ b/core/src/main/resources/net/opengis/schemas/wfs/1.0.0/wfs.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+   targetNamespace="http://www.opengis.net/wfs"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="unqualified"
+   version="1.0.0.3">
+   
+   <xsd:annotation>
+      <xsd:documentation>All-components schema for the Web Feature Service namespace.
+         
+         WFS is an OGC Standard.
+         Copyright (c) 2002,2010 Open Geospatial Consortium.
+         To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+      </xsd:documentation>
+   </xsd:annotation>
+
+   <!-- ==================  includes and imports  ======================= -->
+   <xsd:include schemaLocation="./WFS-basic.xsd"/>
+   <xsd:include schemaLocation="./WFS-transaction.xsd"/>
+   <!-- ================================================================= -->
+</xsd:schema>

--- a/core/src/main/resources/net/opengis/schemas/wfs/1.1.0/wfs.xsd
+++ b/core/src/main/resources/net/opengis/schemas/wfs/1.1.0/wfs.xsd
@@ -1,0 +1,1867 @@
+<?xml version="1.0"?>
+<xsd:schema 
+   targetNamespace="http://www.opengis.net/wfs"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:ows="http://www.opengis.net/ows"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified" version="1.1.2.0">
+
+   <!--
+      WFS is an OGC Standard.
+      Copyright (c) 2002,2010 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
+   -->
+
+   <!-- ==============================================================
+        Includes and Imports
+        ============================================================== -->
+   <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/3.1.1/base/gml.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/ogc" schemaLocation="http://schemas.opengis.net/filter/1.1.0/filter.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/ows" schemaLocation="http://schemas.opengis.net/ows/1.0.0/owsAll.xsd"/>
+
+   <!-- ================================================================== -->
+   <!-- =   BASE REQUEST TYPE                                            = -->
+   <!-- ================================================================== -->
+   <xsd:complexType name="BaseRequestType" abstract="true">
+      <xsd:annotation>
+         <xsd:documentation>
+            XML encoded WFS operation request base, for all operations
+            except GetCapabilities.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:attribute name="service" type="ows:ServiceType"
+                     use="optional" default="WFS">
+        <xsd:annotation>
+           <xsd:documentation>
+              The service attribute is included to support service 
+              endpoints that implement more than one OGC service.
+              For example, a single CGI that implements WMS, WFS
+              and WCS services. 
+              The endpoint can inspect the value of this attribute 
+              to figure out which service should process the request.
+              The value WFS indicates that a web feature service should
+              process the request.
+              This parameter is somewhat redundant in the XML encoding
+              since the request namespace can be used to determine
+              which service should process any give request.  For example,
+              wfs:GetCapabilities and easily be distinguished from
+              wcs:GetCapabilities using the namespaces.
+           </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="version" type="xsd:string"
+                     use="optional" default="1.1.0">
+        <xsd:annotation>
+           <xsd:documentation>
+               The version attribute is used to indicate the version of the
+               WFS specification that a request conforms to.  All requests in
+               this schema conform to V1.1 of the WFS specification.
+               For WFS implementations that support more than one version of
+               a WFS sepcification ... if the version attribute is not 
+               specified then the service should assume that the request
+               conforms to greatest available specification version.
+           </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="handle"
+                     type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The handle attribute allows a client application
+               to assign a client-generated request identifier
+               to a WFS request.  The handle is included to
+               facilitate error reporting.  A WFS may report the
+               handle in an exception report to identify the
+               offending request or action.  If the handle is not
+               present, then the WFS may employ other means to
+               localize the error (e.g. line numbers).
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+
+   <!-- ============================================================== -->
+   <!-- = PROPERTY NAME ELEMENT                                      = -->
+   <!-- ============================================================== -->
+   <xsd:element name="PropertyName" type="xsd:string">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Property element is used to specify one or more
+            properties of a feature whose values are to be retrieved
+            by a Web Feature Service.
+
+            While a Web Feature Service should endeavour to satisfy
+            the exact request specified, in some instance this may
+            not be possible.  Specifically, a Web Feature Service
+            must generate a valid GML3 response to a Query operation.
+            The schema used to generate the output may include
+            properties that are mandatory.  In order that the output
+            validates, these mandatory properties must be specified
+            in the request.  If they are not, a Web Feature Service
+            may add them automatically to the Query before processing
+            it.  Thus a client application should, in general, be
+            prepared to receive more properties than it requested.
+
+            Of course, using the DescribeFeatureType request, a client
+            application can determine which properties are mandatory
+            and request them in the first place.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="XlinkPropertyName">
+      <xsd:annotation>
+         <xsd:documentation>
+            This element may be used in place of an wfs:PropertyName element
+            in a wfs:Query element in a wfs:GetFeature element to selectively
+            request the traversal of nested XLinks in the returned element for
+            the named property. This element may not be used in other requests
+            -- GetFeatureWithLock, LockFeature, Insert, Update, Delete -- in
+            this version of the WFS specification.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+               <xsd:attribute name="traverseXlinkDepth"
+                              type="xsd:string" use="required">
+                  <xsd:annotation>
+                     <xsd:documentation>
+                  This attribute indicates the depth to which nested property
+                  XLink linking element locator attribute (href) XLinks are
+                  traversed and resolved if possible.  A value of "1" indicates
+                  that one linking element locator attribute (href) Xlink
+                  will be traversed and the referenced element returned if
+                  possible, but nested property XLink linking element locator
+                  attribute (href) XLinks in the returned element are not
+                  traversed.  A value of  "*" indicates that all nested property
+                  XLink linking element locator attribute (href) XLinks will be
+                  traversed and the referenced elements returned if possible.
+                  The range of valid values for this attribute consists of
+                  positive integers plus "*".
+                     </xsd:documentation>
+                  </xsd:annotation>
+               </xsd:attribute>
+               <xsd:attribute name="traverseXlinkExpiry"
+                              type="xsd:positiveInteger"
+                              use="optional">
+                  <xsd:annotation>
+                     <xsd:documentation>
+                  The traverseXlinkExpiry attribute value is specified in
+                  minutes It indicates how long a Web Feature Service should
+                  wait to receive a response to a nested GetGmlObject request.	
+                     </xsd:documentation>
+                  </xsd:annotation>
+               </xsd:attribute>
+            </xsd:extension>
+         </xsd:simpleContent>
+      </xsd:complexType>
+   </xsd:element>
+
+   <!-- ================================================================== -->
+   <!-- =   GETCAPABILITIES Request and Response                         = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="GetCapabilities" type="wfs:GetCapabilitiesType"/>
+   <xsd:complexType name="GetCapabilitiesType">
+     <xsd:annotation>
+       <xsd:documentation>
+          Request to a WFS to perform the GetCapabilities operation.
+          This operation allows a client to retrieve a Capabilities
+          XML document providing metadata for the specific WFS server.
+
+          The GetCapapbilities element is used to request that a Web Feature
+          Service generate an XML document describing the organization
+          providing the service, the WFS operations that the service
+          supports, a list of feature types that the service can operate
+          on and list of filtering capabilities that the service support.
+          Such an XML document is called a capabilities document.
+       </xsd:documentation>
+     </xsd:annotation>
+     <xsd:complexContent>
+       <xsd:extension base="ows:GetCapabilitiesType">
+         <xsd:attribute name="service" type="ows:ServiceType"
+                        use="optional" default="WFS"/>
+
+       </xsd:extension>
+     </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <xsd:element name="WFS_Capabilities"
+                type="wfs:WFS_CapabilitiesType"/>
+   <xsd:complexType name="WFS_CapabilitiesType">
+      <xsd:annotation>
+         <xsd:documentation>
+            XML encoded WFS GetCapabilities operation response. This
+            document provides clients with service metadata about a
+            specific service instance, including metadata about the
+            tightly-coupled data served. If the server does not implement
+            the updateSequence parameter, the server shall always return
+            the complete Capabilities document, without the updateSequence
+            parameter. When the server implements the updateSequence
+            parameter and the GetCapabilities operation request included
+            the updateSequence parameter with the current value, the server
+            shall return this element with only the "version" and
+            "updateSequence" attributes. Otherwise, all optional elements
+            shall be included or not depending on the actual value of the
+            Contents parameter in the GetCapabilities operation request.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexContent>
+         <xsd:extension base="ows:CapabilitiesBaseType">
+            <xsd:sequence>
+               <xsd:element ref="wfs:FeatureTypeList" minOccurs="0"/>
+               <xsd:element ref="wfs:ServesGMLObjectTypeList" minOccurs="0"/>
+               <xsd:element ref="wfs:SupportsGMLObjectTypeList" minOccurs="0"/>
+               <xsd:element ref="ogc:Filter_Capabilities"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="FeatureTypeList" type="wfs:FeatureTypeListType"/>
+   <xsd:complexType name="FeatureTypeListType">
+      <xsd:annotation>
+         <xsd:documentation>
+            A list of feature types available from  this server.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="Operations"
+                      type="wfs:OperationsType"
+                      minOccurs="0"/>
+         <xsd:element name="FeatureType"
+                      type="wfs:FeatureTypeType"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeatureTypeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            An element of this type that describes a feature in an application
+            namespace shall have an xml xmlns specifier, e.g.
+            xmlns:bo="http://www.BlueOx.org/BlueOx"
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:QName">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Name of this feature type, including any namespace prefix
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Title" type="xsd:string">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Title of this feature type, normally used for display
+                  to a human.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Abstract" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Brief narrative description of this feature type, normally
+                  used for display to a human.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="ows:Keywords" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice>
+            <xsd:sequence>
+               <xsd:element name="DefaultSRS"
+                            type="xsd:anyURI">
+                  <xsd:annotation>
+                     <xsd:documentation>
+                        The DefaultSRS element indicated which spatial
+                        reference system shall be used by a WFS to
+                        express the state of a spatial feature if not
+                        otherwise explicitly identified within a query
+                        or transaction request.  The SRS may be indicated
+                        using either the EPSG form (EPSG:posc code) or
+                        the URL form defined in subclause 4.3.2 of
+                        refernce[2].
+                     </xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="OtherSRS"
+                            type="xsd:anyURI"
+                            minOccurs="0" maxOccurs="unbounded">
+                  <xsd:annotation>
+                     <xsd:documentation>
+                        The OtherSRS element is used to indicate other 
+                        supported SRSs within query and transaction 
+                        operations.  A supported SRS means that the 
+                        WFS supports the transformation of spatial
+                        properties between the OtherSRS and the internal
+                        storage SRS.  The effects of such transformations 
+                        must be considered when determining and declaring 
+                        the guaranteed data accuracy.
+                     </xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+            <xsd:element name="NoSRS">
+              <xsd:complexType/>
+            </xsd:element>
+         </xsd:choice>
+         <xsd:element name="Operations"
+                      type="wfs:OperationsType"
+                      minOccurs="0"/>
+         <xsd:element name="OutputFormats"
+                      type="wfs:OutputFormatListType"
+                      minOccurs="0"/>
+         <xsd:element ref="ows:WGS84BoundingBox" 
+                      minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="MetadataURL"
+                      type="wfs:MetadataURLType"
+                      minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OperationsType">
+      <xsd:sequence>
+         <xsd:element name="Operation"
+                      type="wfs:OperationType"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="OperationType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="Insert"/>
+         <xsd:enumeration value="Update"/>
+         <xsd:enumeration value="Delete"/>
+         <xsd:enumeration value="Query"/>
+         <xsd:enumeration value="Lock"/>
+         <xsd:enumeration value="GetGmlObject"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="OutputFormatListType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element name="Format" type="xsd:string"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MetadataURLType">
+      <xsd:annotation>
+         <xsd:documentation>
+            A Web Feature Server MAY use zero or more MetadataURL
+            elements to offer detailed, standardized metadata about
+            the data underneath a particular feature type.  The type
+            attribute indicates the standard to which the metadata
+            complies; the format attribute indicates how the metadata is
+            structured.  Two types are defined at present:
+            'TC211' or 'ISO19115' = ISO TC211 19115; 
+            'FGDC'                = FGDC CSDGM.
+            'ISO19139'            = ISO 19139
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="type" use="required">
+               <xsd:simpleType>
+                  <xsd:restriction base="xsd:string">
+                     <xsd:enumeration value="TC211"/>
+                     <xsd:enumeration value="FGDC"/>
+                     <xsd:enumeration value="19115"/>
+                     <xsd:enumeration value="19139"/>
+                  </xsd:restriction>
+               </xsd:simpleType>
+            </xsd:attribute>
+            <xsd:attribute name="format" use="required">
+               <xsd:simpleType>
+                  <xsd:restriction base="xsd:string">
+                     <xsd:enumeration value="text/xml"/>
+                     <xsd:enumeration value="text/html"/>
+                     <xsd:enumeration value="text/sgml"/>
+                     <xsd:enumeration value="text/plain"/>
+                  </xsd:restriction>
+               </xsd:simpleType>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:element name="ServesGMLObjectTypeList"
+                type="wfs:GMLObjectTypeListType">
+      <xsd:annotation>
+         <xsd:documentation>
+            List of GML Object types available for GetGmlObject requests
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="SupportsGMLObjectTypeList"
+                type="wfs:GMLObjectTypeListType">
+      <xsd:annotation>
+         <xsd:documentation>
+            List of GML Object types that WFS is capable of serving, either
+            directly, or as validly derived types defined in a GML application
+            schema.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="GMLObjectTypeListType">
+      <xsd:sequence>
+         <xsd:element name="GMLObjectType" type="wfs:GMLObjectTypeType"
+            maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Name of this GML object type, including any namespace prefix
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GMLObjectTypeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            An element of this type that describes a GML object in an
+            application namespace shall have an xml xmlns specifier,
+            e.g. xmlns:bo="http://www.BlueOx.org/BlueOx"
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:QName">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Name of this GML Object type, including any namespace prefix.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Title" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Title of this GML Object type, normally used for display
+                  to a human.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Abstract" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Brief narrative description of this GML Object type, normally
+                  used for display to a human.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="ows:Keywords"
+                      minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="OutputFormats"
+                      type="wfs:OutputFormatListType" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <!-- ================================================================== -->
+   <!-- =   DESCRIBEFEATURETYPE Request and Response                     = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="DescribeFeatureType" type="wfs:DescribeFeatureTypeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The DescribeFeatureType element is used to request that a Web
+            Feature Service generate a document describing one or more 
+            feature types.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="DescribeFeatureTypeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The DescribeFeatureType operation allows a client application
+            to request that a Web Feature Service describe one or more
+            feature types.   A Web Feature Service must be able to generate
+            feature descriptions as valid GML3 application schemas.
+
+            The schemas generated by the DescribeFeatureType operation can
+            be used by a client application to validate the output.
+
+            Feature instances within the WFS interface must be specified
+            using GML3.  The schema of feature instances specified within
+            the WFS interface must validate against the feature schemas 
+            generated by the DescribeFeatureType request.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element name="TypeName" type="xsd:QName"
+                            minOccurs="0" maxOccurs="unbounded">
+                  <xsd:annotation>
+                     <xsd:documentation>
+                        The TypeName element is used to enumerate the
+                        feature types to be described.  If no TypeName
+                        elements are specified then all features should
+                        be described.  The name must be a valid type
+                        that belongs to the feature content as defined
+                        by the GML Application Schema.
+                     </xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="outputFormat"
+                           type="xsd:string" use="optional"
+                           default="text/xml; subtype=gml/3.1.1">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The outputFormat attribute is used to specify what schema
+                     description language should be used to describe features.
+                     The default value of 'text/xml; subtype=3.1.1' means that
+                     the WFS must generate a GML3 application schema that can
+                     be used to validate the GML3 output of a GetFeature
+                     request or feature instances specified in Transaction
+                     operations.
+                     For the purposes of experimentation, vendor extension,
+                     or even extensions that serve a specific community of
+                     interest, other acceptable output format values may be
+                     advertised by a WFS service in the capabilities document.
+                     The meaning of such values in not defined in the WFS 
+                     specification.  The only proviso is such cases is that
+                     clients may safely ignore outputFormat values that do
+                     not recognize.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <!-- ================================================================== -->
+   <!-- For the outputFormat value of 'text/xml; subtype=3.1.1' a WFS      -->
+   <!-- must generate a valid XML-Schema/GML3 application schema that      -->
+   <!-- describes that requested feature type(s).                          -->
+   <!-- ================================================================== -->
+
+   <!-- ================================================================== -->
+   <!-- =   GETFEATURES Request and Response                             = -->
+   <!-- ================================================================== -->
+   <xsd:element name="GetFeature" type="wfs:GetFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The GetFeature element is used to request that a Web Feature
+            Service return feature type instances of one or more feature
+            types.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="GetFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            A GetFeature element contains one or more Query elements
+            that describe a query operation on one feature type.  In
+            response to a GetFeature request, a Web Feature Service
+            must be able to generate a GML3 response that validates
+            using a schema generated by the DescribeFeatureType request.
+            A Web Feature Service may support other possibly non-XML
+            (and even binary) output formats as long as those formats
+            are advertised in the capabilities document.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element ref="wfs:Query" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="resultType"
+                           type="wfs:ResultTypeType" use="optional"
+                           default="results">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The resultType attribute is used to indicate
+                     what response a WFS should return to user once
+                     a GetFeature request is processed.
+                     Possible values are:
+                        results - meaning that the full response set
+                                  (i.e. all the feature instances) 
+                                  should be returned.
+                        hits    - meaning that an empty response set
+                                  should be returned (i.e. no feature
+                                  instances should be returned) but
+                                  the "numberOfFeatures" attribute
+                                  should be set to the number of feature
+                                  instances that would be returned.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="outputFormat"
+                           type="xsd:string" use="optional"
+                           default="text/xml; subtype=gml/3.1.1">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The outputFormat attribute is used to specify the output
+                     format that the Web Feature Service should generate in
+                     response to a GetFeature or GetFeatureWithLock element.
+                     The default value of 'text/xml; subtype=gml/3.1.1'
+                     indicates that the output is an XML document that
+                     conforms to the Geography Markup Language (GML)
+                     Implementation Specification V3.1.1.
+                     For the purposes of experimentation, vendor extension,
+                     or even extensions that serve a specific community of
+                     interest, other acceptable output format values may be
+                     used to specify other formats as long as those values
+                     are advertised in the capabilities document.
+                     For example, the value WKB may be used to indicate that a 
+                     Well Known Binary format be used to encode the output.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="maxFeatures"
+                           type="xsd:positiveInteger" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The maxFeatures attribute is used to specify the maximum
+                     number of features that a GetFeature operation should
+                     generate (regardless of the actual number of query hits).
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="traverseXlinkDepth"
+                           type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     This attribute indicates the depth to which nested property
+                     XLink linking element locator attribute (href) XLinks are
+                     traversed and resolved if possible.  A value of "1"
+                     indicates that one linking element locator attribute
+                     (href) Xlink will be traversed and the referenced element
+                     returned if possible, but nested property XLink linking
+                     element locator attribute (href) XLinks in the returned
+                     element are not traversed.  A value of "*" indicates that
+                     all nested property XLink linking element locator attribute
+                     (href) XLinks will be traversed and the referenced elements
+                     returned if possible.  The range of valid values for this
+                     attribute consists of positive integers plus "*".
+                     If this attribute is not specified then no xlinks shall be 
+                     resolved and the value of traverseXlinkExpiry attribute (if
+                     it specified) may be ignored.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="traverseXlinkExpiry"
+                           type="xsd:positiveInteger"
+                           use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The traverseXlinkExpiry attribute value is specified in
+                     minutes.  It indicates how long a Web Feature Service
+                     should wait to receive a response to a nested GetGmlObject
+                     request.	
+                     This attribute is only relevant if a value is specified 
+                     for the traverseXlinkDepth attribute.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="ResultTypeType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="results">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Indicates that a complete response should be generated
+                  by the WFS.  That is, all response feature instances
+                  should be returned to the client.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="hits">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Indicates that an empty response should be generated with
+                  the "numberOfFeatures" attribute set (i.e. no feature
+                  instances should be returned).  In this manner a client may
+                  determine the number of feature instances that a GetFeature
+                  request will return without having to actually get the 
+                  entire result set back.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:element name="Query" type="wfs:QueryType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Query element is used to describe a single query.
+            One or more Query elements can be specified inside a
+            GetFeature element so that multiple queries can be 
+            executed in one request.  The output from the various
+            queries are combined in a wfs:FeatureCollection element
+            to form the response document.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="QueryType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Query element is of type QueryType.
+         </xsd:documentation>
+      </xsd:annotation>
+     <xsd:sequence>
+       <xsd:choice minOccurs="0" maxOccurs="unbounded">
+          <xsd:element ref="wfs:PropertyName">
+             <xsd:annotation>
+                <xsd:documentation>
+                   The Property element is used to specify one or more
+                   properties of a feature whose values are to be retrieved
+                   by a Web Feature Service.  
+                   
+                   While a Web Feature Service should endeavour to satisfy
+                   the exact request specified, in some instance this may
+                   not be possible.  Specifically, a Web Feature Service
+                   must generate a valid GML3 response to a Query operation.
+                   The schema used to generate the output may include 
+                   properties that are mandatory.  In order that the output
+                   validates, these mandatory properties must be specified
+                   in the request.  If they are not, a Web Feature Service
+                   may add them automatically to the Query before processing
+                   it.  Thus a client application should, in general, be
+                   prepared to receive more properties than it requested.
+   
+                   Of course, using the DescribeFeatureType request, a client
+                   application can determine which properties are mandatory
+                   and request them in the first place.
+                </xsd:documentation>
+             </xsd:annotation>
+          </xsd:element>
+          <xsd:element ref="wfs:XlinkPropertyName"/>
+          <xsd:element ref="ogc:Function">
+             <xsd:annotation>
+                <xsd:documentation>
+                   A function may be used as a select item in a query.
+                   However, if a function is used, care must be taken
+                   to ensure that the result type matches the type in the 
+ 
+                </xsd:documentation>
+             </xsd:annotation>
+          </xsd:element>
+       </xsd:choice>
+       <xsd:element ref="ogc:Filter" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+             <xsd:documentation>
+                The Filter element is used to define spatial and/or non-spatial
+                constraints on query.  Spatial constrains use GML3 to specify
+                the constraining geometry.  A full description of the Filter
+                element can be found in the Filter Encoding Implementation
+                Specification.
+             </xsd:documentation>
+          </xsd:annotation>
+       </xsd:element>
+       <xsd:element ref="ogc:SortBy" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+             <xsd:documentation>
+                The SortBy element is used specify property names whose
+                values should be used to order (upon presentation) the
+                set of feature instances that satisfy the query.
+             </xsd:documentation>
+          </xsd:annotation>
+       </xsd:element>
+     </xsd:sequence>
+     <xsd:attribute name="handle"
+                    type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The handle attribute allows a client application
+               to assign a client-generated identifier for the 
+               Query.  The handle is included to facilitate error
+               reporting.  If one Query in a GetFeature request
+               causes an exception, a WFS may report the handle
+               to indicate which query element failed.  If the a
+               handle is not present, the WFS may use other means
+               to localize the error (e.g. line numbers).
+            </xsd:documentation>
+         </xsd:annotation>
+     </xsd:attribute>
+     <xsd:attribute name="typeName"
+                    type="wfs:TypeNameListType" use="required">
+        <xsd:annotation>
+           <xsd:documentation>
+              The typeName attribute is a list of one or more
+              feature type names that indicate which types 
+              of feature instances should be included in the
+              reponse set.  Specifying more than one typename
+              indicates that a join operation is being performed.
+              All the names in the typeName list must be valid
+              types that belong to this query's feature content
+              as defined by the GML Application Schema.
+           </xsd:documentation>
+        </xsd:annotation>
+     </xsd:attribute>
+     <xsd:attribute name="featureVersion"
+                    type="xsd:string" use="optional">
+        <xsd:annotation>
+           <xsd:documentation>
+              For systems that implement versioning, the featureVersion
+              attribute is used to specify which version of a particular
+              feature instance is to be retrieved.  A value of ALL means
+              that all versions should be retrieved.  An integer value
+              'i', means that the ith version should be retrieve if it
+              exists or the most recent version otherwise.
+           </xsd:documentation>
+        </xsd:annotation>
+     </xsd:attribute>
+     <xsd:attribute name="srsName" type="xsd:anyURI" use="optional">
+        <xsd:annotation>
+           <xsd:documentation>
+              This attribute is used to specify a specific WFS-supported SRS
+              that should be used for returned feature geometries.  The value
+              may be the WFS StorageSRS value, DefaultRetrievalSRS value, or
+              one of AdditionalSRS values.  If no srsName value is supplied,
+              then the features will be returned using either the
+              DefaultRetrievalSRS, if specified, and StorageSRS otherwise.
+              For feature types with no spatial properties, this attribute
+              must not be specified or ignored if it is specified.
+           </xsd:documentation>
+        </xsd:annotation>
+     </xsd:attribute>
+   </xsd:complexType>
+   <xsd:simpleType name="Base_TypeNameListType">
+      <xsd:list itemType="xsd:QName"/>
+   </xsd:simpleType>
+   <xsd:simpleType name="TypeNameListType">
+      <xsd:restriction base="wfs:Base_TypeNameListType">
+         <xsd:pattern value="((\w:)?\w(=\w)?){1,}">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Example typeName attribute value might be:
+
+                     typeName="ns1:Inwatera_1m=A, ns2:CoastL_1M=B"
+
+                  In this example, A is an alias for ns1:Inwatera_1m
+                  and B is an alias for ns2:CoastL_1M.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:pattern>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <!-- RESPONSE -->
+   <xsd:element name="FeatureCollection"
+                type="wfs:FeatureCollectionType"
+                substitutionGroup="gml:_FeatureCollection">
+      <xsd:annotation>
+         <xsd:documentation>
+            This element is a container for the response to a GetFeature
+            or GetFeatureWithLock (WFS-transaction.xsd) request.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="FeatureCollectionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This type defines a container for the response to a 
+            GetFeature or GetFeatureWithLock request.  If the
+            request is GetFeatureWithLock, the lockId attribute
+            must be populated.  The lockId attribute can otherwise
+            be safely ignored.
+         </xsd:documentation>
+      </xsd:annotation>
+     <xsd:complexContent>
+       <xsd:extension base="gml:AbstractFeatureCollectionType">
+         <xsd:attribute name="lockId" type="xsd:string" use="optional">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The value of the lockId attribute is an identifier
+                  that a Web Feature Service generates when responding
+                  to a GetFeatureWithLock request.  A client application
+                  can use this value in subsequent operations (such as a
+                  Transaction request) to reference the set of locked
+                  features.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+         <xsd:attribute name="timeStamp" type="xsd:dateTime" use="optional">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The timeStamp attribute should contain the date and time
+                  that the response was generated.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+         <xsd:attribute name="numberOfFeatures"
+                        type="xsd:nonNegativeInteger"
+                        use="optional">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The numberOfFeatures attribute should contain a
+                  count of the number of features in the response.
+                  That is a count of all features elements dervied
+                  from gml:AbstractFeatureType.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+       </xsd:extension>
+     </xsd:complexContent>
+   </xsd:complexType>
+
+   <!-- ================================================================== -->
+   <!-- =   GETGMLOBJECT Request and Response                            = -->
+   <!-- ================================================================== -->
+   <xsd:element name="GetGmlObject" type="wfs:GetGmlObjectType"> 
+      <xsd:annotation>
+         <xsd:documentation>
+            The GetGmlObject element is used to request that a Web Feature
+            Service return an element with a gml:id attribute value specified
+            by an ogc:GmlObjectId.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="GetGmlObjectType">
+      <xsd:annotation>
+         <xsd:documentation>
+            A GetGmlObjectType element contains exactly one GmlObjectId.  
+            The value of the gml:id attribute on that GmlObjectId is used 
+            as a unique key to retrieve the complex element with a 
+            gml:id attribute with the same value.  
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element ref="ogc:GmlObjectId"/>
+            </xsd:sequence>
+            <xsd:attribute name="outputFormat"
+                           type="xsd:string" use="optional" default="GML3"/>
+            <xsd:attribute name="traverseXlinkDepth" 
+                           type="xsd:string" use="required">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     This attribute indicates the depth to which nested
+                     property XLink linking element locator attribute
+                     (href) XLinks are traversed and resolved if possible.
+                     A value of "1" indicates that one linking element
+                     locator attribute (href) XLink will be traversed
+                     and the referenced element returned if possible, but
+                     nested property XLink linking element locator attribute
+                     (href) XLinks in the returned element are not traversed.
+                     A value of "*" indicates that all nested property XLink
+                     linking element locator attribute (href) XLinks will be
+                     traversed and the referenced elements returned if
+                     possible.  The range of valid values for this attribute
+                     consists of positive integers plus "*".
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="traverseXlinkExpiry"
+                           type="xsd:positiveInteger"
+                           use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The traverseXlinkExpiry attribute value is specified
+                     in minutes.  It indicates how long a Web Feature Service
+                     should wait to receive a response to a nested GetGmlObject
+                     request.	
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <!-- ================================================================= -->
+   <!-- The response to a GetGMLObject request is a GML3 fragment(s) that -->
+   <!-- has (have) the gml:id('s) specified in the request.               -->
+   <!-- ================================================================= -->
+
+   <!-- ================================================================== -->
+   <!-- =   GETFEATUREWITHLOCK Request and Response                      = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="GetFeatureWithLock" type="wfs:GetFeatureWithLockType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This is the root element for the GetFeatureWithLock request.
+            The GetFeatureWithLock operation performs identically to a
+            GetFeature request except that the GetFeatureWithLock request
+            locks all the feature instances in the result set and returns
+            a lock identifier to a client application in the response.
+            The lock identifier is returned to the client application 
+            using the lockId attribute define on the wfs:FeatureCollection
+            element.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="GetFeatureWithLockType">
+      <xsd:annotation>
+         <xsd:documentation>
+            A GetFeatureWithLock request operates identically to a
+            GetFeature request expect that it attempts to lock the
+            feature instances in the result set and includes a lock
+            identifier in its response to a client.  A lock identifier
+            is an identifier generated by a Web Feature Service that 
+            a client application can use, in subsequent operations,
+            to reference the locked set of feature instances.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element ref="wfs:Query" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="expiry"
+                           type="xsd:positiveInteger"
+                           use="optional" default="5">  
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The expiry attribute is used to set the length
+                     of time (expressed in minutes) that features will
+                     remain locked as a result of a GetFeatureWithLock
+                     request.  After the expiry period elapses, the
+                     locked resources must be released.  If the 
+                     expiry attribute is not set, then the default
+                     value of 5 minutes will be enforced.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="resultType"
+                           type="wfs:ResultTypeType" use="optional"
+                           default="results">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     See definition of wfs:GetFeatureType.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="outputFormat"
+                           type="xsd:string" use="optional"
+                           default="text/xml; subtype=gml/3.1.1">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     See definition of wfs:GetFeatureType.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="maxFeatures"
+                           type="xsd:positiveInteger" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     See definition of wfs:GetFeatureType.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="traverseXlinkDepth"
+                           type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     See definition of wfs:GetFeatureType.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="traverseXlinkExpiry"
+                           type="xsd:positiveInteger" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     See definition of wfs:GetFeatureType.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+
+   <!-- ================================================================== -->
+   <!-- =   LOCKFEATURE Request and Response                             = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="LockFeature" type="wfs:LockFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This is the root element for a LockFeature request.
+            The LockFeature request can be used to lock one or
+            more feature instances.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="LockFeatureType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This type defines the LockFeature operation.  The LockFeature
+            element contains one or more Lock elements that define which
+            features of a particular type should be locked.  A lock
+            identifier (lockId) is returned to the client application which
+            can be used by subsequent operations to reference the locked
+            features.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element name="Lock" type="wfs:LockType"
+                            maxOccurs="unbounded">
+                  <xsd:annotation>
+                     <xsd:documentation>
+                        The lock element is used to indicate which feature 
+                        instances of particular type are to be locked.
+                     </xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="expiry"
+                           type="xsd:positiveInteger"
+                           use="optional" default="5">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The expiry attribute is used to set the length
+                     of time (expressed in minutes) that features will
+                     remain locked as a result of a LockFeature
+                     request.  After the expiry period elapses, the
+                     locked resources must be released.  If the 
+                     expiry attribute is not set, then the default
+                     value of 5 minutes will be enforced.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="lockAction"
+                           type="wfs:AllSomeType"
+                           use="optional" default="ALL">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The lockAction attribute is used to indicate what
+                     a Web Feature Service should do when it encounters
+                     a feature instance that has already been locked by
+                     another client application.
+      
+                     Valid values are ALL or SOME.
+      
+                     ALL means that the Web Feature Service must acquire
+                     locks on all the requested feature instances.  If it
+                     cannot acquire those locks then the request should
+                     fail.  In this instance, all locks acquired by the
+                     operation should be released.
+       
+                     SOME means that the Web Feature Service should lock
+                     as many of the requested features as it can.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="AllSomeType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="ALL"/>
+         <xsd:enumeration value="SOME"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="LockType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This type defines the Lock element.  The Lock element
+            defines a locking operation on feature instances of 
+            a single type. An OGC Filter is used to constrain the
+            scope of the operation.  Features to be locked can be
+            identified individually by using their feature identifier
+            or they can be locked by satisfying the spatial and 
+            non-spatial constraints defined in the filter.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="ogc:Filter" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The handle attribute allows a client application
+               to assign a client-generated request identifier
+               to a Lock action.  The handle is included to 
+               facilitate error reporting.  If one of a set of
+               Lock actions failed while processing a LockFeature
+               request, a WFS may report the handle in an exception
+               report to localize the error.  If a handle is not
+               present then a WFS may employ some other means of 
+               localizing the error (e.g. line number).
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="typeName" type="xsd:QName" use="required">
+        <xsd:annotation>
+           <xsd:documentation>
+              The value of the typeName attribute is the name 
+              of the feature type to be updated. The name
+              specified must be a valid type that belongs to
+              the feature content as defined by the GML
+              Application Schema.
+           </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <xsd:element name="LockFeatureResponse"
+                type="wfs:LockFeatureResponseType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The LockFeatureResponse element contains a report
+            about the completion status of a LockFeature request.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="LockFeatureResponseType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The LockFeatureResponseType is used to define an
+            element to contains the response to a LockFeature
+            operation.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="wfs:LockId">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The LockFeatureResponse includes a LockId element
+                  that contains a lock identifier.  The lock identifier
+                  can be used by a client, in subsequent operations, to
+                  operate upon the locked feature instances.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="FeaturesLocked"
+                      type="wfs:FeaturesLockedType" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The LockFeature or GetFeatureWithLock operations
+                  identify and attempt to lock a set of feature 
+                  instances that satisfy the constraints specified 
+                  in the request.  In the event that the lockAction
+                  attribute (on the LockFeature or GetFeatureWithLock
+                  elements) is set to SOME, a Web Feature Service will
+                  attempt to lock as many of the feature instances from
+                  the result set as possible.
+
+                  The FeaturesLocked element contains list of ogc:FeatureId
+                  elements enumerating the feature instances that a WFS
+                  actually managed to lock.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="FeaturesNotLocked"
+                      type="wfs:FeaturesNotLockedType" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  In contrast to the FeaturesLocked element, the
+                  FeaturesNotLocked element contains a list of 
+                  ogc:Filter elements identifying feature instances
+                  that a WFS did not manage to lock because they were
+                  already locked by another process.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeaturesLockedType">
+     <xsd:sequence maxOccurs="unbounded">
+       <xsd:element ref="ogc:FeatureId"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeaturesNotLockedType">
+     <xsd:sequence maxOccurs="unbounded">
+       <xsd:element ref="ogc:FeatureId"/>
+     </xsd:sequence>
+   </xsd:complexType>
+
+   <!-- ================================================================== -->
+   <!-- =   TRANSACTION Request and Response                             = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="Transaction" type="wfs:TransactionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            This is the root element for a Transaction request.
+            A transaction request allows insert, update and 
+            delete operations to be performed to create, change
+            or remove feature instances.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="TransactionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The TransactionType defines the Transaction operation.  A
+            Transaction element contains one or more Insert, Update
+            Delete and Native elements that allow a client application
+            to create, modify or remove feature instances from the 
+            feature repository that a Web Feature Service controls.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element ref="wfs:LockId" minOccurs="0">
+                  <xsd:annotation>
+                     <xsd:documentation>
+                        In order for a client application to operate upon
+                        locked feature instances, the Transaction request
+                        must include the LockId element.  The content of
+                        this element must be the lock identifier the client
+                        application obtained from a previous
+                        GetFeatureWithLock or LockFeature operation.
+
+                        If the correct lock identifier is specified the Web
+                        Feature Service knows that the client application may
+                        operate upon the locked feature instances.
+
+                        No LockId element needs to be specified to operate upon
+                        unlocked features.
+                     </xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                  <xsd:element ref="wfs:Insert"/>
+                  <xsd:element ref="wfs:Update"/>
+                  <xsd:element ref="wfs:Delete"/>
+                  <xsd:element ref="wfs:Native"/>
+               </xsd:choice>
+            </xsd:sequence>
+            <xsd:attribute name="releaseAction"
+                           type="wfs:AllSomeType" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The releaseAction attribute is used to control how a Web
+                     Feature service releases locks on feature instances after
+                     a Transaction request has been processed.
+
+                     Valid values are ALL or SOME.
+
+                     A value of ALL means that the Web Feature Service should
+                     release the locks of all feature instances locked with the
+                     specified lockId regardless or whether or not the features
+                     were actually modified.
+
+                     A value of SOME means that the Web Feature Service will 
+                     only release the locks held on feature instances that 
+                     were actually operated upon by the transaction.  The
+                     lockId that the client application obtained shall remain
+                     valid and the other, unmodified, feature instances shall
+                     remain locked.
+                    
+                     If the expiry attribute was specified in the original
+                     operation that locked the feature instances, then the
+                     expiry counter will be reset to give the client
+                     application that same amount of time to post subsequent
+                     transactions against the locked features.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="LockId" type="xsd:string">
+      <xsd:annotation>
+         <xsd:documentation>
+            The LockId element contains the value of the lock identifier
+            obtained by a client application from a previous GetFeatureWithLock
+            or LockFeature request.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="Insert" type="wfs:InsertElementType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Insert element is used to indicate that the Web Feature
+            Service should create a new instance of a feature type.  The
+            feature instance is specified using GML3 and one or more 
+            feature instances to be created can be contained inside the
+            Insert element.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="InsertElementType">
+      <xsd:annotation>
+         <xsd:documentation>
+            An Insert element may contain a feature collection or one 
+            or more feature instances to be inserted into the 
+            repository.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element ref="gml:_Feature" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="idgen"
+                     type="wfs:IdentifierGenerationOptionType" 
+                     use="optional" default="GenerateNew">
+         <xsd:annotation>
+            <xsd:documentation>
+               The idgen attribute control how a WFS generates identifiers
+               from newly created feature instances using the Insert action.
+               The default action is to have the WFS generate a new id for
+               the features.  This is also backward compatible with WFS 1.0
+               where the only action was for the WFS to generate an new id.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="handle" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The handle attribute allows a client application
+               to assign a client-generated request identifier
+               to an Insert action.  The handle is included to
+               facilitate error reporting.  If an Insert action
+               in a Transaction request fails, then a WFS may
+               include the handle in an exception report to localize
+               the error.  If no handle is included of the offending
+               Insert element then a WFS may employee other means of
+               localizing the error (e.g. line number).
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="inputFormat" type="xsd:string"
+                     use="optional" default="text/xml; subtype=gml/3.1.1">
+         <xsd:annotation>
+            <xsd:documentation>
+               This inputFormat attribute is used to indicate 
+               the format used to encode a feature instance in
+               an Insert element.  The default value of
+               'text/xml; subtype=gml/3.1.1' is used to indicate
+               that feature encoding is GML3.  Another example
+               might be 'text/xml; subtype=gml/2.1.2' indicating
+               that the feature us encoded in GML2.  A WFS must
+               declare in the capabilities document, using a 
+               Parameter element, which version of GML it supports.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="srsName" type="xsd:anyURI" use="optional">
+        <xsd:annotation>
+           <xsd:documentation>
+              ===== PAV 12NOV2004 ====
+              WHY IS THIS HERE? WOULDN'T WE KNOW THE INCOMING SRS FROM THE 
+              GML GEOMETRY ELEMENTS?   I ASSUME THAT IF THE INCOMING SRS
+              DOES NOT MATCH ONE OF THE STORAGE SRS(s) THEN THE WFS WOULD
+              EITHER PROJECT INTO THE STORAGE SRS OR RAISE AN EXCEPTION.
+           </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:simpleType name="IdentifierGenerationOptionType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="UseExisting">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The UseExsiting value indicates that WFS should not
+                  generate a new feature identifier for the feature
+                  being inserted into the repositry.  Instead, the WFS
+                  should use the identifier encoded if the feature.  
+                  If a duplicate exists then the WFS should raise an
+                  exception.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="ReplaceDuplicate">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The ReplaceDuplicate value indicates that WFS should
+                  not generate a new feature identifier for the feature
+                  being inserted into the repositry.  Instead, the WFS
+                  should use the identifier encoded if the feature.  
+                  If a duplicate exists then the WFS should replace the
+                  existing feature instance with the one encoded in the
+                  Insert action.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="GenerateNew">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The GenerateNew value indicates that WFS should
+                  generate a new unique feature identifier for the
+                  feature being inserted into the repositry.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:element name="Update" type="wfs:UpdateElementType">
+      <xsd:annotation>
+         <xsd:documentation>
+            One or more existing feature instances can be changed by
+            using the Update element.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="UpdateElementType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:Property" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Changing or updating a feature instance means that
+                  the current value of one or more properties of
+                  the feature are replaced with new values.  The Update
+                  element contains  one or more Property elements.  A
+                  Property element contains the name or a feature property
+                  who's value is to be changed and the replacement value
+                  for that property.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element ref="ogc:Filter" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Filter element is used to constrain the scope
+                  of the update operation to those features identified
+                  by the filter.  Feature instances can be specified
+                  explicitly and individually using the identifier of
+                  each feature instance OR a set of features to be
+                  operated on can be identified by specifying spatial
+                  and non-spatial constraints in the filter.
+                  If no filter is specified then update operation 
+                  applies to all feature instances.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The handle attribute allows a client application
+               to assign a client-generated request identifier
+               to an Insert action.  The handle is included to
+               facilitate error reporting.  If an Update action
+               in a Transaction request fails, then a WFS may
+               include the handle in an exception report to localize
+               the error.  If no handle is included of the offending
+               Insert element then a WFS may employee other means of
+               localizing the error (e.g. line number).
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="typeName" type="xsd:QName" use="required">
+        <xsd:annotation>
+           <xsd:documentation>
+              The value of the typeName attribute is the name 
+              of the feature type to be updated. The name
+              specified must be a valid type that belongs to
+              the feature content as defined by the GML
+              Application Schema.
+           </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="inputFormat" type="xsd:string"
+                     use="optional" default="x-application/gml:3">
+         <xsd:annotation>
+            <xsd:documentation>
+               This inputFormat attribute is used to indicate 
+               the format used to encode a feature instance in
+               an Insert element.  The default value of
+               'text/xml; subtype=gml/3.1.1' is used to indicate
+               that feature encoding is GML3.  Another example
+               might be 'text/xml; subtype=gml/2.1.2' indicating
+               that the feature us encoded in GML2.  A WFS must
+               declare in the capabilities document, using a 
+               Parameter element, which version of GML it supports.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="srsName" type="xsd:anyURI" use="optional">
+        <xsd:annotation>
+           <xsd:documentation>
+               DO WE NEED THIS HERE?
+           </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:element name="Property" type="wfs:PropertyType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Property element is used to specify the new
+            value of a feature property inside an Update
+            element.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="PropertyType">
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:QName">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Name element contains the name of a feature property
+                  to be updated.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="Value" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Value element contains the replacement value for the
+                  named property.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="Delete" type="wfs:DeleteElementType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The Delete element is used to indicate that one or more
+            feature instances should be removed from the feature
+            repository.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="DeleteElementType">
+      <xsd:sequence>
+         <xsd:element ref="ogc:Filter" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Filter element is used to constrain the scope
+                  of the delete operation to those features identified
+                  by the filter.  Feature instances can be specified
+                  explicitly and individually using the identifier of
+                  each feature instance OR a set of features to be
+                  operated on can be identified by specifying spatial
+                  and non-spatial constraints in the filter.
+                  If no filter is specified then an exception should
+                  be raised since it is unlikely that a client application
+                  intends to delete all feature instances.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The handle attribute allows a client application
+               to assign a client-generated request identifier
+               to an Insert action.  The handle is included to
+               facilitate error reporting.  If a Delete action
+               in a Transaction request fails, then a WFS may
+               include the handle in an exception report to localize
+               the error.  If no handle is included of the offending
+               Insert element then a WFS may employee other means of
+               localizing the error (e.g. line number).
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="typeName" type="xsd:QName" use="required">
+        <xsd:annotation>
+           <xsd:documentation>
+              The value of the typeName attribute is the name 
+              of the feature type to be updated. The name
+              specified must be a valid type that belongs to
+              the feature content as defined by the GML
+              Application Schema.
+           </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:element name="Native" type="wfs:NativeType">
+      <xsd:annotation>
+         <xsd:documentation>
+            Many times, a Web Feature Service interacts with a repository
+            that may have special vendor specific capabilities.  The native
+            element allows vendor specific command to be passed to the
+            repository via the Web Feature Service.
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="NativeType">
+      <xsd:attribute name="vendorId" type="xsd:string" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               The vendorId attribute is used to specify the name of
+               vendor who's vendor specific command the client
+               application wishes to execute.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="safeToIgnore" type="xsd:boolean" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               In the event that a Web Feature Service does not recognize
+               the vendorId or does not recognize the vendor specific command,
+               the safeToIgnore attribute is used to indicate whether the 
+               exception can be safely ignored.  A value of TRUE means that
+               the Web Feature Service may ignore the command.  A value of
+               FALSE means that a Web Feature Service cannot ignore the
+               command and an exception should be raised if a problem is 
+               encountered.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <!-- REPONSE -->
+   <xsd:element name="TransactionResponse"
+                type="wfs:TransactionResponseType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The TransactionResponse element contains a report
+            about the completion status of a Transaction operation.  
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
+   <xsd:complexType name="TransactionResponseType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            The response for a transaction request that was successfully
+            completed. If the transaction failed for any reason, an
+            exception report is returned instead.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="TransactionSummary"
+                      type="wfs:TransactionSummaryType">
+            <xsd:annotation>
+               <xsd:documentation xml:lang="en">
+                  The TransactionSummary element is used to summarize
+                  the number of feature instances affected by the 
+                  transaction.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="TransactionResults"
+                      type="wfs:TransactionResultsType"
+                      minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation xml:lang="en">
+                  For systems that do not support atomic transactions,
+                  the TransactionResults element may be used to report
+                  exception codes and messages for all actions of a
+                  transaction that failed to execute successfully.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="InsertResults"
+                      type="wfs:InsertResultsType"
+                      minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation xml:lang="en">
+                  A transaction is a collection of Insert,Update and Delete
+                  actions.  The Update and Delete actions modify features
+                  that already exist.  The Insert action, however, creates
+                  new features.  The InsertResults element is used to
+                  report the identifiers of the newly created features.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="xsd:string" use="required" fixed="1.1.0">
+         <xsd:annotation>
+            <xsd:documentation>
+               The version attribute contains the version of the request
+               that generated this response.  So a V1.1.0 transaction
+               request generates a V1.1.0 transaction response.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionSummaryType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            Reports the total number of features affected by some kind 
+            of write action (i.e, insert, update, delete).
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="totalInserted"
+                      type="xsd:nonNegativeInteger"
+                      minOccurs="0"/>
+         <xsd:element name="totalUpdated"
+                      type="xsd:nonNegativeInteger"
+                      minOccurs="0"/>
+         <xsd:element name="totalDeleted"
+                      type="xsd:nonNegativeInteger"
+                      minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionResultsType">
+      <xsd:annotation>
+         <xsd:documentation>
+            The TransactionResults element may be used to report exception
+            codes and messages for all actions of a transaction that failed
+            to complete successfully.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="Action" type="wfs:ActionType"
+                      minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Action element reports an exception code
+                  and exception message indicating why the
+                  corresponding action of a transaction request
+                  failed.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ActionType">
+      <xsd:sequence>
+         <xsd:element name="Message" type="xsd:string"
+                      minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  If an action fails, the message element may be used
+                  to supply an exception message.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="locator" type="xsd:string" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               The locator attribute is used to locate an action 
+               within a &lt;Transaction&gt; element.  The value
+               of the locator attribute is either a string that
+               is equal to the value of the handle attribute
+               specified on an  &lt;Insert&gt;, &lt;Update&gt;
+               or &lt;Delete&gt; action.  If a value is not 
+               specified for the handle attribute then a WFS 
+               may employ some other means of locating the 
+               action.  For example, the value of the locator
+               attribute may be an integer indicating the order
+               of the action (i.e. 1=First action, 2=Second action,
+               etc.).
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="code" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               The code attribute may be used to specify an 
+               exception code indicating why an action failed.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+   <xsd:complexType name="InsertResultsType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            Reports the list of identifiers of all features created 
+            by a transaction request.  New features are created using
+            the Insert action and the list of idetifiers must be 
+            presented in the same order as the Insert actions were
+            encountered in the transaction request.  Features may
+            optionally be correlated with identifiers using the 
+            handle attribute (if it was specified on the Insert 
+            element).
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="Feature"
+                      type="wfs:InsertedFeatureType"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InsertedFeatureType">
+      <xsd:sequence>
+         <xsd:element ref="ogc:FeatureId" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation xml:lang="en">
+                  This is the feature identifier for the newly created
+                  feature.  The feature identifier may be generated by
+                  the WFS or provided by the client (depending on the 
+                  value of the idgen attribute).  In all cases of idgen
+                  values, the feature id must be reported here.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+               If the insert element that generated this feature 
+               had a value for the "handle" attribute then a WFS
+               may report it using this attribute to correlate
+               the feature created with the action that created it.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+</xsd:schema>

--- a/core/src/main/resources/net/opengis/schemas/wfs/2.0/wfs.xsd
+++ b/core/src/main/resources/net/opengis/schemas/wfs/2.0/wfs.xsd
@@ -1,0 +1,786 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   targetNamespace="http://www.opengis.net/wfs/2.0"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:fes="http://www.opengis.net/fes/2.0"
+   xmlns:ows="http://www.opengis.net/ows/1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:xml="http://www.w3.org/XML/1998/namespace"
+   elementFormDefault="qualified" version="2.0.2">
+   <xsd:annotation>
+      <xsd:documentation>This XML Schema Document includes and imports, 
+      directly or indirectly, all the XML Schemas defined by the 
+      Web Feature Service (WFS) Implementation Specification.
+
+      WFS is an OGC Standard.
+      Copyright (c) 2010, 2014 Open Geospatial Consortium.
+      To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .     
+      </xsd:documentation>
+   </xsd:annotation>
+   <!-- ==============================================================
+        Includes and Imports
+        ============================================================== -->
+   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+   <xsd:import namespace="http://www.w3.org/1999/xlink"
+      schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/ows/1.1"
+      schemaLocation="http://schemas.opengis.net/ows/1.1.0/owsAll.xsd"/>
+   <xsd:import namespace="http://www.opengis.net/fes/2.0"
+      schemaLocation="http://schemas.opengis.net/filter/2.0/filterAll.xsd"/>
+   <!-- ================================================================== -->
+   <!-- =   BASE REQUEST TYPE                                            = -->
+   <!-- ================================================================== -->
+   <xsd:complexType name="BaseRequestType" abstract="true">
+      <xsd:attribute name="service"
+                     type="xsd:string" use="required" fixed="WFS"/>
+      <xsd:attribute name="version" type="wfs:VersionStringType"
+         use="required"/>
+      <xsd:attribute name="handle" type="xsd:string"/>
+   </xsd:complexType>
+   <xsd:simpleType name="VersionStringType">
+      <xsd:restriction base="xsd:string">
+         <xsd:pattern value="2\.0\.\d+"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <!-- ================================================================== -->
+   <!-- =   STANDARD QUERY PARAMETERS                                    = -->
+   <!-- ================================================================== -->
+   <xsd:attributeGroup name="StandardPresentationParameters">
+      <xsd:attribute name="startIndex"
+                     type="xsd:nonNegativeInteger" default="0"/>
+      <xsd:attribute name="count" type="xsd:nonNegativeInteger"/>
+      <xsd:attribute name="resultType" type="wfs:ResultTypeType"
+         default="results"/>
+      <xsd:attribute name="outputFormat" type="xsd:string"
+         default="application/gml+xml; version=3.2"/>
+   </xsd:attributeGroup>
+   <xsd:simpleType name="ResultTypeType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="results"/>
+         <xsd:enumeration value="hits"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <!-- ================================================================== -->
+   <!-- =   RESOLVE PARAMETERS                                           = -->
+   <!-- ================================================================== -->
+   <xsd:attributeGroup name="StandardResolveParameters">
+      <xsd:attribute name="resolve" type="wfs:ResolveValueType" default="none"/>
+      <xsd:attribute name="resolveDepth" type="wfs:positiveIntegerWithStar"
+         default="*"/>
+      <xsd:attribute name="resolveTimeout" type="xsd:positiveInteger"
+         default="300"/>
+   </xsd:attributeGroup>
+   <xsd:simpleType name="ResolveValueType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="local"/>
+         <xsd:enumeration value="remote"/>
+         <xsd:enumeration value="all"/>
+         <xsd:enumeration value="none"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="positiveIntegerWithStar">
+      <xsd:union memberTypes="xsd:positiveInteger wfs:StarStringType"/>
+   </xsd:simpleType>
+   <xsd:simpleType name="StarStringType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="*"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <!-- ================================================================== -->
+   <!-- =   STANDARD FEATURE INPUT PARAMETERS                            = -->
+   <!-- ================================================================== -->
+   <xsd:attributeGroup name="StandardInputParameters">
+      <xsd:attribute name="inputFormat" type="xsd:string"
+         default="application/gml+xml; version=3.2"/>
+      <xsd:attribute name="srsName" type="xsd:anyURI"/>
+   </xsd:attributeGroup>
+   <!-- ================================================================== -->
+   <!-- =   RESPONSE METADATA                                            = -->
+   <!-- ================================================================== -->
+   <xsd:attributeGroup name="StandardResponseParameters">
+      <xsd:attribute name="timeStamp" type="xsd:dateTime" use="required"/>
+      <xsd:attribute name="numberMatched" type="wfs:nonNegativeIntegerOrUnknown"
+         use="required"/>
+      <xsd:attribute name="numberReturned" type="xsd:nonNegativeInteger"
+         use="required"/>
+      <xsd:attribute name="next" type="xsd:anyURI"/>
+      <xsd:attribute name="previous" type="xsd:anyURI"/>
+   </xsd:attributeGroup>
+   <xsd:simpleType name="nonNegativeIntegerOrUnknown">
+      <xsd:union>
+         <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+               <xsd:enumeration value="unknown"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType>
+            <xsd:restriction base="xsd:nonNegativeInteger"/>
+         </xsd:simpleType>
+      </xsd:union>
+   </xsd:simpleType>
+   <!-- ================================================================== -->
+   <!-- =   COMMON FEATURE METADATA ELEMENTS                             = -->
+   <!-- ================================================================== -->
+   <xsd:element name="Title">
+      <xsd:complexType>
+         <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+               <xsd:attribute ref="xml:lang" default="en"/>
+            </xsd:extension>
+         </xsd:simpleContent>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="Abstract">
+      <xsd:complexType>
+         <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+               <xsd:attribute ref="xml:lang" default="en"/>
+            </xsd:extension>
+         </xsd:simpleContent>
+      </xsd:complexType>
+   </xsd:element>
+   <!-- ================================================================== -->
+   <!-- =   QUERY ELEMENTS                                               = -->
+   <!-- ================================================================== -->
+   <!-- === ADHOC QUERY ================================================== -->
+   <xsd:element name="Query" type="wfs:QueryType"
+      substitutionGroup="fes:AbstractAdhocQueryExpression"/>
+   <xsd:complexType name="QueryType">
+      <xsd:complexContent>
+         <xsd:extension base="fes:AbstractAdhocQueryExpressionType">
+            <xsd:attribute name="srsName" type="xsd:anyURI"/>
+            <xsd:attribute name="featureVersion" type="xsd:string"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- === STORED QUERY ================================================= -->
+   <xsd:element name="StoredQuery" type="wfs:StoredQueryType"
+      substitutionGroup="fes:AbstractQueryExpression"/>
+   <xsd:complexType name="StoredQueryType">
+      <xsd:complexContent>
+         <xsd:extension base="fes:AbstractQueryExpressionType">
+            <xsd:sequence>
+               <xsd:element name="Parameter" type="wfs:ParameterType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="id" type="xsd:anyURI" use="required"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParameterType" mixed="true">
+      <xsd:sequence>
+         <xsd:any namespace="##other" processContents="lax" minOccurs="0"
+            maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+   </xsd:complexType>
+   <!-- ================================================================== -->
+   <!-- =   GETCAPABILITIES Request and Response                         = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="GetCapabilities" type="wfs:GetCapabilitiesType"/>
+   <xsd:complexType name="GetCapabilitiesType">
+      <xsd:complexContent>
+         <xsd:extension base="ows:GetCapabilitiesType">
+            <xsd:attribute name="service" type="ows:ServiceType" use="required"
+               fixed="WFS"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <xsd:element name="WFS_Capabilities" type="wfs:WFS_CapabilitiesType"/>
+   <xsd:complexType name="WFS_CapabilitiesType">
+      <xsd:complexContent>
+         <xsd:extension base="ows:CapabilitiesBaseType">
+            <xsd:sequence>
+               <xsd:element name="WSDL" minOccurs="0">
+                  <xsd:complexType>
+                     <xsd:complexContent>
+                        <xsd:restriction base="xsd:anyType">
+                           <xsd:attributeGroup ref="xlink:simpleAttrs"/>
+                        </xsd:restriction>
+                     </xsd:complexContent>
+                  </xsd:complexType>
+               </xsd:element>
+               <xsd:element ref="wfs:FeatureTypeList" minOccurs="0"/>
+               <xsd:element ref="fes:Filter_Capabilities" minOccurs="0"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="FeatureTypeList" type="wfs:FeatureTypeListType"/>
+   <xsd:complexType name="FeatureTypeListType">
+      <xsd:sequence>
+         <xsd:element name="FeatureType" type="wfs:FeatureTypeType"
+            maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeatureTypeType">
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:QName"/>
+         <xsd:element ref="wfs:Title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="wfs:Abstract" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="ows:Keywords" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice>
+            <xsd:sequence>
+               <xsd:element name="DefaultCRS" type="xsd:anyURI"/>
+               <xsd:element name="OtherCRS" type="xsd:anyURI" minOccurs="0"
+                  maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:element name="NoCRS">
+               <xsd:complexType/>
+            </xsd:element>
+         </xsd:choice>
+         <xsd:element name="OutputFormats" type="wfs:OutputFormatListType"
+            minOccurs="0"/>
+         <xsd:element ref="ows:WGS84BoundingBox" minOccurs="0"
+            maxOccurs="unbounded"/>
+         <xsd:element name="MetadataURL" type="wfs:MetadataURLType"
+            minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="ExtendedDescription"
+            type="wfs:ExtendedDescriptionType" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OutputFormatListType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element name="Format" type="xsd:string"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MetadataURLType">
+      <xsd:attributeGroup ref="xlink:simpleAttrs"/>
+      <xsd:attribute name="about" type="xsd:anyURI"/>
+   </xsd:complexType>
+   <xsd:complexType name="ExtendedDescriptionType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:Element" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="Element" type="wfs:ElementType"/>
+   <xsd:complexType name="ElementType">
+      <xsd:sequence>
+         <xsd:element ref="ows:Metadata"/>
+         <xsd:element ref="wfs:ValueList"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="type" type="xsd:QName" use="required"/>
+   </xsd:complexType>
+   <xsd:element name="ValueList" type="wfs:ValueListType"/>
+   <xsd:complexType name="ValueListType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element ref="wfs:Value"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="Value" type="xsd:anyType"/>
+   <!-- ================================================================== -->
+   <!-- =   DESCRIBEFEATURETYPE Request and Response                     = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="DescribeFeatureType" type="wfs:DescribeFeatureTypeType"/>
+   <xsd:complexType name="DescribeFeatureTypeType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element name="TypeName" type="xsd:QName" minOccurs="0"
+                  maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="outputFormat" type="xsd:string"
+               default="application/gml+xml; version=3.2"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <!-- ================================================================== -->
+   <!-- For the outputFormat value of 'application/gml+xml; version=3.2'   -->
+   <!-- a WFS shall generate a valid XML-Schema/GML3 application schema    -->
+   <!-- that describes that requested feature type(s).                     -->
+   <!-- ================================================================== -->
+   <!-- ================================================================== -->
+   <!-- =   GETPROPERTYVALUE Request and Response                        = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="GetPropertyValue" type="wfs:GetPropertyValueType"/>
+   <xsd:complexType name="GetPropertyValueType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element ref="fes:AbstractQueryExpression"/>
+            </xsd:sequence>
+            <xsd:attribute name="valueReference" type="xsd:string"
+               use="required"/>
+            <xsd:attribute name="resolvePath" type="xsd:string"/>
+            <xsd:attributeGroup ref="wfs:StandardPresentationParameters"/>
+            <xsd:attributeGroup ref="wfs:StandardResolveParameters"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <xsd:element name="ValueCollection" type="wfs:ValueCollectionType"/>
+   <xsd:complexType name="ValueCollectionType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:member" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="wfs:additionalValues" minOccurs="0"/>
+         <xsd:element ref="wfs:truncatedResponse" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="wfs:StandardResponseParameters"/>
+   </xsd:complexType>
+   <xsd:element name="member" type="wfs:MemberPropertyType"/>
+   <xsd:complexType name="MemberPropertyType" mixed="true">
+      <xsd:choice minOccurs="0">
+         <xsd:any processContents="lax" namespace="##other"/>
+         <xsd:element ref="wfs:Tuple"/>
+         <xsd:element ref="wfs:SimpleFeatureCollection"/>
+      </xsd:choice>
+      <xsd:attribute name="state" type="wfs:StateValueType"/>
+      <xsd:attributeGroup ref="xlink:simpleAttrs"/>
+   </xsd:complexType>
+   <xsd:element name="Tuple" type="wfs:TupleType"/>
+   <xsd:complexType name="TupleType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:member" minOccurs="2" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="additionalValues">
+      <xsd:complexType>
+         <xsd:choice>
+            <xsd:element ref="wfs:ValueCollection"/>
+            <xsd:element ref="wfs:SimpleFeatureCollection"/>
+         </xsd:choice>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="truncatedResponse">
+      <xsd:complexType>
+         <xsd:sequence>
+            <xsd:element ref="ows:ExceptionReport"/>
+         </xsd:sequence>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:simpleType name="StateValueType">
+      <xsd:union>
+         <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+               <xsd:enumeration value="valid"/>
+               <xsd:enumeration value="superseded"/>
+               <xsd:enumeration value="retired"/>
+               <xsd:enumeration value="future"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+               <xsd:pattern value="other:\w{2,}"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+      </xsd:union>
+   </xsd:simpleType>
+   <!-- ================================================================== -->
+   <!-- =   GETFEATURE Request & Response                                = -->
+   <!-- ================================================================== -->
+   <xsd:element name="GetFeature" type="wfs:GetFeatureType"/>
+   <xsd:complexType name="GetFeatureType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element ref="fes:AbstractQueryExpression"
+                  maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attributeGroup ref="wfs:StandardPresentationParameters"/>
+            <xsd:attributeGroup ref="wfs:StandardResolveParameters"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- === GETFEATUREWITHLOCK REQUEST =================================== -->
+   <xsd:element name="GetFeatureWithLock" type="wfs:GetFeatureWithLockType"/>
+   <xsd:complexType name="GetFeatureWithLockType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:GetFeatureType">
+            <xsd:attribute name="expiry" type="xsd:positiveInteger"
+               default="300"/>
+            <xsd:attribute name="lockAction" type="wfs:AllSomeType"
+               default="ALL"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- === PROPERTYNAME (Projection clause) ============================= -->
+   <xsd:element name="PropertyName"
+      substitutionGroup="fes:AbstractProjectionClause">
+      <xsd:complexType>
+         <xsd:simpleContent>
+            <xsd:extension base="xsd:QName">
+               <xsd:attributeGroup ref="wfs:StandardResolveParameters"/>
+               <xsd:attribute name="resolvePath" type="xsd:string"/>
+            </xsd:extension>
+         </xsd:simpleContent>
+      </xsd:complexType>
+   </xsd:element>
+   <!-- === GETFEATURE & GETFEATUREWITHLOCK RESPONSE ===================== -->
+   <xsd:element name="FeatureCollection" type="wfs:FeatureCollectionType"
+      substitutionGroup="wfs:SimpleFeatureCollection"/>
+   <xsd:complexType name="FeatureCollectionType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:SimpleFeatureCollectionType">
+            <xsd:sequence>
+               <xsd:element ref="wfs:additionalObjects" minOccurs="0"/>
+               <xsd:element ref="wfs:truncatedResponse" minOccurs="0"/>
+            </xsd:sequence>
+            <xsd:attributeGroup ref="wfs:StandardResponseParameters"/>
+            <xsd:attribute name="lockId" type="xsd:string"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="additionalObjects">
+      <xsd:complexType>
+         <xsd:choice>
+            <xsd:element ref="wfs:ValueCollection"/>
+            <xsd:element ref="wfs:SimpleFeatureCollection"/>
+         </xsd:choice>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="SimpleFeatureCollection"
+                type="wfs:SimpleFeatureCollectionType"/>
+   <xsd:complexType name="SimpleFeatureCollectionType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:boundedBy" minOccurs="0"/>
+         <xsd:element ref="wfs:member" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="boundedBy" type="wfs:EnvelopePropertyType"/>
+   <xsd:complexType name="EnvelopePropertyType">
+      <xsd:sequence>
+         <xsd:any namespace="##other"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <!-- ================================================================== -->
+   <!-- =   LIST STORED QUERIES                                          = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="ListStoredQueries" type="wfs:ListStoredQueriesType"/>
+   <xsd:complexType name="ListStoredQueriesType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType"/>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <xsd:element name="ListStoredQueriesResponse"
+      type="wfs:ListStoredQueriesResponseType"/>
+   <xsd:complexType name="ListStoredQueriesResponseType">
+      <xsd:sequence>
+         <xsd:element name="StoredQuery" type="wfs:StoredQueryListItemType"
+            minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StoredQueryListItemType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:Title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="ReturnFeatureType" type="xsd:QName"
+            minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:anyURI" use="required"/>
+   </xsd:complexType>
+   <!-- ================================================================== -->
+   <!-- =   DESCRIBE STORED QUERIES                                      = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="DescribeStoredQueries"
+      type="wfs:DescribeStoredQueriesType"/>
+   <xsd:complexType name="DescribeStoredQueriesType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element name="StoredQueryId" type="xsd:anyURI" minOccurs="0"
+                  maxOccurs="unbounded"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- RESPONSE -->
+   <xsd:element name="DescribeStoredQueriesResponse"
+      type="wfs:DescribeStoredQueriesResponseType"/>
+   <xsd:complexType name="DescribeStoredQueriesResponseType">
+      <xsd:sequence>
+         <xsd:element name="StoredQueryDescription"
+                      type="wfs:StoredQueryDescriptionType"
+                      minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StoredQueryDescriptionType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:Title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="wfs:Abstract" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="ows:Metadata" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="Parameter"
+                      type="wfs:ParameterExpressionType"
+                      minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="QueryExpressionText"
+                      type="wfs:QueryExpressionTextType"
+                      minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:anyURI" use="required"/>
+   </xsd:complexType>
+   <!-- ================================================================== -->
+   <!-- =   CREATE STORED QUERIES                                        = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="CreateStoredQuery" type="wfs:CreateStoredQueryType"/>
+   <xsd:complexType name="CreateStoredQueryType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element name="StoredQueryDefinition"
+                  type="wfs:StoredQueryDescriptionType" minOccurs="0"
+                  maxOccurs="unbounded"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParameterExpressionType">
+      <xsd:sequence>
+         <xsd:element ref="wfs:Title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="wfs:Abstract" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="ows:Metadata" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="type" type="xsd:QName" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="QueryExpressionTextType" mixed="true">
+      <xsd:choice>
+         <xsd:any namespace="##other" processContents="skip"
+                  minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:any namespace="##targetNamespace" processContents="skip"
+                  minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:choice>
+      <xsd:attribute name="returnFeatureTypes"
+                     type="wfs:ReturnFeatureTypesListType" use="required"/>
+      <xsd:attribute name="language" type="xsd:anyURI" use="required"/>
+      <xsd:attribute name="isPrivate" type="xsd:boolean" default="false"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ReturnFeatureTypesListType">
+      <xsd:list itemType="xsd:QName"/>
+   </xsd:simpleType>
+   <!-- RESPONSE -->
+   <xsd:element name="CreateStoredQueryResponse"
+      type="wfs:CreateStoredQueryResponseType"/>
+   <xsd:complexType name="ExecutionStatusType">
+      <xsd:attribute name="status" type="xsd:string" fixed="OK"/>
+   </xsd:complexType>
+   <xsd:complexType name="CreateStoredQueryResponseType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:ExecutionStatusType"/>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- ================================================================== -->
+   <!-- =   DROP STORED QUERIES                                          = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="DropStoredQuery">
+      <xsd:complexType>
+         <xsd:complexContent>
+            <xsd:extension base="wfs:BaseRequestType">
+               <xsd:attribute name="id" type="xsd:anyURI" use="required"/>
+            </xsd:extension>
+         </xsd:complexContent>
+      </xsd:complexType>
+   </xsd:element>
+   <!-- RESPONSE -->
+   <xsd:element name="DropStoredQueryResponse" type="wfs:ExecutionStatusType"/>
+   <!-- ================================================================== -->
+   <!-- =   LOCKFEATURE Request and Response                             = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="LockFeature" type="wfs:LockFeatureType"/>
+   <xsd:complexType name="LockFeatureType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:element ref="fes:AbstractQueryExpression"
+                  maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="lockId" type="xsd:string"/>
+            <xsd:attribute name="expiry" type="xsd:positiveInteger"
+               default="300"/>
+            <xsd:attribute name="lockAction" type="wfs:AllSomeType"
+               default="ALL"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="AllSomeType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="ALL"/>
+         <xsd:enumeration value="SOME"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <!-- RESPONSE -->
+   <xsd:element name="LockFeatureResponse" type="wfs:LockFeatureResponseType"/>
+   <xsd:complexType name="LockFeatureResponseType">
+      <xsd:sequence>
+         <xsd:element name="FeaturesLocked" type="wfs:FeaturesLockedType"
+            minOccurs="0"/>
+         <xsd:element name="FeaturesNotLocked" type="wfs:FeaturesNotLockedType"
+            minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="lockId" type="xsd:string"/>
+   </xsd:complexType>
+   <xsd:complexType name="FeaturesLockedType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element ref="fes:ResourceId"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeaturesNotLockedType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element ref="fes:ResourceId"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <!-- ================================================================== -->
+   <!-- =   TRANSACTION Request and Response                             = -->
+   <!-- ================================================================== -->
+   <!-- REQUEST -->
+   <xsd:element name="Transaction" type="wfs:TransactionType"/>
+   <xsd:complexType name="TransactionType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:BaseRequestType">
+            <xsd:sequence>
+               <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+                  <xsd:element ref="wfs:AbstractTransactionAction"/>
+               </xsd:sequence>
+            </xsd:sequence>
+            <xsd:attribute name="lockId" type="xsd:string"/>
+            <xsd:attribute name="releaseAction" type="wfs:AllSomeType"
+               default="ALL"/>
+            <xsd:attribute name="srsName" type="xsd:anyURI"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="AbstractTransactionAction"
+      type="wfs:AbstractTransactionActionType" abstract="true"/>
+   <xsd:complexType name="AbstractTransactionActionType" abstract="true">
+      <xsd:attribute name="handle" type="xsd:string"/>
+   </xsd:complexType>
+   <xsd:element name="Insert" type="wfs:InsertType"
+      substitutionGroup="wfs:AbstractTransactionAction"/>
+   <xsd:complexType name="InsertType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:AbstractTransactionActionType">
+            <xsd:sequence>
+               <xsd:any namespace="##other" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attributeGroup ref="wfs:StandardInputParameters"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="Update" type="wfs:UpdateType"
+      substitutionGroup="wfs:AbstractTransactionAction"/>
+   <xsd:complexType name="UpdateType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:AbstractTransactionActionType">
+            <xsd:sequence>
+               <xsd:element ref="wfs:Property" maxOccurs="unbounded"/>
+               <xsd:element ref="fes:Filter" minOccurs="0"/>
+            </xsd:sequence>
+            <xsd:attribute name="typeName" type="xsd:QName" use="required"/>
+            <xsd:attributeGroup ref="wfs:StandardInputParameters"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="Property" type="wfs:PropertyType"/>
+   <xsd:complexType name="PropertyType">
+      <xsd:sequence>
+         <xsd:element name="ValueReference">
+            <xsd:complexType>
+               <xsd:simpleContent>
+                  <xsd:extension base="xsd:string">
+                     <xsd:attribute name="action" type="wfs:UpdateActionType"
+                        default="replace"/>
+                  </xsd:extension>
+               </xsd:simpleContent>
+            </xsd:complexType>
+         </xsd:element>
+         <xsd:element name="Value" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="UpdateActionType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="replace"/>
+         <xsd:enumeration value="insertBefore"/>
+         <xsd:enumeration value="insertAfter"/>
+         <xsd:enumeration value="remove"/>
+      </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:element name="Replace" type="wfs:ReplaceType"
+      substitutionGroup="wfs:AbstractTransactionAction"/>
+   <xsd:complexType name="ReplaceType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:AbstractTransactionActionType">
+            <xsd:sequence>
+               <xsd:any namespace="##other"/>
+               <xsd:element ref="fes:Filter"/>
+            </xsd:sequence>
+            <xsd:attributeGroup ref="wfs:StandardInputParameters"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="Delete" type="wfs:DeleteType"
+      substitutionGroup="wfs:AbstractTransactionAction"/>
+   <xsd:complexType name="DeleteType">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:AbstractTransactionActionType">
+            <xsd:sequence>
+               <xsd:element ref="fes:Filter"/>
+            </xsd:sequence>
+            <xsd:attribute name="typeName" type="xsd:QName" use="required"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="Native" type="wfs:NativeType"
+      substitutionGroup="wfs:AbstractTransactionAction"/>
+   <xsd:complexType name="NativeType" mixed="true">
+      <xsd:complexContent>
+         <xsd:extension base="wfs:AbstractTransactionActionType">
+            <xsd:sequence>
+               <xsd:any processContents="lax" namespace="##other" minOccurs="0"/>
+            </xsd:sequence>
+            <xsd:attribute name="vendorId" type="xsd:string" use="required"/>
+            <xsd:attribute name="safeToIgnore" type="xsd:boolean" use="required"/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <!-- REPONSE -->
+   <xsd:element name="TransactionResponse" type="wfs:TransactionResponseType"/>
+   <xsd:complexType name="TransactionResponseType">
+      <xsd:sequence>
+         <xsd:element name="TransactionSummary"
+            type="wfs:TransactionSummaryType"/>
+         <xsd:element name="InsertResults" type="wfs:ActionResultsType"
+            minOccurs="0"/>
+         <xsd:element name="UpdateResults" type="wfs:ActionResultsType"
+            minOccurs="0"/>
+         <xsd:element name="ReplaceResults" type="wfs:ActionResultsType"
+            minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="wfs:VersionStringType"
+         use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionSummaryType">
+      <xsd:sequence>
+         <xsd:element name="totalInserted" type="xsd:nonNegativeInteger"
+            minOccurs="0"/>
+         <xsd:element name="totalUpdated" type="xsd:nonNegativeInteger"
+            minOccurs="0"/>
+         <xsd:element name="totalReplaced" type="xsd:nonNegativeInteger"
+            minOccurs="0"/>
+         <xsd:element name="totalDeleted" type="xsd:nonNegativeInteger"
+            minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ActionResultsType">
+      <xsd:sequence>
+         <xsd:element name="Feature" type="wfs:CreatedOrModifiedFeatureType"
+            maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CreatedOrModifiedFeatureType">
+      <xsd:sequence maxOccurs="unbounded">
+         <xsd:element ref="fes:ResourceId"/>
+      </xsd:sequence>
+      <xsd:attribute name="handle" type="xsd:string"/>
+   </xsd:complexType>
+   <xsd:complexType name="EmptyType"/>
+</xsd:schema>


### PR DESCRIPTION
Also add a few XSDs to work around problems when the webapp is on a machine
without an access to internet.

The GML/filter/OWS XSDs are located within GeoTools, so we don't need to have them.

Fixes #371.