### PR TITLE
Fix failing tests in function of order

### DIFF
--- a/core/src/test/java/org/mapfish/print/processor/http/AbstractHttpProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/http/AbstractHttpProcessorTest.java
@@ -82,6 +82,7 @@ public abstract class AbstractHttpProcessorTest extends AbstractMapfishSpringTes
     }
 
     @Test
+    @DirtiesContext
     public void testCreateMapDependency() throws Exception {
 
         this.configurationFactory.setDoValidation(false);

--- a/core/src/test/java/org/mapfish/print/processor/http/MapUriBug228ProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/http/MapUriBug228ProcessorTest.java
@@ -16,6 +16,7 @@ import org.mapfish.print.output.Values;
 import org.mapfish.print.processor.ProcessorDependencyGraph;
 import org.mapfish.print.processor.ProcessorGraphNode;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
@@ -41,6 +42,7 @@ public class MapUriBug228ProcessorTest extends AbstractMapfishSpringTest {
         return "map-uri";
     }
     @Test
+    @DirtiesContext
     public void bug228FixMapUri() throws Exception {
         this.configurationFactory.setDoValidation(false);
         final Configuration config = configurationFactory.getConfig(getFile(baseDir() + "/map-uri-228-bug-fix-config.yaml"));

--- a/core/src/test/java/org/mapfish/print/processor/jasper/TableProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/jasper/TableProcessorTest.java
@@ -165,6 +165,7 @@ public class TableProcessorTest extends AbstractMapfishSpringTest {
     }
 
     @Test
+    @DirtiesContext
     public void testTableConverters() throws Exception {
         httpRequestFactory.registerHandler(new Predicate<URI>() {
             @Override


### PR DESCRIPTION
Sprinkled a few @DirtiesContext to avoid failing tests in function
of their run order.