### PR TITLE
Fetch tiles in parallel

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/AbstractGridCoverageLayerPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/AbstractGridCoverageLayerPlugin.java
@@ -19,6 +19,15 @@ public abstract class AbstractGridCoverageLayerPlugin {
     private StyleParser styleParser;
 
     /**
+     * Maximum number of requests we can do in parallel to avoid overloading servers.
+     */
+    private final int maxNumberParallelRequests = 15;
+
+    public final int getMaxNumberParallelRequests() {
+        return this.maxNumberParallelRequests;
+    }
+
+    /**
      * Common method for creating styles.
      *
      * @param template the template that the map is part of

--- a/core/src/main/java/org/mapfish/print/map/tiled/AbstractTiledLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/AbstractTiledLayer.java
@@ -50,7 +50,7 @@ public abstract class AbstractTiledLayer extends AbstractGeotoolsLayer {
         Rectangle paintArea = new Rectangle(mapContext.getMapSize());
         TileCacheInformation tileCacheInformation = createTileInformation(bounds, paintArea, dpi, isFirstLayer);
         final TileLoaderTask task = new TileLoaderTask(httpRequestFactory, dpi,
-                mapContext, tileCacheInformation, getFailOnError());
+                mapContext, tileCacheInformation, getFailOnError(), this.forkJoinPool);
         final GridCoverage2D gridCoverage2D = this.forkJoinPool.invoke(task);
 
         GridCoverageLayer layer = new GridCoverageLayer(gridCoverage2D, this.styleSupplier.load(httpRequestFactory, gridCoverage2D,

--- a/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayerParserPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayerParserPlugin.java
@@ -22,8 +22,7 @@ import javax.annotation.Nonnull;
 public final class OsmLayerParserPlugin extends AbstractGridCoverageLayerPlugin implements MapLayerFactoryPlugin<OsmLayerParam> {
     @Autowired
     private StyleParser parser;
-    @Autowired
-    private ForkJoinPool forkJoinPool;
+    private final ForkJoinPool forkJoinPool = new ForkJoinPool(this.getMaxNumberParallelRequests());
 
     private Set<String> typenames = Sets.newHashSet("osm");
 

--- a/core/src/main/java/org/mapfish/print/map/tiled/wms/TiledWmsLayerParserPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wms/TiledWmsLayerParserPlugin.java
@@ -6,7 +6,6 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.mapfish.print.config.Template;
 import org.mapfish.print.map.MapLayerFactoryPlugin;
 import org.mapfish.print.map.geotools.AbstractGridCoverageLayerPlugin;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -20,8 +19,7 @@ import javax.annotation.Nonnull;
  */
 public final class TiledWmsLayerParserPlugin extends AbstractGridCoverageLayerPlugin implements MapLayerFactoryPlugin<TiledWmsLayerParam> {
 
-    @Autowired
-    private ForkJoinPool forkJoinPool;
+    private final ForkJoinPool forkJoinPool = new ForkJoinPool(this.getMaxNumberParallelRequests());
 
     private final Set<String> typenames = Sets.newHashSet("tiledwms");
 

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WmtsLayerParserPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WmtsLayerParserPlugin.java
@@ -6,7 +6,6 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.mapfish.print.config.Template;
 import org.mapfish.print.map.MapLayerFactoryPlugin;
 import org.mapfish.print.map.geotools.AbstractGridCoverageLayerPlugin;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -19,8 +18,7 @@ import javax.annotation.Nonnull;
  * @author Jesse on 4/3/14.
  */
 public final class WmtsLayerParserPlugin extends AbstractGridCoverageLayerPlugin implements MapLayerFactoryPlugin<WMTSLayerParam> {
-    @Autowired
-    private ForkJoinPool forkJoinPool;
+    private final ForkJoinPool forkJoinPool = new ForkJoinPool(this.getMaxNumberParallelRequests());
 
     private Set<String> typenames = Sets.newHashSet("wmts");
 

--- a/core/src/main/java/org/mapfish/print/processor/AbstractProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/AbstractProcessor.java
@@ -34,6 +34,11 @@ public abstract class AbstractProcessor<In, Out> implements Processor<In, Out> {
     private String outputPrefix;
 
     /**
+     * Maximum number of requests we can do in parallel to avoid overloading servers.
+     */
+    protected final int maxNumberParallelRequets = 15;
+
+    /**
      * Constructor.
      *
      * @param outputType the type of the output of this processor.  Used to calculate processor dependencies.

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
@@ -106,8 +106,7 @@ public final class CreateMapProcessor extends AbstractProcessor<CreateMapProcess
 
     @Autowired
     FeatureLayer.Plugin featureLayerPlugin;
-    @Autowired
-    private ForkJoinPool forkJoinPool;
+    private final ForkJoinPool forkJoinPool = new ForkJoinPool(this.maxNumberParallelRequets);
 
     private BufferedImageType imageType = BufferedImageType.TYPE_4BYTE_ABGR;
 

--- a/core/src/main/java/org/mapfish/print/processor/map/LayerTaskCreator.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/LayerTaskCreator.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2016  Camptocamp
+ *
+ * This file is part of MapFish Print
+ *
+ * MapFish Print is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MapFish Print is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MapFish Print.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapfish.print.processor.map;
+
+import com.vividsolutions.jts.awt.ShapeWriter;
+import com.vividsolutions.jts.geom.Polygon;
+
+import org.apache.batik.svggen.SVGGraphics2D;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.operation.transform.AffineTransform2D;
+import org.mapfish.print.attribute.map.AreaOfInterest;
+import org.mapfish.print.attribute.map.MapLayer;
+import org.mapfish.print.attribute.map.MapfishMapContext;
+import org.mapfish.print.http.MfClientHttpRequestFactory;
+import org.mapfish.print.map.geotools.AbstractFeatureSourceLayer;
+import org.mapfish.print.processor.Processor;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.net.URI;
+import java.util.concurrent.Callable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.imageio.ImageIO;
+
+import static org.geotools.renderer.lite.RendererUtilities.worldToScreenTransform;
+import static org.mapfish.print.processor.map.CreateMapProcessor.getSvgGraphics;
+import static org.mapfish.print.processor.map.CreateMapProcessor.saveSvgFile;
+
+/**
+ *
+ * @author jenselme
+ */
+public class LayerTaskCreator {
+
+    private final File printDirectory;
+    private final MfClientHttpRequestFactory clientHttpRequestFactory;
+    private final MapfishMapContext mapContext;
+    private final AreaOfInterest areaOfInterest;
+    private final String mapKey;
+
+    /**
+     * Create LayerTask from common parameters.
+     *
+     * @param printDirectory Directory in which the temporary images will be
+     * stored.
+     * @param clientHttpRequestFactory A factory for making http requests.
+     * @param mapContext The map context for a print task
+     * @param areaOfInterest A GeoJSON geometry that is essentially the area of
+     * the area to draw on the map.
+     * @param mapKey UUID for the map.
+     */
+    public LayerTaskCreator(final File printDirectory,
+            final MfClientHttpRequestFactory clientHttpRequestFactory,
+            final MapfishMapContext mapContext,
+            final AreaOfInterest areaOfInterest,
+            final String mapKey) {
+        this.printDirectory = printDirectory;
+        this.clientHttpRequestFactory = clientHttpRequestFactory;
+        this.mapContext = mapContext;
+        this.areaOfInterest = areaOfInterest;
+        this.mapKey = mapKey;
+    }
+
+    /**
+     * Create a LayerTask from the common a specific parameters.
+     *
+     * @param layer The layer to print.
+     * @param context The execution context for a print task.
+     * @param imageTypeValue The type of the image.
+     * @param index The index of the layer.
+     * @return The LayerTask to be executed.
+     */
+    public final LayerTask create(final MapLayer layer,
+            final Processor.ExecutionContext context,
+            final int imageTypeValue,
+            final int index) {
+        LayerTask task
+                = new LayerTask(this.printDirectory, this.clientHttpRequestFactory, this.mapContext, this.areaOfInterest, this.mapKey);
+        task.setup(layer, context, imageTypeValue, index);
+
+        return task;
+    }
+
+    /**
+     * The LayerTask to execute in parallel.
+     */
+    public final class LayerTask implements Callable<URI> {
+
+        private final MapfishMapContext mapContext;
+        private final AreaOfInterest areaOfInterest;
+        private final MfClientHttpRequestFactory clientHttpRequestFactory;
+        private final File printDirectory;
+        private final String mapKey;
+        private int imageType;
+        private Processor.ExecutionContext context;
+        private MapLayer layer;
+        private int index;
+
+        private LayerTask(final File printDirectory,
+                final MfClientHttpRequestFactory clientHttpRequestFactory,
+                final MapfishMapContext mapContext,
+                final AreaOfInterest areaOfInterest,
+                final String mapKey) {
+            this.mapContext = mapContext;
+            this.areaOfInterest = areaOfInterest;
+            this.clientHttpRequestFactory = clientHttpRequestFactory;
+            this.printDirectory = printDirectory;
+            this.mapKey = mapKey;
+        }
+
+        /**
+         * Apply the specific parameters to a task.
+         *
+         * @param mapLayer The layer to print.
+         * @param executionContext The execution context for a print task.
+         * @param imageTypeValue The type of the image.
+         * @param layerIndex The index of the layer.
+         */
+        public void setup(final MapLayer mapLayer,
+                final Processor.ExecutionContext executionContext,
+                final int imageTypeValue,
+                final int layerIndex) {
+            this.layer = mapLayer;
+            this.context = executionContext;
+            this.imageType = imageTypeValue;
+            this.index = layerIndex;
+        }
+
+        @Override
+        public URI call() throws Exception {
+            boolean isFirstLayer = this.index == 0;
+
+            File path = null;
+            if (renderAsSvg(this.layer)) {
+                // render layer as SVG
+                final SVGGraphics2D graphics2D = getSvgGraphics(this.mapContext.getMapSize());
+
+                try {
+                    Graphics2D clippedGraphics2D = createClippedGraphics(this.mapContext, this.areaOfInterest, graphics2D);
+                    this.layer.render(clippedGraphics2D, this.clientHttpRequestFactory, this.mapContext, isFirstLayer);
+
+                    path = new File(this.printDirectory, this.mapKey + "_layer_" + this.index + ".svg");
+                    saveSvgFile(graphics2D, path);
+                } finally {
+                    graphics2D.dispose();
+                }
+            } else {
+                // render layer as raster graphic
+                final BufferedImage bufferedImage = new BufferedImage(this.mapContext.getMapSize().width,
+                        this.mapContext.getMapSize().height, this.imageType);
+                Graphics2D graphics2D = createClippedGraphics(this.mapContext, this.areaOfInterest, bufferedImage.createGraphics());
+                try {
+                    this.layer.render(graphics2D, this.clientHttpRequestFactory, this.mapContext, isFirstLayer);
+
+                    path = new File(this.printDirectory, this.mapKey + "_layer_" + this.index + ".png");
+                    ImageIO.write(bufferedImage, "png", path);
+                } finally {
+                    graphics2D.dispose();
+                }
+            }
+
+            return path.toURI();
+        }
+
+        private boolean renderAsSvg(final MapLayer layerBis) {
+            if (layerBis instanceof AbstractFeatureSourceLayer) {
+                AbstractFeatureSourceLayer featureLayer = (AbstractFeatureSourceLayer) layerBis;
+                return featureLayer.shouldRenderAsSvg();
+            }
+            return false;
+        }
+
+        private Graphics2D createClippedGraphics(@Nonnull final MapfishMapContext transformer,
+                @Nullable final AreaOfInterest areaOfInterestBis,
+                @Nonnull final Graphics2D graphics2D) {
+            if (areaOfInterestBis != null && areaOfInterestBis.display == AreaOfInterest.AoiDisplay.CLIP) {
+                final Polygon screenGeometry = areaOfInterestInScreenCRS(transformer, areaOfInterestBis);
+                final ShapeWriter shapeWriter = new ShapeWriter();
+                final Shape clipShape = shapeWriter.toShape(screenGeometry);
+                return new ConstantClipGraphics2D(graphics2D, clipShape);
+            }
+
+            return graphics2D;
+        }
+
+        private Polygon areaOfInterestInScreenCRS(@Nonnull final MapfishMapContext transformer,
+                @Nullable final AreaOfInterest areaOfInterestBis) {
+            if (areaOfInterestBis != null) {
+                final AffineTransform worldToScreenTransform = worldToScreenTransform(transformer.toReferencedEnvelope(),
+                        transformer.getPaintArea());
+
+                MathTransform mathTransform = new AffineTransform2D(worldToScreenTransform);
+                final Polygon screenGeometry;
+                try {
+                    screenGeometry = (Polygon) JTS.transform(areaOfInterestBis.getArea(), mathTransform);
+                } catch (TransformException e) {
+                    throw new RuntimeException(e);
+                }
+                return screenGeometry;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
I did some work to fetch tiles in parallel as requested by #157. This provides a welcomed speed improvement.

To continue with performance improvement, I am now trying to understand how to send the response before the `ThreadPoolSubreportRunnerFactory` shutdowns (since this takes a quite long time). From our log:

```
10:24:32.767 [PrintJobManager-5] DEBUG n.s.j.e.f.ThreadPoolSubreportRunnerFactory - shutting down java.util.concurrent.ThreadPoolExecutor@5e0e8f36[Running, pool size = 1, active threads = 0, queued tasks = 0, completed tasks = 2]
10:24:37.012 [PrintJobManager-5] INFO  o.mapfish.print.servlet.job.PrintJob - Successfully completed print job 9503e3e0-d239-48b5-aa96-a2a50563ea65@0763e02a-643c-4ca1-8381-7281bb789adb
```

If you have any idea about this, let me know.