### PR TITLE
Prevent exception on wrong geometry in GeoJSON

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/AbstractGeotoolsLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/AbstractGeotoolsLayer.java
@@ -15,6 +15,8 @@ import org.mapfish.print.attribute.map.MapLayer;
 import org.mapfish.print.attribute.map.MapfishMapContext;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.map.AbstractLayerParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -32,6 +34,7 @@ import static org.mapfish.print.Constants.OPACITY_PRECISION;
  */
 public abstract class AbstractGeotoolsLayer implements MapLayer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGeotoolsLayer.class);
     private final ExecutorService executorService;
     private final AbstractLayerParams params;
 
@@ -116,7 +119,11 @@ public abstract class AbstractGeotoolsLayer implements MapLayer {
             final ReferencedEnvelope mapArea = bounds.toReferencedEnvelope(paintArea, transformer.getDPI());
             renderer.paint(graphics2D, paintArea, mapArea);
         } catch (Exception e) {
-            throw ExceptionUtils.getRuntimeException(e);
+            if (e instanceof NullPointerException || e.getCause() instanceof NullPointerException) {
+                LOGGER.info("Rendering layer failed", e);
+            } else {
+                throw ExceptionUtils.getRuntimeException(e);
+            }
         } finally {
             content.dispose();
         }


### PR DESCRIPTION
With some invalid GeoJSON document like [this one](http://jenselme.perso.centrale-marseille.fr/visible/payload-invalid-geojson.json), MFP fires an exceptions. This PR ignore the invalid geometry.