### PR TITLE
Revert "Correct height and width of the WMS image for high DPI"

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -69,9 +69,6 @@ public final class WmsUtilities {
 
         if (wmsLayerParam.serverType != null && dpi != Constants.PDF_DPI) {
             addDpiParam(extraParams, (int) Math.round(dpi), wmsLayerParam.serverType);
-            int width = (int) (imageSize.width * dpi / Constants.PDF_DPI);
-            int height = (int) (imageSize.height * dpi / Constants.PDF_DPI);
-            getMapRequest.setDimensions(width, height);
         }
         return URIUtils.addParams(getMapUri, extraParams, Collections.<String>emptySet());
 


### PR DESCRIPTION
This reverts commit 754995fee07f670553c9083bf1a068c3f46eef19

This doesn't seem to have an effect, plus the height and width look correct now.