### PR TITLE
Improve output of integration tests (a bit)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'org.akhikhl.gretty:gretty:+'
+    classpath 'org.akhikhl.gretty:gretty:1.4.0'
   }
 }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -42,6 +42,12 @@ test { }
 test.onlyIf{false}
 
 task integrationTest(type: Test) {
+    testLogging {
+        exceptionFormat = 'full'
+        showCauses true
+        showExceptions true
+        showStackTraces true
+    }
 }
 integrationTest.dependsOn ':core:compileJava'
 


### PR DESCRIPTION
In case of an error, it is hard to see why the integration tests are failing. This PR enables logging in Gradle.

```
org.mapfish.print.ExamplesTest > testAllExamples FAILED
    java.lang.AssertionError: 
    1 errors encountered while running 57 examples.
    See Standard Error for the stack traces.  A summary is as follows:

        * simple (requestData.json) -> attribute [spec.attributes.map.layers[0].type] missing
        at org.junit.Assert.fail(Assert.java:88)
        at org.mapfish.print.ExamplesTest.testAllExamples(ExamplesTest.java:142)
```

There is still the problem that the output of GeoServer is polluting the logs, but I haven't found a way to configure it with Gretty (see https://github.com/akhikhl/gretty/issues/303). We could try extract the GeoServer WAR, add a custom log configuation (similar to [this](https://github.com/mapfish/mapfish-print/blob/5282d68841ab730b8b0c829ce686f65bd5c55d36/examples/build.gradle#L23-L65)), then create a WAR again and [run the WAR with Gretty](http://akhikhl.github.io/gretty-doc/Farm-web-app-list.html#_file_based_web_app_references).