### PR TITLE
Case insensitive string comparisons should be made without intermediate upper or lower casing

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -122,9 +122,8 @@ public final class WmsUtilities {
      * Checks if a map contains a key ignoring upper/lower case.
      */
     private static boolean contains(final Multimap<String, ?> map, final String searchKey) {
-        String searchKeyLower = searchKey.toLowerCase();
         for (String key : map.keys()) {
-            if (key.toLowerCase().equals(searchKeyLower)) {
+            if (key.equalsIgnoreCase(searchKey)) {
                 return true;
             }
         }
@@ -137,7 +136,7 @@ public final class WmsUtilities {
     private static boolean isDpiSet(final Multimap<String, String> extraParams) {
         String searchKey = "FORMAT_OPTIONS";
         for (String key : extraParams.keys()) {
-            if (key.toUpperCase().equals(searchKey)) {
+            if (key.equalsIgnoreCase(searchKey)) {
                 for (String value : extraParams.get(key)) {
                     if (value.toLowerCase().contains("dpi:")) {
                         return true;
@@ -154,7 +153,7 @@ public final class WmsUtilities {
     private static void setDpiValue(final Multimap<String, String> extraParams, final int dpi) {
         String searchKey = "FORMAT_OPTIONS";
         for (String key : extraParams.keys()) {
-            if (key.toUpperCase().equals(searchKey)) {
+            if (key.equalsIgnoreCase(searchKey)) {
                 Collection<String> values = extraParams.removeAll(key);
                 List<String> newValues = new ArrayList<String>();
                 for (String value : values) {

--- a/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
@@ -58,11 +58,11 @@ public abstract class BaseMapServlet {
      * @param date the date to replace the value with if the variable is a date variable.
      */
     public static String findReplacement(final String variableName, final Date date) {
-        if (variableName.toLowerCase().equals("date")) {
+        if (variableName.equalsIgnoreCase("date")) {
             return cleanUpName(DateFormat.getDateInstance().format(date));
-        } else if (variableName.toLowerCase().equals("datetime")) {
+        } else if (variableName.equalsIgnoreCase("datetime")) {
             return cleanUpName(DateFormat.getDateTimeInstance().format(date));
-        } else if (variableName.toLowerCase().equals("time")) {
+        } else if (variableName.equalsIgnoreCase("time")) {
             return cleanUpName(DateFormat.getTimeInstance().format(date));
         } else {
             try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1157 - “Case insensitive string comparisons should be made without intermediate upper or lower casing”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1157
Please let me know if you have any questions.
Ayman Abdelghany.