### PR TITLE
Fix URL rewrite for icons in SLD and JSON styles

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -178,6 +178,7 @@ dependencies {
     compile ('org.apache.xmlgraphics:batik-transcoder:1.7'){
         exclude module: 'fop'
     }
+    compile ('org.apache.xmlgraphics:batik-codec:1.7')
     providedCompile('com.google.code.findbugs:jsr305:2.0.1')
 
     providedCompile('javax.servlet:servlet-api:2.5')

--- a/core/src/main/java/org/mapfish/print/map/style/json/MapfishJsonStyleVersion1.java
+++ b/core/src/main/java/org/mapfish/print/map/style/json/MapfishJsonStyleVersion1.java
@@ -24,6 +24,7 @@ import org.mapfish.print.wrapper.json.PJsonObject;
 import org.opengis.filter.Filter;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
+import org.springframework.http.client.ClientHttpRequestFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -53,10 +54,11 @@ public final class MapfishJsonStyleVersion1 {
     MapfishJsonStyleVersion1(@Nonnull final PJsonObject json,
                              @Nonnull final StyleBuilder styleBuilder,
                              @Nonnull final Configuration configuration,
-                             @Nonnull final String defaultGeomAttName) {
+                             @Nonnull final String defaultGeomAttName,
+                             @Nonnull final ClientHttpRequestFactory clientHttpRequestFactory) {
         this.json = json;
         this.sldStyleBuilder = styleBuilder;
-        this.parserHelper = new JsonStyleParserHelper(configuration, this.sldStyleBuilder, true, Versions.ONE);
+        this.parserHelper = new JsonStyleParserHelper(configuration, this.sldStyleBuilder, true, Versions.ONE, clientHttpRequestFactory);
         this.geometryProperty = defaultGeomAttName;
     }
 

--- a/core/src/main/java/org/mapfish/print/map/style/json/MapfishJsonStyleVersion2.java
+++ b/core/src/main/java/org/mapfish/print/map/style/json/MapfishJsonStyleVersion2.java
@@ -16,6 +16,7 @@ import org.mapfish.print.config.Configuration;
 import org.mapfish.print.wrapper.json.PJsonArray;
 import org.mapfish.print.wrapper.json.PJsonObject;
 import org.opengis.filter.Filter;
+import org.springframework.http.client.ClientHttpRequestFactory;
 
 import java.util.Iterator;
 import java.util.List;
@@ -65,14 +66,17 @@ public final class MapfishJsonStyleVersion2 {
 
     private final PJsonObject json;
     private final StyleBuilder styleBuilder;
+    private final ClientHttpRequestFactory clientHttpRequestFactory;
     private final JsonStyleParserHelper parserHelper;
 
     MapfishJsonStyleVersion2(@Nonnull final PJsonObject json,
                              @Nonnull final StyleBuilder styleBuilder,
-                             @Nonnull final Configuration configuration) {
+                             @Nonnull final Configuration configuration,
+                             @Nonnull final ClientHttpRequestFactory clientHttpRequestFactory) {
         this.json = json;
         this.styleBuilder = styleBuilder;
-        this.parserHelper = new JsonStyleParserHelper(configuration, styleBuilder, false, Versions.TWO);
+        this.clientHttpRequestFactory = clientHttpRequestFactory;
+        this.parserHelper = new JsonStyleParserHelper(configuration, styleBuilder, false, Versions.TWO, clientHttpRequestFactory);
     }
 
     Style parseStyle() {

--- a/core/src/main/java/org/mapfish/print/processor/http/MapUriProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/MapUriProcessor.java
@@ -6,6 +6,8 @@ import org.mapfish.print.ExceptionUtils;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.http.AbstractMfClientHttpRequestFactoryWrapper;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
 
@@ -32,6 +34,7 @@ import java.util.regex.Pattern;
  * [[examples=http_processors,osm_custom_params]]
  */
 public final class MapUriProcessor extends AbstractClientHttpRequestFactoryProcessor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MapUriProcessor.class);
     private final Map<Pattern, String> uriMapping = Maps.newHashMap();
 
     /**
@@ -61,12 +64,15 @@ public final class MapUriProcessor extends AbstractClientHttpRequestFactoryProce
                 for (Map.Entry<Pattern, String> entry : MapUriProcessor.this.uriMapping.entrySet()) {
                     Matcher matcher = entry.getKey().matcher(uriString);
                     if (matcher.matches()) {
+                        LOGGER.debug("URI {} matched {}", uriString, entry.getKey());
                         final String finalUri = matcher.replaceAll(entry.getValue());
                         try {
                             return requestFactory.createRequest(new URI(finalUri), httpMethod);
                         } catch (URISyntaxException e) {
                             throw ExceptionUtils.getRuntimeException(e);
                         }
+                    } else {
+                        LOGGER.debug("URI {} did not match {}", uriString, entry.getKey());
                     }
                 }
                 return requestFactory.createRequest(uri, httpMethod);

--- a/core/src/test/java/org/mapfish/print/map/style/json/JsonStyleParserHelperTest.java
+++ b/core/src/test/java/org/mapfish/print/map/style/json/JsonStyleParserHelperTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mapfish.print.Constants;
 import org.mapfish.print.MapPrinter;
+import org.mapfish.print.TestHttpClientFactory;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.wrapper.json.PJsonArray;
 import org.mapfish.print.wrapper.json.PJsonObject;
@@ -31,6 +32,8 @@ import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.style.GraphicalSymbol;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 
 import java.io.File;
 import java.net.URI;
@@ -60,7 +63,9 @@ public class JsonStyleParserHelperTest {
         Configuration configuration = new Configuration();
         final File file = getFile(MapfishJsonStyleParserPluginTest.class, REQUEST_DATA_STYLE_JSON_V1_STYLE_JSON);
         configuration.setConfigurationFile(file);
-        helper = new JsonStyleParserHelper(configuration, new StyleBuilder(), true, Versions.ONE);
+        final ClientHttpRequestFactory clientHttpRequestFactory = new TestHttpClientFactory();
+        helper = new JsonStyleParserHelper(configuration, new StyleBuilder(), true, Versions.ONE,
+                clientHttpRequestFactory);
     }
 
     private File getFile(Class<?> base, String fileName) throws URISyntaxException {


### PR DESCRIPTION
The solution is not 100% perfect (only the URL remapping is taken into account), but it's an easyfix that solves the customers' need.

Fix PNG in SVG layer. Was missing a Batik library for including images in SVG.