### PR TITLE
Allows to have empty processor list

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/jasper/DataSourceProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/DataSourceProcessor.java
@@ -204,7 +204,7 @@ public final class DataSourceProcessor extends AbstractProcessor<DataSourceProce
 
     @Override
     protected void extraValidation(final List<Throwable> validationErrors, final Configuration configuration) {
-        if (this.processorGraph == null || this.processorGraph.getAllProcessors().isEmpty()) {
+        if (this.processorGraph == null) {
             validationErrors.add(new ConfigurationException("There are child processors for this processor"));
         }
 


### PR DESCRIPTION
Useful with create datasource

See example: https://github.com/sbrunner/crdppf/blob/master/config.yaml#L68