### PR TITLE
Add config option to disable automatic WMS merge

### DIFF
--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -17,6 +17,7 @@ Here is the general structure:
   ?integerSvg: false # the library in MapServer <= 5.6 does not support floating point values in the SVG coordinate space, set this to true if using a WMS that does not support floating point values in SVG coordinates
 
   ?ignoreCapabilities: false # assume client is correct and do not load capabilities.  This is not recommended to be used unless you it fails when false (false is default)
+  ?disableLayersMerging: false # WMS layers with mergable parameters will be merged by default. Set this to true to disable attempts to merge.
   ?maxPrintTimeBeforeWarningInSeconds: 30 # if print jobs take longer than this then a warning in the logs will be written along with the spec.
   ?printTimeoutMinutes: 5 # The maximum time to allow a print job to take before cancelling the print job.  The default is 5 (minutes)
   ?formats:

--- a/src/main/java/org/mapfish/print/config/Config.java
+++ b/src/main/java/org/mapfish/print/config/Config.java
@@ -76,6 +76,7 @@ public class Config implements Closeable {
     private boolean ignoreCapabilities = false;
     private int maxPrintTimeBeforeWarningInSeconds = 30;
     private int printTimeoutMinutes = 5;
+    private boolean disableLayersMerging = false;
 
     private ThreadResources threadResources;
 
@@ -407,6 +408,14 @@ public class Config implements Closeable {
 
     public void setConnectionTimeout(int connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
+    }
+    
+    public void setDisableLayersMerging(boolean disableLayersMerging) {
+       this.disableLayersMerging = disableLayersMerging;
+    }
+    
+    public boolean isDisableLayersMerging() {
+        return disableLayersMerging;
     }
 
     public String getOutputFilename(String layoutName) {

--- a/src/main/java/org/mapfish/print/map/readers/WMSMapReader.java
+++ b/src/main/java/org/mapfish/print/map/readers/WMSMapReader.java
@@ -211,7 +211,7 @@ public class WMSMapReader extends TileableMapReader {
     }
     @Override
     public boolean testMerge(MapReader other) {
-        if (canMerge(other)) {
+        if (!context.getConfig().isDisableLayersMerging() && canMerge(other)) {
             WMSMapReader wms = (WMSMapReader) other;
             layers.addAll(wms.layers);
             styles.addAll(wms.styles);


### PR DESCRIPTION
Actually a six year old request and patch from http://trac.mapfish.org/trac/mapfish/ticket/598 that we found currently useful.

Introduces the config option disableLayersMerging (default false) that can disable the automatic WMS merge that is done my mapfish when WMS layer parameters are mergable.