### PR TITLE
Create unique snaphot releases

### DIFF
--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -59,7 +59,7 @@ if (Boolean.parseBoolean(enablePublishing)) {
                 }
                 snapshotRepository(url: "https://$host/content/repositories/snapshots")  {
                     authentication(userName: sonatypeUsername, password: sonatypePassword)
-                    uniqueVersion = false
+                    uniqueVersion = true
                 }
                 def extAnd = {file, ext ->
                     file.name.endsWith(ext) || file.name.endsWith(".asc") || file.name.endsWith(".pom")


### PR DESCRIPTION
To ensure compatibility with Maven 3. Otherwise Maven complains that a corresponding POM can not be found.

cc @pmauduit