### PR TITLE
Make route for capabilities consistent with other routes

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -591,7 +591,7 @@ public class MapPrinterServlet extends BaseMapServlet {
      * @param jsonpCallback        if given the result is returned with a function call wrapped around it
      * @param capabilitiesResponse the response object
      */
-    @RequestMapping(value = "/{appId:\\w+}" + CAPABILITIES_URL, method = RequestMethod.GET)
+    @RequestMapping(value = "/{appId}" + CAPABILITIES_URL, method = RequestMethod.GET)
     public final void getCapabilities(
             @PathVariable final String appId,
             @RequestParam(value = "pretty", defaultValue = "false") final boolean pretty,


### PR DESCRIPTION
The route for the capabilities service defined the `appId` parameter differently than all other services. While it was ok to print a report for a configuration `my-print-app`, you could not request the capabilities (because of the `-` character).

This PR changes the definition so that it is consistent among all services.