### PR TITLE
Improve configurability through system properties

### DIFF
--- a/core/src/main/resources/mapfish-spring-application-context.xml
+++ b/core/src/main/resources/mapfish-spring-application-context.xml
@@ -15,7 +15,7 @@
     <import resource="mapfish-spring-named-styles.xml" />
 
     <context:annotation-config/>
-    <context:property-placeholder system-properties-mode="FALLBACK" file-encoding="UTF-8" location="classpath:mapfish-spring.properties"/>
+    <context:property-placeholder system-properties-mode="OVERRIDE" file-encoding="UTF-8" location="classpath:mapfish-spring.properties"/>
 
     <!--<bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter">-->
         <!--<property name="pathMatcher">-->
@@ -41,10 +41,10 @@
     </bean>
 
     <bean id="jobManager" class="org.mapfish.print.servlet.job.ThreadPoolJobManager">
-        <property name="maxNumberOfRunningPrintJobs" value="10" />
+        <property name="maxNumberOfRunningPrintJobs" value="${maxNumberOfRunningPrintJobs}" />
         <property name="maxNumberOfWaitingJobs" value="5000" />
         <!-- Timeout for print jobs in seconds -->
-        <property name="timeout" value="600" />
+        <property name="timeout" value="${printTimeout}" />
         <!-- Timeout after which a print job is canceled, if the status has not been checked (in seconds). -->
         <property name="abandonedTimeout" value="120" />
         <property name="oldFileCleanUp" value="${fileCleanUp}" />

--- a/core/src/main/resources/mapfish-spring.properties
+++ b/core/src/main/resources/mapfish-spring.properties
@@ -16,3 +16,8 @@ fileCleanUpMaxAgeReport=86400
 # the clean-up process will remove these directories.
 fileCleanUpMaxAgeTaskDir=86400
 
+# The maximum number of threads that will be used for print jobs.
+maxNumberOfRunningPrintJobs=10
+
+# A print job is cancelled, if it is not completed after this amount of time (in seconds).
+printTimeout=600


### PR DESCRIPTION
Now, if system properties are defined, they override what's defined in
mapfish-spring.properties. This is nicer in a Docker context since they can
then be tuned by defining CATALINA_OPTS=-DmaxNumberOfRunningPrintJobs=12, for
example.

Added two new properties:
- maxNumberOfRunningPrintJobs
- printTimeout