### PR TITLE
Remove oraclejdk7 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ services:
 - docker
 
 jdk:
-- oraclejdk7
 - openjdk7
 - oraclejdk8
 
@@ -43,4 +42,4 @@ deploy:
   skip_cleanup: true
   on:
     repo: mapfish/mapfish-print
-    java: oraclejdk7
+    java: openjdk7


### PR DESCRIPTION
It was timeouting in the integration tests quite often.