### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/core/src/main/java/org/mapfish/print/URIUtils.java
+++ b/core/src/main/java/org/mapfish/print/URIUtils.java
@@ -117,7 +117,7 @@ public final class URIUtils {
      * @return The new query
      */
     public static URI addParams(final URI uri, final Multimap<String, String> params, final Set<String> overrideParams) {
-        if (params == null || params.size() == 0) {
+        if (params == null || params.isEmpty()) {
             return uri;
         }
         final String origTxt = uri.toString();

--- a/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
@@ -111,7 +111,7 @@ public abstract class ReflectiveAttribute<Value> implements Attribute {
     private void validateParamObject(final Class<?> typeToTest, final Set<Class> tested) {
         if (!tested.contains(typeToTest)) {
             final Collection<Field> allAttributes = ParserUtils.getAllAttributes(typeToTest);
-            Assert.isTrue(allAttributes.size() > 0, "An attribute value object must have at least on public field.");
+            Assert.isTrue(!allAttributes.isEmpty(), "An attribute value object must have at least on public field.");
             for (Field attribute : allAttributes) {
                 Class<?> type = attribute.getType();
                 if (type.isArray()) {

--- a/core/src/main/java/org/mapfish/print/parser/OneOfTracker.java
+++ b/core/src/main/java/org/mapfish/print/parser/OneOfTracker.java
@@ -97,7 +97,7 @@ final class OneOfTracker {
 
         for (OneOfGroup group : this.mapping.values()) {
 
-            if (group.satisfiedBy.size() == 0) {
+            if (group.satisfiedBy.isEmpty()) {
                 errors.append("\n");
                 errors.append("\t* The OneOf choice: ").append(group.name).append(" was not satisfied.  One (and only one) of the ");
                 errors.append("following fields is required in the request data: ").append(toNames(group.choices));

--- a/core/src/main/java/org/mapfish/print/test/util/ImageSimilarity.java
+++ b/core/src/main/java/org/mapfish/print/test/util/ImageSimilarity.java
@@ -220,7 +220,7 @@ public final class ImageSimilarity {
      */
     public static BufferedImage mergeImages(List<URI> graphicFiles, int width, int height)
             throws IOException, TranscoderException {
-        if (graphicFiles.size() == 0) {
+        if (graphicFiles.isEmpty()) {
             throw new IllegalArgumentException("no graphics given");
         }
 

--- a/core/src/main/java/org/mapfish/print/wrapper/multi/PMultiObject.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/multi/PMultiObject.java
@@ -154,7 +154,7 @@ public class PMultiObject extends PAbstractObject {
                 results.add(result);
             }
         }
-        if (results.size() == 0) {
+        if (results.isEmpty()) {
             return null;
         }
         if (results.size() == 1) {

--- a/core/src/test/java/org/mapfish/print/processor/jasper/DataSourceProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/jasper/DataSourceProcessorTest.java
@@ -69,7 +69,7 @@ public class DataSourceProcessorTest extends AbstractMapfishSpringTest {
 
         final List<Throwable> validate = config.validate();
 
-        assertTrue(validate.size() > 0);
+        assertTrue(!validate.isEmpty());
     }
 
     @Test

--- a/examples/src/test/java/org/mapfish/print/HumanAlphaSerie.java
+++ b/examples/src/test/java/org/mapfish/print/HumanAlphaSerie.java
@@ -59,7 +59,7 @@ public class HumanAlphaSerie {
     private static String convertToString(Stack<Integer> array) {
         StringBuilder sb = new StringBuilder();
 
-        while (array.size() != 0) {
+        while (!array.isEmpty()) {
             int number = array.pop();
             sb.append(numberToChar(number));
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.