### PR TITLE
"equals(Object obj)" should test argument type

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraphFactory.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraphFactory.java
@@ -353,6 +353,14 @@ public final class ProcessorDependencyGraphFactory {
 
         @Override
         public boolean equals(final Object obj) {
+            if (obj == null) {
+                return false;
+            }
+
+            if (this.getClass() != obj.getClass()) {
+                return false;
+            }
+
             return Objects.equal(this.name, ((InputValue) obj).name);
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - “ "equals(Object obj)" should test argument type ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2097
Please let me know if you have any questions.
Ayman Abdelghany.