### PR TITLE
 Floating point numbers should not be tested for equality

### DIFF
--- a/core/src/main/java/org/mapfish/print/FloatingPointUtil.java
+++ b/core/src/main/java/org/mapfish/print/FloatingPointUtil.java
@@ -1,0 +1,35 @@
+package org.mapfish.print;
+
+/**
+ * Util class to Test equality of floating point
+ * 
+ * @author ayman on 2/22/16.
+ */
+ 
+public final class FloatingPointUtil {
+    private static final float EPSILON =  0.00000001F;
+
+    private FloatingPointUtil() {
+    }
+
+    /**
+     * Check the equality of two floats taking into consideration the precision issue of floating point arithmetic in Java   
+     * 
+     * @param f1
+     * @param f2
+     * @return
+     */
+    public static boolean equals(final float f1, final float f2) {
+        return Math.abs(f1 - f2) <= EPSILON;
+    }
+
+    /**
+     * Check the equality of two doubles taking into consideration the precision issue of floating point arithmetic in Java
+     * @param d1
+     * @param d2
+     * @return
+     */
+    public static boolean equals(final double d1, final double d2) {
+        return Math.abs(d1 - d2) <= EPSILON;
+    }
+}

--- a/core/src/main/java/org/mapfish/print/attribute/map/BBoxMapBounds.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/BBoxMapBounds.java
@@ -24,6 +24,7 @@ import com.vividsolutions.jts.geom.Envelope;
 
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.GeodeticCalculator;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.map.DistanceUnit;
 import org.mapfish.print.map.Scale;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -154,7 +155,7 @@ public final class BBoxMapBounds extends MapBounds {
 
     @Override
     public MapBounds adjustBoundsToRotation(final double rotation) {
-        if (rotation == 0.0) {
+        if (FloatingPointUtil.equals(rotation, 0.0)) {
             return this;
         }
 
@@ -180,7 +181,7 @@ public final class BBoxMapBounds extends MapBounds {
 
     private double getRotatedWidth(final double rotation) {
         double width = this.bbox.getWidth();
-        if (rotation != 0.0) {
+        if (!FloatingPointUtil.equals(rotation, 0.0)) {
             double height = this.bbox.getHeight();
             width = (float) (Math.abs(width * Math.cos(rotation)) +
                     Math.abs(height * Math.sin(rotation)));
@@ -190,7 +191,7 @@ public final class BBoxMapBounds extends MapBounds {
 
     private double getRotatedHeight(final double rotation) {
         double height = this.bbox.getHeight();
-        if (rotation != 0.0) {
+        if (!FloatingPointUtil.equals(rotation, 0.0)) {
             double width = this.bbox.getWidth();
             height = (float) (Math.abs(height * Math.cos(rotation)) +
                     Math.abs(width * Math.sin(rotation)));
@@ -200,7 +201,7 @@ public final class BBoxMapBounds extends MapBounds {
 
     @Override
     public MapBounds zoomOut(final double factor) {
-        if (factor == 1.0) {
+        if (FloatingPointUtil.equals(factor, 1.0)) {
             return this;
         }
 

--- a/core/src/main/java/org/mapfish/print/attribute/map/CenterScaleMapBounds.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/CenterScaleMapBounds.java
@@ -24,6 +24,7 @@ import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.GeodeticCalculator;
 import org.mapfish.print.ExceptionUtils;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.map.DistanceUnit;
 import org.mapfish.print.map.Scale;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -124,7 +125,7 @@ public final class CenterScaleMapBounds extends MapBounds {
 
     @Override
     public CenterScaleMapBounds zoomOut(final double factor) {
-        if (factor == 1.0) {
+        if (FloatingPointUtil.equals(factor, 1.0)) {
             return this;
         }
 

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapfishMapContext.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapfishMapContext.java
@@ -20,6 +20,7 @@
 package org.mapfish.print.attribute.map;
 
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.map.Scale;
 
 import java.awt.Dimension;
@@ -157,7 +158,7 @@ public final class MapfishMapContext {
      * @return The new map size taking the rotation into account.
      */
     public Dimension getRotatedMapSize() {
-        if (this.rotation == 0.0) {
+        if (FloatingPointUtil.equals(this.rotation, 0.0)) {
             return this.mapSize;
         }
         
@@ -173,7 +174,7 @@ public final class MapfishMapContext {
      * @return an affine transformation
      */
     public AffineTransform getTransform() {
-        if (this.rotation == 0.0) {
+        if (FloatingPointUtil.equals(this.rotation, 0.0)) {
             return null;
         }
         
@@ -205,7 +206,7 @@ public final class MapfishMapContext {
 
     private int getRotatedMapWidth() {
         double width = this.mapSize.getWidth();
-        if (this.rotation != 0.0) {
+        if (!FloatingPointUtil.equals(this.rotation, 0.0)) {
             double height = this.mapSize.getHeight();
             width = Math.abs(width * Math.cos(this.rotation))
                     + Math.abs(height * Math.sin(this.rotation));
@@ -215,7 +216,7 @@ public final class MapfishMapContext {
 
     private int getRotatedMapHeight() {
         double height = this.mapSize.getHeight();
-        if (this.rotation != 0.0) {
+        if (!FloatingPointUtil.equals(this.rotation, 0.0)) {
             double width = this.mapSize.getWidth();
             height = Math.abs(height * Math.cos(this.rotation))
                      + Math.abs(width * Math.sin(this.rotation));

--- a/core/src/main/java/org/mapfish/print/map/geotools/AbstractGeotoolsLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/AbstractGeotoolsLayer.java
@@ -29,6 +29,7 @@ import org.geotools.renderer.lite.StreamingRenderer;
 import org.geotools.styling.Style;
 import org.geotools.styling.StyleVisitor;
 import org.mapfish.print.ExceptionUtils;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.attribute.map.MapBounds;
 import org.mapfish.print.attribute.map.MapLayer;
 import org.mapfish.print.attribute.map.MapfishMapContext;
@@ -80,7 +81,7 @@ public abstract class AbstractGeotoolsLayer implements MapLayer {
         MapBounds bounds = transformer.getBounds();
 
         MapfishMapContext layerTransformer = transformer;
-        if (transformer.getRotation() != 0.0 && !this.supportsNativeRotation()) {
+        if (!FloatingPointUtil.equals(transformer.getRotation(), 0.0) && !this.supportsNativeRotation()) {
             // if a rotation is set and the rotation can not be handled natively
             // by the layer, we have to adjust the bounds and map size
             paintArea = new Rectangle(transformer.getRotatedMapSize());

--- a/core/src/main/java/org/mapfish/print/map/tiled/TileLoaderTask.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/TileLoaderTask.java
@@ -33,6 +33,7 @@ import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.mapfish.print.ExceptionUtils;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.attribute.map.MapBounds;
 import org.mapfish.print.attribute.map.MapfishMapContext;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
@@ -210,7 +211,7 @@ public final class TileLoaderTask extends RecursiveTask<GridCoverage2D> {
      * if a tile is really required to draw the map.
      */
     private boolean isTileVisible(final ReferencedEnvelope tileBounds) {
-        if (this.transformer.getRotation() == 0.0) {
+        if (FloatingPointUtil.equals(this.transformer.getRotation(), 0.0)) {
             return true;
         }
 

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateOverviewMapProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateOverviewMapProcessor.java
@@ -29,6 +29,7 @@ import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.mapfish.print.Constants;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.attribute.map.MapAttribute;
 import org.mapfish.print.attribute.map.MapBounds;
 import org.mapfish.print.attribute.map.OverviewMapAttribute;
@@ -135,7 +136,7 @@ public class CreateOverviewMapProcessor extends AbstractProcessor<CreateOverview
                 adjustedBounds.toReferencedEnvelope(originalPaintArea, values.map.getDpi());
 
         Geometry mapExtent = JTS.toGeometry(originalEnvelope);
-        if (values.map.getRotation() != 0.0) {
+        if (!FloatingPointUtil.equals(values.map.getRotation(), 0.0)) {
             mapExtent = rotateExtent(mapExtent, values.map.getRotation(), originalEnvelope);
         }
         

--- a/core/src/main/java/org/mapfish/print/processor/map/NorthArrowGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/NorthArrowGraphic.java
@@ -27,6 +27,7 @@ import org.apache.batik.dom.util.DOMUtilities;
 import org.apache.batik.util.SVGConstants;
 import org.apache.batik.util.XMLResourceDescriptor;
 import org.apache.commons.io.output.FileWriterWithEncoding;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.map.style.json.ColorParser;
 import org.slf4j.Logger;
@@ -168,7 +169,7 @@ public final class NorthArrowGraphic {
             int deltaX = (int) Math.floor((targetSize.width - newWidth) / 2.0);
             int deltaY = (int) Math.floor((targetSize.height - newHeight) / 2.0);
 
-            if (rotation != 0.0) {
+            if (!FloatingPointUtil.equals(rotation, 0.0)) {
                 final AffineTransform rotate = AffineTransform.getRotateInstance(
                         Math.toRadians(rotation), targetSize.width / 2.0, targetSize.height / 2.0);
                 graphics2d.setTransform(rotate);

--- a/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPILayerConverter.java
+++ b/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPILayerConverter.java
@@ -22,6 +22,7 @@ package org.mapfish.print.servlet.oldapi;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.mapfish.print.FloatingPointUtil;
 import org.mapfish.print.config.OldApiConfig;
 import org.mapfish.print.wrapper.json.PJsonObject;
 
@@ -289,7 +290,7 @@ public final class OldAPILayerConverter {
 
                         Double scaleDenominator = 0.0D;
                         Double resolution = old.optDouble("resolution", 0.0D);
-                        if (resolution != 0.0D) {
+                        if (!FloatingPointUtil.equals(resolution, 0.0D)) {
                             //works with meter based srs
                             final double conversionRatio = 0.00028D;
                             scaleDenominator = resolution / conversionRatio;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1244 - “Floating point numbers should not be tested for equality”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1244
Please let me know if you have any questions.
Ayman Abdelghany.