### PR TITLE
Fix gradle CLI target

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,6 +24,7 @@ task startScripts(type: CreateStartScripts) {
 }
 task print(type: JavaExec) {
     main = "org.mapfish.print.cli.Main"
+    classpath = sourceSets.main.runtimeClasspath
 }
 
 // define what should be included as distribution. usually this configuration


### PR DESCRIPTION
Fixes https://github.com/mapfish/mapfish-print/issues/443

Now a report can be generated with:
```
CONF="$(readlink -e examples/src/test/resources/examples/simple)"
./gradlew print -PprintArgs="-config $CONF/config.yaml -spec $CONF/requestData.json -output /tmp/out.pdf"

```