### PR TITLE
Fix Verboseexample Port

### DIFF
--- a/examples/src/test/resources/examples/verboseExample/config.yaml
+++ b/examples/src/test/resources/examples/verboseExample/config.yaml
@@ -36,7 +36,7 @@ templates:
     - !restrictUris
       matchers:
         - !localMatch
-          port : 9876
+          port : 8080
           pathRegex : /.+
     - !reportBuilder # compile all reports in current directory
       directory: '.'


### PR DESCRIPTION
verboseExample is failing to download legend images because of the wrong port specified in config.yaml.