### PR TITLE
Check for labelAlign in text style

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/style/json/JsonStyleParserHelper.java
+++ b/core/src/main/java/org/mapfish/print/map/style/json/JsonStyleParserHelper.java
@@ -536,7 +536,7 @@ public final class JsonStyleParserHelper {
             }
         });
 
-        if (anchorX == null && anchorY == null) {
+        if (anchorX == null && anchorY == null && styleJson.has(JSON_LABEL_ALIGN)) {
             String labelAlign = styleJson.getString(JSON_LABEL_ALIGN);
             String xAlign = labelAlign.substring(0, 1);
             String yAlign = labelAlign.substring(1, 2);

--- a/core/src/test/java/org/mapfish/print/map/style/json/JsonStyleParserHelperTest.java
+++ b/core/src/test/java/org/mapfish/print/map/style/json/JsonStyleParserHelperTest.java
@@ -240,6 +240,30 @@ public class JsonStyleParserHelperTest {
     }
 
     @Test
+    public void testCreateTextSymbolizerRotated() throws Exception {
+        final String fontColor = "#333333";
+        final String fontStyle = "normal";
+        final String fontFamily = "Arial, sans-serif";
+        final String fontWeight = "bold";
+
+
+        JSONObject style = new JSONObject();
+        style.put("label", "name");
+        style.put("fontColor", fontColor);
+        style.put("fontStyle", fontStyle);
+        style.put("fontFamily", fontFamily);
+        style.put("fontWeight", fontWeight);
+        style.put("fontSize", "12");
+        style.put("labelRotation", "45");
+
+        final PJsonObject pStyle = new PJsonObject(style, null);
+        TextSymbolizer symbolizer = helper.createTextSymbolizer(pStyle);
+        assertNotNull(symbolizer);
+
+        transformer.transform(symbolizer);  // test that it can be written to xml correctly
+    }
+
+    @Test
     public void testCreateTextSymbolizerInPX() throws Exception {
         final String fontColor = "#333333";
         final String fontStyle = "normal";


### PR DESCRIPTION
When using a rotation for text labels, the request parsing fails with an error message like `org.mapfish.print.wrapper.ObjectMissingException: attribute [.labelAlign] missing`. But `labelAlign` is actually not required if a label rotation is used.

This PR proposes to add a simple check if `labelAlign` is set.
