### PR TITLE
Fix multi-instance mode (hibernate)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -335,4 +335,5 @@ task createDocker(type: Docker, dependsOn: 'unzipWar') {
     setEnvironment('SPRING_LOG_LEVEL', 'WARN')
     setEnvironment('JASPER_LOG_LEVEL', 'WARN')
     setEnvironment('APACHE_LOG_LEVEL', 'WARN')
+    setEnvironment('SQL_LOG_LEVEL', 'WARN')
 }

--- a/core/logback-custom.xml
+++ b/core/logback-custom.xml
@@ -8,4 +8,5 @@
     <logger name="com.codahale.metrics" level="INFO" />
     <logger name="net.sf.jasperreports" level="${JASPER_LOG_LEVEL}" />
     <logger name="org.apache" level="${APACHE_LOG_LEVEL}" />
+    <logger name="org.hibernate" level="${SQL_LOG_LEVEL}" />
 </included>

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
@@ -363,10 +363,8 @@ public class ThreadPoolJobManager implements JobManager {
     
     @Override
     public final PrintJobStatus getStatus(final String referenceId) throws NoSuchReferenceException {
-        PrintJobStatus jobStatus = null;
-
         // check if the reference id is valid
-        jobStatus = this.jobQueue.get(referenceId, true);
+        final PrintJobStatus jobStatus = this.jobQueue.get(referenceId, true);
         jobStatus.getEntry().assertAccess();
                 
         if (jobStatus.getStatus() == PrintJobStatus.Status.WAITING) {

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernateJobQueue.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernateJobQueue.java
@@ -28,7 +28,6 @@ import javax.annotation.PreDestroy;
  */
 @Transactional
 public class HibernateJobQueue implements JobQueue {
-
     private static final int DEFAULT_TIME_TO_KEEP_AFTER_ACCESS = 30; /* minutes */
 
     private static final long DEFAULT_CLEAN_UP_INTERVAL = 300; /* seconds */
@@ -96,8 +95,7 @@ public class HibernateJobQueue implements JobQueue {
         }
         record.setStatusTime(now);
         if (!record.isDone() && external) {
-            record.setLastCheckTime(System.currentTimeMillis());
-            this.dao.save(record);
+            this.dao.updateLastCheckTime(referenceId, System.currentTimeMillis());
         }
         return record;
     }
@@ -222,5 +220,4 @@ public class HibernateJobQueue implements JobQueue {
             }
         });
     }
-
 }

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
     <logger name="com.codahale.metrics.JmxReporter" level="INFO" />
     <logger name="org.springframework" level="WARN" />
     <logger name="org.apache" level="WARN" />
+    <logger name="org.hibernate" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="standardOut" />


### PR DESCRIPTION
Some jobs were never ending or were being run twice because the
job status was put back to RUNNING when the client was getting the
status.