### PR TITLE
Correct height and width of the WMS image for high DPI

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -69,6 +69,9 @@ public final class WmsUtilities {
 
         if (wmsLayerParam.serverType != null && dpi != Constants.PDF_DPI) {
             addDpiParam(extraParams, (int) Math.round(dpi), wmsLayerParam.serverType);
+            int width = (int) (imageSize.width * dpi / Constants.PDF_DPI);
+            int height = (int) (imageSize.height * dpi / Constants.PDF_DPI);
+            getMapRequest.setDimensions(width, height);
         }
         return URIUtils.addParams(getMapUri, extraParams, Collections.<String>emptySet());
 


### PR DESCRIPTION
Currently, MFP doesn't take into account the DPI when calculating the size of the image to request to the WMS server. This means that, for instance, with a DPI of 72 and 150 it will request a tile with WIDTH=1093 and HEIGHT=1510. The problem is that with MapServer and MAP_RESOLUTION set to 150, the representation of the layer can be incorrect (height and width too small for current DPI resulting in wrong scaling of symbols). We get:
![screenshot from 2016-08-03 15-47-09](https://cloud.githubusercontent.com/assets/6643536/17367944/5ae07972-5992-11e6-837e-427c066fe160.png)


instead of:
![screenshot from 2016-08-03 15-47-20](https://cloud.githubusercontent.com/assets/6643536/17367946/5ddbffb6-5992-11e6-8c79-b7e7cc478a33.png)


A similar issue should appear with other cartographic servers.

With this commit, the DPI is correctly taken into account to calculate the height and width of the tile. This means that for instance, with a DPI of 72, it will request a tile with WIDTH=1093 and HEIGHT=1510. But with a DPI of 150, it will request a tile with WIDTH=2277 and HEIGHT=3146. This way, the representation of the layer is correct.

The formula used for the calculation is [based on the one used by [MapServer](http://www.mapserver.org/development/rfc/ms-rfc-55.html#usage-example).