### PR TITLE
Be more strict around scale usage

### DIFF
--- a/BREAKING-CHANGES.rst
+++ b/BREAKING-CHANGES.rst
@@ -12,3 +12,4 @@ The processor graph is more strict
   e.g. the !createScaleBar should be after the !createMap processor.
 - In the !prepareLegend processor, the legend output is renamed to legendDataSource
 - In the !prepareTable processor, the table output is renamed to tableDataSource
+- In the mapContext the method getRoundedScale is renamed to getRoundedScaleDenominator

--- a/core/src/main/java/org/mapfish/print/attribute/map/CenterScaleMapBounds.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/CenterScaleMapBounds.java
@@ -20,28 +20,29 @@ import java.awt.Rectangle;
  */
 public final class CenterScaleMapBounds extends MapBounds {
     private final Coordinate center;
-    private final Scale scale;
+    private final double scaleDenominator;
     /**
      * Constructor.
      *
      * @param projection the projection these bounds are defined in.
      * @param centerX the x coordinate of the center point.
      * @param centerY the y coordinate of the center point.
-     * @param scale the scale of the map
+     * @param scaleDenominator the scale denominator of the map
      */
-    public CenterScaleMapBounds(final CoordinateReferenceSystem projection, final double centerX,
-                                final double centerY, final Scale scale) {
+    public CenterScaleMapBounds(
+            final CoordinateReferenceSystem projection, final double centerX,
+            final double centerY, final double scaleDenominator) {
         super(projection);
         this.center = new Coordinate(centerX, centerY);
-        this.scale = scale;
+        this.scaleDenominator = scaleDenominator;
     }
 
 
     @Override
     public ReferencedEnvelope toReferencedEnvelope(final Rectangle paintArea, final double dpi) {
 
-        double geoWidthInches = this.scale.getDenominator() * paintArea.width / dpi;
-        double geoHeightInches = this.scale.getDenominator() * paintArea.height / dpi;
+        double geoWidthInches = this.scaleDenominator * paintArea.width / dpi;
+        double geoHeightInches = this.scaleDenominator * paintArea.height / dpi;
 
         ReferencedEnvelope bbox;
 
@@ -77,25 +78,20 @@ public final class CenterScaleMapBounds extends MapBounds {
             final boolean geodetic,
             final Rectangle paintArea, final double dpi) {
 
-        Scale resultScale;
-        if (geodetic) {
-            final Scale currentScale = getScaleDenominator(paintArea, dpi);
-            final Scale geodeticScale = getGeodeticScaleDenominator(paintArea, dpi);
-            final ZoomLevelSnapStrategy.SearchResult result = zoomLevelSnapStrategy.search(
-                    geodeticScale, tolerance, zoomLevels);
-            resultScale = new Scale(result.getScale().getDenominator() *
-                    currentScale.getDenominator() / geodeticScale.getDenominator());
-        } else {
-            final ZoomLevelSnapStrategy.SearchResult result = zoomLevelSnapStrategy.search(this.scale, tolerance, zoomLevels);
-            resultScale = result.getScale();
-        }
+        final double currentScaleDenominator = getScaleDenominator(paintArea, dpi);
+        final double geodeticScaleDenominator = new Scale(currentScaleDenominator, getProjection(), dpi)
+                .getDenominator(geodetic, getProjection(), dpi, this.center);
+        final ZoomLevelSnapStrategy.SearchResult result = zoomLevelSnapStrategy.search(
+                geodeticScaleDenominator, tolerance, zoomLevels);
+        final double resultScaleDenominator = result.getScaleDenominator();
 
-        return new CenterScaleMapBounds(getProjection(), this.center.x, this.center.y, resultScale);
+        return new CenterScaleMapBounds(getProjection(), this.center.x, this.center.y,
+                resultScaleDenominator);
     }
 
     @Override
-    public Scale getScaleDenominator(final Rectangle paintArea, final double dpi) {
-        return this.scale;
+    public double getScaleDenominator(final Rectangle paintArea, final double dpi) {
+        return this.scaleDenominator;
     }
 
     @Override
@@ -110,13 +106,18 @@ public final class CenterScaleMapBounds extends MapBounds {
             return this;
         }
 
-        final double newDenominator = this.scale.getDenominator() * factor;
-        return new CenterScaleMapBounds(getProjection(), this.center.x, this.center.y, new Scale(newDenominator));
+        final double newDenominator = this.scaleDenominator * factor;
+        return new CenterScaleMapBounds(getProjection(), this.center.x, this.center.y, newDenominator);
     }
 
     @Override
-    public MapBounds zoomToScale(final double newScale) {
-        return new CenterScaleMapBounds(getProjection(), this.center.x, this.center.y, new Scale(newScale));
+    public MapBounds zoomToScale(final double newScaleDenominator) {
+        return new CenterScaleMapBounds(getProjection(), this.center.x, this.center.y, newScaleDenominator);
+    }
+
+    @Override
+    public Coordinate getCenter() {
+        return this.center;
     }
 
     private ReferencedEnvelope computeGeodeticBBox(final double geoWidthInInches, final double geoHeightInInches) {
@@ -187,7 +188,7 @@ public final class CenterScaleMapBounds extends MapBounds {
         if (!center.equals(that.center)) {
             return false;
         }
-        if (!scale.equals(that.scale)) {
+        if (this.scaleDenominator != that.scaleDenominator) {
             return false;
         }
 
@@ -198,7 +199,7 @@ public final class CenterScaleMapBounds extends MapBounds {
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + center.hashCode();
-        result = 31 * result + scale.hashCode();
+        result = 31 * result + new Double(scaleDenominator).hashCode();
         return result;
     }
 
@@ -206,7 +207,7 @@ public final class CenterScaleMapBounds extends MapBounds {
     public String toString() {
         return "CenterScaleMapBounds{" +
                "center=" + center +
-               ", scale=" + scale +
+               ", scaleDenominator=" + scaleDenominator +
                '}';
     }
     // CHECKSTYLE:ON

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapAttribute.java
@@ -8,7 +8,6 @@ import org.mapfish.print.ExceptionUtils;
 import org.mapfish.print.attribute.map.OverviewMapAttribute.OverviewMapAttributeValues;
 import org.mapfish.print.attribute.map.ZoomToFeatures.ZoomType;
 import org.mapfish.print.config.Template;
-import org.mapfish.print.map.Scale;
 import org.mapfish.print.parser.CanSatisfyOneOf;
 import org.mapfish.print.parser.HasDefaultValue;
 import org.mapfish.print.parser.OneOf;
@@ -175,9 +174,8 @@ public final class MapAttribute extends GenericMapAttribute {
             if (this.center != null) {
                 double centerX = this.center[0];
                 double centerY = this.center[1];
-                Scale scaleObject = new Scale(this.scale);
 
-                bounds = new CenterScaleMapBounds(crs, centerX, centerY, scaleObject);
+                bounds = new CenterScaleMapBounds(crs, centerX, centerY, this.scale);
             } else if (this.bbox != null) {
                 final int maxYIndex = 3;
                 double minX = this.bbox[0];
@@ -189,10 +187,12 @@ public final class MapAttribute extends GenericMapAttribute {
                 Envelope area = this.areaOfInterest.getArea().getEnvelopeInternal();
                 bounds = new BBoxMapBounds(crs, area);
             } else if (this.zoomToFeatures != null) {
-                bounds = new BBoxMapBounds(crs, 0, 0, 0, 0);
+                // CSOFF: MagicNumber
+                bounds = new BBoxMapBounds(crs, 0, 0, 10, 10);
+                // CSON: MagicNumber
             } else {
-                throw new IllegalArgumentException("Expected either: center and scale, bbox, or an areaOfInterest defined in order to " +
-                                                   "calculate the map bounds");
+                throw new IllegalArgumentException("Expected either: center and scale, bbox, or an " +
+                        "areaOfInterest defined in order to calculate the map bounds");
             }
             return bounds;
         }

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapfishMapContext.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapfishMapContext.java
@@ -148,10 +148,10 @@ public final class MapfishMapContext {
     }
 
     public Scale getScale() {
-        return this.bounds.getScaleDenominator(getPaintArea(), this.dpi);
+        return new Scale(this.bounds.getScaleDenominator(getPaintArea(), this.dpi), getBounds().getProjection(), getRequestorDPI());
     }
-    public Scale getGeodeticScale() {
-        return this.bounds.getGeodeticScaleDenominator(getPaintArea(), this.dpi);
+    public double getGeodeticScaleDenominator() {
+        return getScale().getGeodeticDenominator(this.bounds.getProjection(), this.dpi, getBounds().getCenter());
     }
 
     /**
@@ -160,11 +160,11 @@ public final class MapfishMapContext {
      *     One of the output parameters of the {@link org.mapfish.print.processor.map.CreateMapProcessor}
      *     is 'mapContext' which can be accessed in a template.  If the scale is required in the template
      *     then it can be accessed via:
-     *     <code>$P{mapContext}.getRoundedScale()</code>
+     *     <code>$P{mapContext}.getRoundedScaleDenominator()</code>
      * </p>
      */
-    public double getRoundedScale() {
-        return getRoundedScale(false);
+    public double getRoundedScaleDenominator() {
+        return getRoundedScaleDenominator(false);
     }
 
     /**
@@ -173,30 +173,26 @@ public final class MapfishMapContext {
      *     One of the output parameters of the {@link org.mapfish.print.processor.map.CreateMapProcessor}
      *     is 'mapContext' which can be accessed in a template.  If the scale is required in the template
      *     then it can be accessed via:
-     *     <code>$P{mapContext}.getRoundedScale()</code>
+     *     <code>$P{mapContext}.getRoundedScaleDenominato()</code>
      * </p>
      *
      * @param geodetic Get geodetic scale
      */
-    public double getRoundedScale(final boolean geodetic) {
-        double scale;
-        if (geodetic) {
-            scale = this.bounds.getGeodeticScaleDenominator(getPaintArea(), this.dpi).getDenominator();
-        } else {
-            scale = this.bounds.getScaleDenominator(getPaintArea(), this.dpi).getDenominator();
-        }
+    public double getRoundedScaleDenominator(final boolean geodetic) {
+        final double scaleDenominator = new Scale(
+                this.bounds.getScaleDenominator(getPaintArea(), this.dpi), getBounds().getProjection(), this.dpi
+        ).getDenominator(geodetic, getBounds().getProjection(), this.dpi, getBounds().getCenter());
 
-        final int numChars = String.format("%d", Math.round(scale)).length();
+        final int numChars = String.format("%d", Math.round(scaleDenominator)).length();
         if (numChars > 2) {
             // CSOFF: MagicNumber
             double factor = Math.pow(10, (numChars - 2));
             // CSON: MagicNumber
-            scale = Math.round(scale / factor) * factor;
-        } else if (scale > 1) {
-            scale = Math.round(scale);
+            return Math.round(scaleDenominator / factor) * factor;
+        } else if (scaleDenominator > 1) {
+            return Math.round(scaleDenominator);
         }
-
-        return scale;
+        return scaleDenominator;
     }
 
     /**

--- a/core/src/main/java/org/mapfish/print/attribute/map/OverviewMapAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/OverviewMapAttribute.java
@@ -2,7 +2,6 @@ package org.mapfish.print.attribute.map;
 
 import org.json.JSONArray;
 import org.mapfish.print.config.Template;
-import org.mapfish.print.map.Scale;
 import org.mapfish.print.parser.HasDefaultValue;
 import org.mapfish.print.parser.Requires;
 import org.mapfish.print.wrapper.PArray;
@@ -133,9 +132,8 @@ public final class OverviewMapAttribute extends GenericMapAttribute {
             if (this.center != null) {
                 double centerX = this.center[0];
                 double centerY = this.center[1];
-                Scale scaleObject = new Scale(this.scale);
 
-                bounds = new CenterScaleMapBounds(crs, centerX, centerY, scaleObject);
+                bounds = new CenterScaleMapBounds(crs, centerX, centerY, this.scale);
             } else if (this.bbox != null) {
                 final int maxYIndex = 3;
                 double minX = this.bbox[0];

--- a/core/src/main/java/org/mapfish/print/attribute/map/ZoomLevelSnapStrategy.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/ZoomLevelSnapStrategy.java
@@ -1,7 +1,5 @@
 package org.mapfish.print.attribute.map;
 
-import org.mapfish.print.map.Scale;
-
 /**
  * Enumerates the different strategies for finding the closest zoom-level/scale.
  */
@@ -12,16 +10,14 @@ public enum ZoomLevelSnapStrategy {
      */
     CLOSEST_LOWER_SCALE_ON_TIE {
         @Override
-        protected SearchResult search(final Scale scale, final double tolerance, final ZoomLevels zoomLevels) {
-            double targetScale = scale.getDenominator();
-
+        protected SearchResult search(final double scaleDenominator, final double tolerance, final ZoomLevels zoomLevels) {
             int pos = zoomLevels.size() - 1;
-            double distance = Math.abs(zoomLevels.get(pos) - targetScale);
+            double distance = Math.abs(zoomLevels.get(pos) - scaleDenominator);
 
             for (int i = zoomLevels.size() - 2; i >= 0; --i) {
                 double cur = zoomLevels.get(i);
 
-                double newDistance = Math.abs(targetScale - cur);
+                double newDistance = Math.abs(scaleDenominator - cur);
                 if (newDistance < distance) {
                     distance = newDistance;
                     pos = i;
@@ -39,15 +35,14 @@ public enum ZoomLevelSnapStrategy {
      */
     CLOSEST_HIGHER_SCALE_ON_TIE {
         @Override
-        protected SearchResult search(final Scale scale, final double tolerance, final ZoomLevels zoomLevels) {
-            double targetScale = scale.getDenominator();
+        protected SearchResult search(final double scaleDenominator, final double tolerance, final ZoomLevels zoomLevels) {
             int pos = zoomLevels.size() - 1;
-            double distance = Math.abs(zoomLevels.get(pos) - targetScale);
+            double distance = Math.abs(zoomLevels.get(pos) - scaleDenominator);
 
             for (int i = 1; i < zoomLevels.size(); i++) {
                 double cur = zoomLevels.get(i);
 
-                double newDistance = Math.abs(targetScale - cur);
+                double newDistance = Math.abs(scaleDenominator - cur);
                 if (newDistance < distance) {
                     distance = newDistance;
                     pos = i;
@@ -64,9 +59,8 @@ public enum ZoomLevelSnapStrategy {
      */
     HIGHER_SCALE {
         @Override
-        protected SearchResult search(final Scale scale, final double tolerance, final ZoomLevels zoomLevels) {
-            double targetScale = scale.getDenominator();
-            final double cutOff = targetScale * (1 - tolerance);
+        protected SearchResult search(final double scaleDenominator, final double tolerance, final ZoomLevels zoomLevels) {
+            final double cutOff = scaleDenominator * (1 - tolerance);
 
             int pos = zoomLevels.size() - 1;
             for (int i = zoomLevels.size() - 1; i >= 0; --i) {
@@ -86,9 +80,8 @@ public enum ZoomLevelSnapStrategy {
      */
     LOWER_SCALE {
         @Override
-        protected SearchResult search(final Scale scale, final double tolerance, final ZoomLevels zoomLevels) {
-            double targetScale = scale.getDenominator();
-            final double cutOff = targetScale * (1 + tolerance);
+        protected SearchResult search(final double scaleDenominator, final double tolerance, final ZoomLevels zoomLevels) {
+            final double cutOff = scaleDenominator * (1 + tolerance);
 
             int pos = 0;
             for (int i = 1; i < zoomLevels.size(); i++) {
@@ -107,13 +100,13 @@ public enum ZoomLevelSnapStrategy {
     /**
      * Search the provided zoomLevels for the scale that is the closest according to the current strategy.
      *
-     * @param targetScale the reference scale
+     * @param scaleDenominator the reference scale
      * @param tolerance the amount from one of the zoomLevels to still be considered <em>at</em> the scale.
      *      This is important for all strategies other than CLOSEST in order to prevent the scale from jumping
      *      to a different version even when it is very close to one of the zoomLevels.
      * @param zoomLevels the allowed zoomLevels
      */
-    protected abstract SearchResult search(Scale targetScale, double tolerance, ZoomLevels zoomLevels);
+    protected abstract SearchResult search(double scaleDenominator, double tolerance, ZoomLevels zoomLevels);
 
     /**
      * The results of a search.
@@ -135,8 +128,8 @@ public enum ZoomLevelSnapStrategy {
             return this.zoomLevels;
         }
 
-        public Scale getScale() {
-            return new Scale(this.zoomLevels.get(this.zoomLevel));
+        public double getScaleDenominator() {
+            return this.zoomLevels.get(this.zoomLevel);
         }
 
         // CHECKSTYLE:OFF

--- a/core/src/main/java/org/mapfish/print/map/Scale.java
+++ b/core/src/main/java/org/mapfish/print/map/Scale.java
@@ -1,58 +1,179 @@
 package org.mapfish.print.map;
 
+import com.vividsolutions.jts.geom.Coordinate;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.GeodeticCalculator;
+import org.mapfish.print.attribute.map.GenericMapAttribute;
+import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
 /**
- * Represent a scale denominator.  For example 1:10'000m which means 1 meter on the paper represent 10'000m on the ground.
+ * Represent a scale and provide transformation.
  */
 public final class Scale {
-    private final double denominator;
+    private final double resolution;
+    private static final Logger LOGGER = LoggerFactory.getLogger(Scale.class);
 
     /**
      * Constructor.
      *
-     * @param denominator the scale denominator.  a value of 1'000 would be a scale of 1:1'000
+     * @param denominator the scale denominator.  a value of 1'000 would be a scale of 1:1'000.
+     * @param projection the projection.
+     * @param dpi the DPI on witch the scale is valid.
      */
-    public Scale(final double denominator) {
-        this.denominator = denominator;
-    }
-
-    public double getDenominator() {
-        return this.denominator;
+    public Scale(final double denominator, @Nonnull final CoordinateReferenceSystem projection, final double dpi) {
+        this(denominator, DistanceUnit.fromProjection(projection), dpi);
     }
 
     /**
-     * Calculate the resolution for this scale.
+     * Constructor.
      *
-     * @param projection the projection to perform the calculation in
-     * @param dpi the dpi of the display device.
+     * @param denominator the scale denominator.  a value of 1'000 would be a scale of 1:1'000.
+     * @param projectionUnit the unit used by the projection.
+     * @param dpi the DPI on witch the scale is valid.
      */
-    public double toResolution(@Nonnull final CoordinateReferenceSystem projection, final double dpi) {
-        double normScale = normalizeScale(this.denominator);
-        final double distancePerInch = DistanceUnit.fromProjection(projection).convertTo(normScale, DistanceUnit.IN);
-        return 1.0 / (distancePerInch * dpi);
+    public Scale(final double denominator, @Nonnull final DistanceUnit projectionUnit, final double dpi) {
+        this(1.0 / (projectionUnit.convertTo(1.0 / denominator, DistanceUnit.IN) * dpi));
     }
 
-    private double normalizeScale(final double scale) {
-        if (scale > 1.0) {
-            return (1.0 / scale);
-        } else {
-            return scale;
+    /**
+     * Constructor.
+     *
+     * @param resolution the resolution.
+     */
+    private Scale(final double resolution) {
+        this.resolution = resolution;
+    }
+
+    /**
+     * Get the resolution.
+     * @return the resolution
+     */
+    public double getResolution() {
+        return this.resolution;
+    }
+
+    /**
+     * @param geodetic geodetic mode.
+     * @param projection the projection to perform the calculation in.
+     * @param dpi the dpi of the display device.
+     * @param position the position on the map.
+     * @return the scale denominator
+     */
+    public double getDenominator(
+            final boolean geodetic, @Nonnull final CoordinateReferenceSystem projection,
+            final double dpi, final Coordinate position) {
+        return geodetic ?
+                getGeodeticDenominator(projection, dpi, position) :
+                getDenominator(projection, dpi);
+    }
+
+    /**
+     * @param projection the projection to perform the calculation in
+     * @param dpi the dpi of the display device.
+     * @return the scale denominator
+     */
+    public double getDenominator(@Nonnull final CoordinateReferenceSystem projection, final double dpi) {
+        return getDenominator(DistanceUnit.fromProjection(projection), dpi);
+    }
+
+    /**
+     * @param projectionUnit the projection unit
+     * @param dpi the dpi of the display device.
+     * @return the scale denominator
+     */
+    public double getDenominator(@Nonnull final DistanceUnit projectionUnit, final double dpi) {
+        final double resolutionInInches = projectionUnit.convertTo(this.resolution, DistanceUnit.IN);
+        return resolutionInInches * dpi;
+    }
+
+    /**
+     * @param projection the projection to perform the calculation in
+     * @param dpi the dpi of the display device.
+     * @param position the position on the map.
+     * @return the scale denominator
+     */
+    public double getGeodeticDenominator(@Nonnull final CoordinateReferenceSystem projection, final double dpi, final Coordinate position) {
+        final DistanceUnit projectionUnit = DistanceUnit.fromProjection(projection);
+        double scaleDenominator = getDenominator(projectionUnit, dpi);
+
+        if (projectionUnit == DistanceUnit.DEGREES) {
+            return scaleDenominator;
         }
+
+        try {
+            double width = 1;
+            double geoWidthInches = scaleDenominator * width / dpi;
+            double geoWidth = DistanceUnit.IN.convertTo(geoWidthInches, projectionUnit);
+            double minGeoX = position.y - (geoWidth / 2.0);
+            double maxGeoX = minGeoX + geoWidth;
+
+            final GeodeticCalculator calculator = new GeodeticCalculator(projection);
+            final double centerY = position.y;
+
+            final MathTransform transform = CRS.findMathTransform(projection,
+                    GenericMapAttribute.parseProjection("EPSG:4326", true));
+            final Coordinate start = JTS.transform(new Coordinate(minGeoX, centerY), null, transform);
+            final Coordinate end = JTS.transform(new Coordinate(maxGeoX, centerY), null, transform);
+            calculator.setStartingGeographicPoint(start.x, start.y);
+            calculator.setDestinationGeographicPoint(end.x, end.y);
+            final double geoWidthInEllipsoidUnits = calculator.getOrthodromicDistance();
+            final DistanceUnit ellipsoidUnit = DistanceUnit.fromString(calculator.getEllipsoid().getAxisUnit().toString());
+
+            final double geoWidthInInches = ellipsoidUnit.convertTo(geoWidthInEllipsoidUnits, DistanceUnit.IN);
+            return geoWidthInInches * (dpi / width);
+        } catch (FactoryException e) {
+            LOGGER.error("Unable to do the geodetic calculation on the scale", e);
+        } catch (TransformException e) {
+            LOGGER.error("Unable to do the geodetic calculation on the scale", e);
+        }
+
+        // fall back
+        return getDenominator(projectionUnit, dpi);
+    }
+
+    /**
+     * @param geodetic Do in geodetic.
+     * @param scaleDenominator the scale denominator.
+     * @param projection the projection to perform the calculation in.
+     * @param dpi the dpi of the display device.
+     * @param position the position on the map.
+     * @return the scale denominator.
+     */
+    public static double getDenominator(
+            final boolean geodetic,
+            final double scaleDenominator, @Nonnull final CoordinateReferenceSystem projection,
+            final double dpi, final Coordinate position) {
+        return geodetic ? getGeodeticDenominator(scaleDenominator, projection, dpi, position) : scaleDenominator;
+    }
+
+    /**
+     * @param scaleDenominator the scale denominator.
+     * @param projection the projection to perform the calculation in.
+     * @param dpi the dpi of the display device.
+     * @param position the position on the map.
+     * @return the scale denominator.
+     */
+    public static double getGeodeticDenominator(
+            final double scaleDenominator, @Nonnull final CoordinateReferenceSystem projection,
+            final double dpi, final Coordinate position) {
+        return new Scale(scaleDenominator, DistanceUnit.fromProjection(projection), dpi).getGeodeticDenominator(projection, dpi, position);
     }
 
     /**
      * Construct a scale object from a resolution.
      *
      * @param resolution the resolution of the map
-     * @param projection the projection of the map
-     * @param dpi the dpi of the display device.
      */
-    public static Scale fromResolution(final double resolution, @Nonnull final CoordinateReferenceSystem projection, final double dpi) {
-        final double resolutionInInches = DistanceUnit.fromProjection(projection).convertTo(resolution, DistanceUnit.IN);
-        return new Scale(resolutionInInches * dpi);
+    public static Scale fromResolution(final double resolution) {
+        return new Scale(resolution);
     }
 
     // CHECKSTYLE:OFF
@@ -68,7 +189,7 @@ public final class Scale {
 
         Scale scale = (Scale) o;
 
-        if (Double.compare(scale.denominator, denominator) != 0) {
+        if (Double.compare(scale.resolution, resolution) != 0) {
             return false;
         }
 
@@ -77,17 +198,12 @@ public final class Scale {
 
     @Override
     public int hashCode() {
-        int result;
-        long temp;
-        temp = Double.doubleToLongBits(denominator);
-        result = (int) (temp ^ (temp >>> 32));
-        return result;
+        return new Double(resolution).hashCode();
     }
 
     @Override
     public String toString() {
-        return "Scale{" + denominator + '}';
+        return "Scale{resolution=" + resolution + '}';
     }
     // CHECKSTYLE:ON
-
 }

--- a/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayer.java
@@ -7,6 +7,7 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.mapfish.print.URIUtils;
 import org.mapfish.print.attribute.map.MapBounds;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
+import org.mapfish.print.map.Scale;
 import org.mapfish.print.map.geotools.StyleSupplier;
 import org.mapfish.print.map.tiled.AbstractTiledLayer;
 import org.mapfish.print.map.tiled.TileCacheInformation;
@@ -59,7 +60,8 @@ public final class OsmLayer extends AbstractTiledLayer {
                 final MapBounds bounds, final Rectangle paintArea, final double dpi) {
             super(bounds, paintArea, dpi, OsmLayer.this.param);
 
-            final double targetResolution = bounds.getScaleDenominator(paintArea, dpi).toResolution(bounds.getProjection(), dpi);
+            final double targetResolution = new Scale(
+                    bounds.getScaleDenominator(paintArea, dpi), bounds.getProjection(), dpi).getResolution();
 
             Double[] resolutions = OsmLayer.this.param.resolutions;
             int pos = resolutions.length - 1;

--- a/core/src/main/java/org/mapfish/print/map/tiled/wms/TiledWmsLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wms/TiledWmsLayer.java
@@ -6,6 +6,7 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.mapfish.print.attribute.map.MapBounds;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
+import org.mapfish.print.map.Scale;
 import org.mapfish.print.map.geotools.StyleSupplier;
 import org.mapfish.print.map.tiled.AbstractTiledLayer;
 import org.mapfish.print.map.tiled.TileCacheInformation;
@@ -86,8 +87,8 @@ public final class TiledWmsLayer extends AbstractTiledLayer {
 
         @Override
         public double getResolution() {
-            return WmsTileCacheInformation.this.bounds.getScaleDenominator(
-                    WmsTileCacheInformation.this.paintArea, dpi).toResolution(WmsTileCacheInformation.this.bounds.getProjection(), dpi);
+            return new Scale(WmsTileCacheInformation.this.bounds.getScaleDenominator(WmsTileCacheInformation.this.paintArea, dpi),
+                    bounds.getProjection(), dpi).getResolution();
         }
 
         @Override

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/Matrix.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/Matrix.java
@@ -66,6 +66,6 @@ public class Matrix {
      * @param projection The map projection
      */
     public final double getResolution(final CoordinateReferenceSystem projection) {
-        return new Scale(this.scaleDenominator).toResolution(projection, OGC_DPI);
+        return new Scale(this.scaleDenominator, projection, OGC_DPI).getResolution();
     }
 }

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayer.java
@@ -9,6 +9,7 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.mapfish.print.URIUtils;
 import org.mapfish.print.attribute.map.MapBounds;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
+import org.mapfish.print.map.Scale;
 import org.mapfish.print.map.geotools.StyleSupplier;
 import org.mapfish.print.map.tiled.AbstractTiledLayer;
 import org.mapfish.print.map.tiled.TileCacheInformation;
@@ -65,7 +66,8 @@ public class WMTSLayer extends AbstractTiledLayer {
         public WMTSTileCacheInfo(final MapBounds bounds, final Rectangle paintArea, final double dpi) {
             super(bounds, paintArea, dpi, WMTSLayer.this.param);
             double diff = Double.POSITIVE_INFINITY;
-            final double targetResolution = bounds.getScaleDenominator(paintArea, dpi).toResolution(bounds.getProjection(), dpi);
+            final double targetResolution = new Scale(bounds.getScaleDenominator(paintArea, dpi),
+                    bounds.getProjection(), dpi).getResolution();
 
             for (Matrix m : WMTSLayer.this.param.matrices) {
                 final double resolution = m.getResolution(this.bounds.getProjection());

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
@@ -43,7 +43,6 @@ import org.mapfish.print.config.Configuration;
 import org.mapfish.print.config.ConfigurationException;
 import org.mapfish.print.http.HttpRequestCache;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
-import org.mapfish.print.map.Scale;
 import org.mapfish.print.map.geotools.AbstractFeatureSourceLayer;
 import org.mapfish.print.map.geotools.FeatureLayer;
 import org.mapfish.print.map.geotools.grid.GridLayer;
@@ -594,8 +593,8 @@ public final class CreateMapProcessor extends AbstractProcessor<CreateMapProcess
                         mapBounds = ((BBoxMapBounds) mapBounds).expand(mapValues.zoomToFeatures.minMargin, paintArea);
                     }
 
-                    Scale scale = mapBounds.getScaleDenominator(paintArea, mapValues.getDpi());
-                    if (scale.getDenominator() < mapValues.zoomToFeatures.minScale) {
+                    final double scaleDenominator = mapBounds.getScaleDenominator(paintArea, mapValues.getDpi());
+                    if (scaleDenominator < mapValues.zoomToFeatures.minScale) {
                         // if the current scale is smaller than the min. scale, change it
                         mapBounds = mapBounds.zoomToScale(mapValues.zoomToFeatures.minScale);
                     }

--- a/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
@@ -57,13 +57,10 @@ public class ScalebarGraphic {
         MapBounds bounds = mapContext.getBounds();
 
         final DistanceUnit mapUnit = getUnit(bounds);
-        Scale scale;
-        if (scalebarParams.geodetic) {
-            // to calculate the scale the requestor DPI is used , because the paint area is already adjusted
-            scale = bounds.getGeodeticScaleDenominator(paintArea, mapContext.getRequestorDPI());
-        } else {
-            scale = bounds.getScaleDenominator(paintArea, mapContext.getRequestorDPI());
-        }
+        final Scale scale = new Scale(bounds.getScaleDenominator(paintArea, mapContext.getRequestorDPI()),
+                bounds.getProjection(), dpi);
+        final double scaleDenominator = scale.getDenominator(scalebarParams.geodetic,
+                bounds.getProjection(), dpi, bounds.getCenter());
 
         DistanceUnit scaleUnit = scalebarParams.getUnit();
         if (scaleUnit == null) {
@@ -77,7 +74,7 @@ public class ScalebarGraphic {
                 maxWidthInPixelAdjusted : maxHeightInPixelAdjusted;
 
         final double maxIntervalLengthInWorldUnits = DistanceUnit.PX.convertTo(maxLengthInPixelAdjusted, scaleUnit)
-                * scale.getDenominator() / scalebarParams.intervals;
+                * scaleDenominator / scalebarParams.intervals;
         final double niceIntervalLengthInWorldUnits =
                 getNearestNiceValue(maxIntervalLengthInWorldUnits, scaleUnit, scalebarParams.lockUnits);
 
@@ -95,7 +92,7 @@ public class ScalebarGraphic {
                     new Dimension(maxWidthInPixelAdjusted, maxHeightInPixelAdjusted));
 
             try {
-                tryLayout(graphics2D, scaleUnit, scale, niceIntervalLengthInWorldUnits, settings, 0);
+                tryLayout(graphics2D, scaleUnit, scaleDenominator, niceIntervalLengthInWorldUnits, settings, 0);
 
                 path = File.createTempFile("scalebar-graphic-", ".svg", tempFolder);
                 CreateMapProcessor.saveSvgFile(graphics2D, path);
@@ -109,7 +106,7 @@ public class ScalebarGraphic {
             final Graphics2D graphics2D = bufferedImage.createGraphics();
 
             try {
-                tryLayout(graphics2D, scaleUnit, scale, niceIntervalLengthInWorldUnits, settings, 0);
+                tryLayout(graphics2D, scaleUnit, scaleDenominator, niceIntervalLengthInWorldUnits, settings, 0);
 
                 path = File.createTempFile("scalebar-graphic-", ".tiff", tempFolder);
                 ImageIO.write(bufferedImage, "tiff", path);
@@ -129,19 +126,19 @@ public class ScalebarGraphic {
     /**
      * Try recursively to find the correct layout.
      */
-    private void tryLayout(final Graphics2D graphics2D, final DistanceUnit scaleUnit, final Scale scale,
+    private void tryLayout(final Graphics2D graphics2D, final DistanceUnit scaleUnit, final double scaleDenominator,
             final double intervalLengthInWorldUnits, final ScaleBarRenderSettings settings, final int tryNumber) {
         if (tryNumber > MAX_NUMBER_LAYOUTING_TRIES) {
             // if no good layout can be found, stop. an empty scalebar graphic will be shown.
             LOGGER.error("layouting the scalebar failed (unit: " + scaleUnit.toString()
-                    + ", scale: " + scale.getDenominator() + ")");
+                    + ", scale: " + scaleDenominator + ")");
             return;
         }
 
         final ScalebarAttributeValues scalebarParams = settings.getParams();
         final DistanceUnit intervalUnit = bestUnit(scaleUnit, intervalLengthInWorldUnits, scalebarParams.lockUnits);
         final float intervalLengthInPixels = (float) scaleUnit.convertTo(
-                intervalLengthInWorldUnits / scale.getDenominator(), DistanceUnit.PX);
+                intervalLengthInWorldUnits / scaleDenominator, DistanceUnit.PX);
 
         //compute the label positions
         final List<Label> labels = new ArrayList<Label>(scalebarParams.intervals + 1);
@@ -199,7 +196,7 @@ public class ScalebarGraphic {
             //CSOFF: MagicNumber
             double nextIntervalDistance = getNearestNiceValue(intervalLengthInWorldUnits * 0.9, scaleUnit, scalebarParams.lockUnits);
             //CSOFF: MagicNumber
-            tryLayout(graphics2D, scaleUnit, scale, nextIntervalDistance, settings, tryNumber + 1);
+            tryLayout(graphics2D, scaleUnit, scaleDenominator, nextIntervalDistance, settings, tryNumber + 1);
         }
     }
 

--- a/core/src/test/java/org/mapfish/print/AbstractMapfishSpringTest.java
+++ b/core/src/test/java/org/mapfish/print/AbstractMapfishSpringTest.java
@@ -97,7 +97,7 @@ public abstract class AbstractMapfishSpringTest {
 
     public static MapfishMapContext createTestMapContext() {
         try {
-            final CenterScaleMapBounds bounds = new CenterScaleMapBounds(CRS.decode("CRS:84"), 0, 0, new Scale(30000));
+            final CenterScaleMapBounds bounds = new CenterScaleMapBounds(CRS.decode("CRS:84"), 0, 0, 30000);
             return new MapfishMapContext(bounds, new Dimension(500,500), 0, 72, Constants.PDF_DPI, null, true);
         } catch (Throwable e) {
             throw new Error(e);

--- a/core/src/test/java/org/mapfish/print/attribute/map/BBoxMapBoundsTest.java
+++ b/core/src/test/java/org/mapfish/print/attribute/map/BBoxMapBoundsTest.java
@@ -52,13 +52,13 @@ public class BBoxMapBoundsTest {
 
     @Test
     public void testAdjustToScale() throws Exception {
-        int scale = 24000;
+        int scaleDenominator = 24000;
         double dpi = 100;
         Rectangle screen = new Rectangle(100, 100);
         ZoomLevels zoomLevels = new ZoomLevels(15000, 20000, 25000, 30000, 350000);
 
 
-        final CenterScaleMapBounds mapBounds = new CenterScaleMapBounds(CH1903, 50000, 50000, new Scale(scale));
+        final CenterScaleMapBounds mapBounds = new CenterScaleMapBounds(CH1903, 50000, 50000, scaleDenominator);
         final ReferencedEnvelope originalBBox = mapBounds.toReferencedEnvelope(screen, dpi);
 
         BBoxMapBounds linear = new BBoxMapBounds(CH1903, originalBBox.getMinX(), originalBBox.getMinY(),
@@ -74,19 +74,19 @@ public class BBoxMapBoundsTest {
 
         double expectedScale = 25000;
         CenterScaleMapBounds expectedMapBounds = new CenterScaleMapBounds(CH1903, originalBBox.centre().x, originalBBox.centre().y,
-                new Scale(expectedScale));
+                expectedScale);
         assertEquals(expectedMapBounds.toReferencedEnvelope(screen, dpi), newBBox);
     }
 
     @Test
     public void testAdjustToScaleLatLong() throws Exception {
-        int scale = 24000;
+        int scaleDenominator = 24000;
         double dpi = 100;
         Rectangle screen = new Rectangle(100, 100);
         ZoomLevels zoomLevels = new ZoomLevels(15000, 20000, 25000, 30000, 350000);
 
 
-        final CenterScaleMapBounds mapBounds = new CenterScaleMapBounds(WGS84, 5, 5, new Scale(scale));
+        final CenterScaleMapBounds mapBounds = new CenterScaleMapBounds(WGS84, 5, 5, scaleDenominator);
         final ReferencedEnvelope originalBBox = mapBounds.toReferencedEnvelope(screen, dpi);
 
         BBoxMapBounds linear = new BBoxMapBounds(WGS84, originalBBox.getMinX(), originalBBox.getMinY(),
@@ -103,7 +103,7 @@ public class BBoxMapBoundsTest {
 
         double expectedScale = 25000;
         CenterScaleMapBounds expectedMapBounds = new CenterScaleMapBounds(WGS84, originalBBox.centre().x, originalBBox.centre().y,
-                new Scale(expectedScale));
+                expectedScale);
         assertEquals(expectedMapBounds.toReferencedEnvelope(screen, dpi), newBBox);
     }
 
@@ -138,15 +138,17 @@ public class BBoxMapBoundsTest {
 
     @Test
     public void testAdjustToGeodeticScale() throws Exception {
-        int scale = 24000;
+        int scaleDenominator = 24000;
         double dpi = 100;
         Rectangle screen = new Rectangle(100, 100);
         ZoomLevels zoomLevels = new ZoomLevels(15000, 20000, 25000, 30000, 350000);
 
-        final CenterScaleMapBounds mapBounds = new CenterScaleMapBounds(SPHERICAL_MERCATOR, 400000, 5000000, new Scale(scale));
+        final CenterScaleMapBounds mapBounds = new CenterScaleMapBounds(SPHERICAL_MERCATOR, 400000,
+                5000000, scaleDenominator);
         final ReferencedEnvelope originalBBox = mapBounds.toReferencedEnvelope(screen, dpi);
 
-        BBoxMapBounds linear = new BBoxMapBounds(SPHERICAL_MERCATOR, originalBBox.getMinX(), originalBBox.getMinY(),
+        BBoxMapBounds linear = new BBoxMapBounds(SPHERICAL_MERCATOR,
+                originalBBox.getMinX(), originalBBox.getMinY(),
                 originalBBox.getMaxX(), originalBBox.getMaxY());
 
         final MapBounds newMapBounds = linear.adjustBoundsToNearestScale(zoomLevels, 0.05,
@@ -161,7 +163,10 @@ public class BBoxMapBoundsTest {
         assertEquals(4999664, newBBox.getMinY(), 1);
         assertEquals(400335, newBBox.getMaxX(), 1);
         assertEquals(5000335, newBBox.getMaxY(), 1);
-        assertEquals(26428, newMapBounds.getScaleDenominator(screen, dpi).getDenominator(), 1);
-        assertEquals(20000, newMapBounds.getGeodeticScaleDenominator(screen, dpi).getDenominator(), delta);
+        assertEquals(26429, newMapBounds.getScaleDenominator(screen, dpi), 1);
+        assertEquals(20000,
+                new Scale(newMapBounds.getScaleDenominator(screen, dpi), SPHERICAL_MERCATOR, dpi)
+                .getGeodeticDenominator(SPHERICAL_MERCATOR, dpi, newBBox.centre()),
+                1);
     }
 }

--- a/core/src/test/java/org/mapfish/print/attribute/map/CenterScaleMapBoundsTest.java
+++ b/core/src/test/java/org/mapfish/print/attribute/map/CenterScaleMapBoundsTest.java
@@ -32,8 +32,8 @@ public class CenterScaleMapBoundsTest {
 
     @Test
     public void testToReferencedEnvelopeCH1903Projection() throws Exception {
-        final Scale startScale = new Scale(18984.396150703426);
-        final CenterScaleMapBounds bounds = new CenterScaleMapBounds(CH1903, 659596.5, 185610.5, startScale);
+        final double startScaleDenominator = 18984.396150703426;
+        final CenterScaleMapBounds bounds = new CenterScaleMapBounds(CH1903, 659596.5, 185610.5, startScaleDenominator);
         final Rectangle paintArea = new Rectangle(521, 330);
         final ReferencedEnvelope envelope = bounds.toReferencedEnvelope(paintArea, OPENLAYERS_2_DPI);
 
@@ -48,8 +48,8 @@ public class CenterScaleMapBoundsTest {
 
     @Test
     public void testToReferencedEnvelopeLambertProjection() throws Exception {
-        final Scale startScale = new Scale(17983.582534790035);
-        final CenterScaleMapBounds bounds = new CenterScaleMapBounds(LAMBERT, 445000, 6355000, startScale);
+        final double startScaleDenominator = 17983.582534790035;
+        final CenterScaleMapBounds bounds = new CenterScaleMapBounds(LAMBERT, 445000, 6355000, startScaleDenominator);
         final Rectangle paintArea = new Rectangle(418, 512);
         final ReferencedEnvelope envelope = bounds.toReferencedEnvelope(paintArea, OPENLAYERS_2_DPI);
 
@@ -64,9 +64,9 @@ public class CenterScaleMapBoundsTest {
 
     @Test
     public void testToReferencedEnvelopeLatLong() throws Exception {
-        final Scale startScale = new Scale(56304.83087498591);
+        final double startScaleDenominator = 56304.83087498591;
         final CenterScaleMapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 8.2335427805083, 46.801424340241,
-                startScale);
+                startScaleDenominator);
         final Rectangle paintArea = new Rectangle(521, 330);
         final ReferencedEnvelope envelope = bounds.toReferencedEnvelope(paintArea, OPENLAYERS_2_DPI);
 
@@ -82,8 +82,8 @@ public class CenterScaleMapBoundsTest {
 
     @Test
     public void testZoomOut() throws Exception {
-        final Scale scale = new Scale(2500.0);
-        final CenterScaleMapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 0.0, 0.0, scale);
+        final double Denominator = 2500.0;
+        final CenterScaleMapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 0.0, 0.0, Denominator);
         final Rectangle paintArea = new Rectangle(400, 200);
         final ReferencedEnvelope envelope = bounds.toReferencedEnvelope(paintArea, OPENLAYERS_2_DPI);
 
@@ -103,17 +103,5 @@ public class CenterScaleMapBoundsTest {
         assertEquals(envelope.getMaxX() * 2, newEnvelope.getMaxX(), delta);
         assertEquals(envelope.getMinY() * 2, newEnvelope.getMinY(), delta);
         assertEquals(envelope.getMaxY() * 2, newEnvelope.getMaxY(), delta);
-    }
-
-    @Test
-    public void geodetic() throws Exception {
-        final Scale scale = new Scale(15432.0);
-        final CenterScaleMapBounds centerBounds = new CenterScaleMapBounds(SPHERICAL_MERCATOR, 682433.0, 6379270.0, scale);
-        assertEquals(
-                centerBounds.getScaleDenominator(new Rectangle(715, 395), 254).getDenominator(),
-                15432.0, 1.0);
-        assertEquals(
-                centerBounds.getGeodeticScaleDenominator(new Rectangle(715, 395), 254).getDenominator(),
-                10019.0, 1.0);
     }
 }

--- a/core/src/test/java/org/mapfish/print/attribute/map/ScaleAdjustmentAccuracyTest.java
+++ b/core/src/test/java/org/mapfish/print/attribute/map/ScaleAdjustmentAccuracyTest.java
@@ -19,48 +19,48 @@ public class ScaleAdjustmentAccuracyTest {
 
     @Test
     public void testSearchCLOSEST_LOWER_SCALE_ON_MATCHMatch() throws Exception {
-        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(12), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(12.01), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(12.5), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_8_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(10), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(13), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(11.88), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(11), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_8_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(new Scale(9), TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(12, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(12.01, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(12.5, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_8_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(10, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(13, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(11.88, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(11, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_8_RESULT, CLOSEST_LOWER_SCALE_ON_TIE.search(9, TOLERANCE, ZOOM_LEVELS));
     }
 
     @Test
     public void testSearchCLOSEST_HIGHER_SCALE_ON_MATCHMatch() throws Exception {
-        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(12), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(12.01), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(12.5), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(10), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(13), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(11.88), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(11), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_8_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(new Scale(9), TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(12, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(12.01, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(12.5, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(10, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(13, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(11.88, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(11, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_8_RESULT, CLOSEST_HIGHER_SCALE_ON_TIE.search(9, TOLERANCE, ZOOM_LEVELS));
     }
 
     @Test
     public void testSearchNextHighest() throws Exception {
-        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(new Scale(12), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(new Scale(12.01), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(new Scale(12.5), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(new Scale(10), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_16_RESULT, HIGHER_SCALE.search(new Scale(13), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(new Scale(11.88), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(new Scale(11), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(new Scale(9), TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(12, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(12.01, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(12.5, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(10, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_16_RESULT, HIGHER_SCALE.search(13, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(11.88, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(11, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, HIGHER_SCALE.search(9, TOLERANCE, ZOOM_LEVELS));
     }
     @Test
     public void testSearchLower() throws Exception {
-        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(new Scale(12), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(new Scale(12.01), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(new Scale(12.5), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_8_RESULT, LOWER_SCALE.search(new Scale(10), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(new Scale(13), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(new Scale(11.88), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_8_RESULT, LOWER_SCALE.search(new Scale(11), TOLERANCE, ZOOM_LEVELS));
-        assertEquals(SCALE_8_RESULT, LOWER_SCALE.search(new Scale(9), TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(12, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(12.01, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(12.5, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_8_RESULT, LOWER_SCALE.search(10, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(13, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_12_RESULT, LOWER_SCALE.search(11.88, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_8_RESULT, LOWER_SCALE.search(11, TOLERANCE, ZOOM_LEVELS));
+        assertEquals(SCALE_8_RESULT, LOWER_SCALE.search(9, TOLERANCE, ZOOM_LEVELS));
     }
 }

--- a/core/src/test/java/org/mapfish/print/map/ScaleTest.java
+++ b/core/src/test/java/org/mapfish/print/map/ScaleTest.java
@@ -1,6 +1,12 @@
 package org.mapfish.print.map;
 
+import com.vividsolutions.jts.geom.Coordinate;
+import org.geotools.referencing.CRS;
 import org.junit.Test;
+import org.mapfish.print.attribute.map.CenterScaleMapBounds;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.awt.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.mapfish.print.Constants.PDF_DPI;
@@ -10,15 +16,39 @@ public class ScaleTest{
     private static final double DELTA = 0.00001;
     private static final double SCALE = 108335.72891406555;
     private static final double RESOLUTION = 38.21843770023979;
+    public static final CoordinateReferenceSystem SPHERICAL_MERCATOR;
+    public static final CoordinateReferenceSystem CH1903;
+
+    static {
+        try {
+            SPHERICAL_MERCATOR = CRS.decode("EPSG:3857");
+            CH1903 = CRS.decode("EPSG:21781");
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     public void testToResolution() throws Exception {
-        final double resolution = new Scale(SCALE).toResolution(CH1903, PDF_DPI);
+        final double resolution = new Scale(SCALE, CH1903, PDF_DPI).getResolution();
         assertEquals(RESOLUTION, resolution, DELTA);
-        assertEquals(SCALE, Scale.fromResolution(resolution, CH1903, PDF_DPI).getDenominator(), DELTA);
+        assertEquals(SCALE, Scale.fromResolution(resolution).getDenominator(CH1903, PDF_DPI), DELTA);
     }
 
     @Test
     public void fromResolution() {
-        assertEquals(SCALE, Scale.fromResolution(RESOLUTION, CH1903, PDF_DPI).getDenominator(), DELTA);
+        assertEquals(SCALE, Scale.fromResolution(RESOLUTION).getDenominator(CH1903, PDF_DPI), DELTA);
+    }
+
+    @Test
+    public void geodetic() throws Exception {
+        final Scale scale = new Scale(15432.0, SPHERICAL_MERCATOR, 254);
+
+        assertEquals(
+                scale.getDenominator(SPHERICAL_MERCATOR, 254),
+                15432.0, 1.0);
+        assertEquals(
+                scale.getGeodeticDenominator(SPHERICAL_MERCATOR, 254, new Coordinate(682433.0, 6379270.0)),
+                10019.0, 1.0);
     }
 }

--- a/core/src/test/java/org/mapfish/print/map/style/json/MapfishStyleParserPluginTest.java
+++ b/core/src/test/java/org/mapfish/print/map/style/json/MapfishStyleParserPluginTest.java
@@ -277,7 +277,7 @@ public class MapfishStyleParserPluginTest {
         final String styleJson = getSpec(styleJsonFileName);
 
         final CenterScaleMapBounds bounds = new CenterScaleMapBounds(
-                CRS.decode("CRS:84"), 0, 0, new Scale(300000));
+                CRS.decode("CRS:84"), 0, 0,300000);
         MapfishMapContext context = new MapfishMapContext(
                 bounds, new Dimension(500, 500), 0, 72, Constants.PDF_DPI,
                 null, true);

--- a/core/src/test/java/org/mapfish/print/map/tiled/wmts/WMTSLayerTest.java
+++ b/core/src/test/java/org/mapfish/print/map/tiled/wmts/WMTSLayerTest.java
@@ -27,7 +27,7 @@ public class WMTSLayerTest {
         WMTSLayer wmtsLayer = new WMTSLayer(null, null, null, params, null);
 
         Rectangle paintArea = new Rectangle(0, 0, 256, 256);
-        MapBounds bounds = new CenterScaleMapBounds(CRS.decode("EPSG:21781"), 595217.02, 236708.54, new Scale(7500));
+        MapBounds bounds = new CenterScaleMapBounds(CRS.decode("EPSG:21781"), 595217.02, 236708.54, 7500);
         WMTSLayer.WMTSTileCacheInfo tileInformation =
                 (WMTSLayer.WMTSTileCacheInfo) wmtsLayer.createTileInformation(bounds, paintArea, 256);
 

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSRestTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSRestTest.java
@@ -113,7 +113,8 @@ public class CreateMapProcessorFixedScaleAndCenterWMTSRestTest extends AbstractM
         assertEquals(2, layerGraphics.size());
 
         MapfishMapContext mapContext = values.getObject("mapContext", MapfishMapContext.class);
-        assertEquals(110000.0, mapContext.getScale().getDenominator(), 1E-6);
+        assertEquals(110000.0, mapContext.getScale().getDenominator(
+                mapContext.getBounds().getProjection(), mapContext.getRequestorDPI()), 1E-6);
 
         final BufferedImage referenceImage = ImageSimilarity.mergeImages(layerGraphics, 630, 294);
         // ImageIO.write(referenceImage, "png", new File("/tmp/expectedSimpleImage.png"));

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmDpiTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmDpiTest.java
@@ -100,7 +100,7 @@ public class CreateMapProcessorFixedScaleCenterOsmDpiTest extends AbstractMapfis
         assertEquals(2, layerGraphics.size());
 
         MapfishMapContext mapContext = values.getObject("mapContext", MapfishMapContext.class);
-        assertEquals(25000.0, mapContext.getScale().getDenominator(), 1E-6);
+        assertEquals(25000.0, mapContext.getScale().getDenominator(mapContext.getBounds().getProjection(), mapContext.getRequestorDPI()), 1E-6);
 
 //        Files.copy(new File(layerGraphics.get(0)), new File("/tmp/0_"+getClass().getSimpleName()+".tiff"));
 //        Files.copy(new File(layerGraphics.get(1)), new File("/tmp/1_"+getClass().getSimpleName()+".tiff"));

--- a/core/src/test/java/org/mapfish/print/processor/map/MapfishMapContextTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/MapfishMapContextTest.java
@@ -42,11 +42,11 @@ public class MapfishMapContextTest {
         assertRoundedScale(12342290, 12000000);
     }
 
-    private void assertRoundedScale(double actualScale, double roundedScale) {
-        MapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 0, 0, new Scale(actualScale));
+    private void assertRoundedScale(double actualScaleDenominator, double roundedScale) {
+        MapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 0, 0, actualScaleDenominator);
         Dimension paint = new Dimension(200, 200);
         MapfishMapContext transformer = new MapfishMapContext(bounds, paint, 90, Constants.PDF_DPI, Constants.PDF_DPI, null, true);
-        assertEquals(roundedScale, transformer.getRoundedScale(), 0.00001);
+        assertEquals(roundedScale, transformer.getRoundedScaleDenominator(), 0.00001);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class MapfishMapContextTest {
 
     @Test
     public void testGetRotatedBounds_CenterScaleMapBounds() {
-        MapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 0, 0, new Scale(1000));
+        MapBounds bounds = new CenterScaleMapBounds(DefaultGeographicCRS.WGS84, 0, 0, 1000);
         MapfishMapContext transformer = new MapfishMapContext(bounds, null, 90, Constants.PDF_DPI, Constants.PDF_DPI, null, true);
         // nothing changes
         assertEquals(bounds, transformer.getRotatedBounds());
@@ -116,7 +116,7 @@ public class MapfishMapContextTest {
         MapAttribute.MapAttributeValues mapValues = (new MapAttribute()).new MapAttributeValues(null, 780, 330);
         mapValues.dpi = 100;
         mapValues.rotation = 55.26239249861529;
-        mapValues.setMapBounds(new CenterScaleMapBounds(epsg2056, 2742033.0, 1253823.0, new Scale(25000)));
+        mapValues.setMapBounds(new CenterScaleMapBounds(epsg2056, 2742033.0, 1253823.0, 25000));
 
         MapBounds centerBounds = mapValues.getMapBounds();
         Rectangle paintAreaRotated = new Rectangle(993, 1151);

--- a/core/src/test/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphicTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphicTest.java
@@ -121,7 +121,7 @@ public class ScalebarGraphicTest {
     @Test
     public void testRender() throws Exception {
         MapBounds bounds = new CenterScaleMapBounds(
-                CRS.decode("EPSG:3857"), -8235878.4938425, 4979784.7605681, new Scale(26000));
+                CRS.decode("EPSG:3857"), -8235878.4938425, 4979784.7605681, 26000);
         MapfishMapContext mapParams = new MapfishMapContext(
                 bounds, new Dimension(780, 330), 0, 72, 72, true, false);
 
@@ -141,7 +141,7 @@ public class ScalebarGraphicTest {
     @Test
     public void testRenderDoubleDpi() throws Exception {
         MapBounds bounds = new CenterScaleMapBounds(
-                CRS.decode("EPSG:3857"), -8235878.4938425, 4979784.7605681, new Scale(26000));
+                CRS.decode("EPSG:3857"), -8235878.4938425, 4979784.7605681, 26000);
         MapfishMapContext mapParams = new MapfishMapContext(
                 bounds, new Dimension(780, 330), 0, 144, 72, true, false);
 
@@ -160,7 +160,7 @@ public class ScalebarGraphicTest {
     @Test
     public void testRenderSvg() throws Exception {
         MapBounds bounds = new CenterScaleMapBounds(
-                CRS.decode("EPSG:3857"), -8235878.4938425, 4979784.7605681, new Scale(26000));
+                CRS.decode("EPSG:3857"), -8235878.4938425, 4979784.7605681, 26000);
         MapfishMapContext mapParams = new MapfishMapContext(
                 bounds, new Dimension(780, 330), 0, 72, 72, true, false);
 

--- a/core/src/test/resources/org/mapfish/print/processor/map/center_geojson_zoomToExtent/geojson.json
+++ b/core/src/test/resources/org/mapfish/print/processor/map/center_geojson_zoomToExtent/geojson.json
@@ -1,6 +1,8 @@
-{ "type": "FeatureCollection",
+{
+  "type": "FeatureCollection",
   "features": [
-    { "type": "Feature",
+    {
+      "type": "Feature",
       "geometry": {
         "type": "Polygon",
         "coordinates": [
@@ -13,7 +15,8 @@
         "prop1": 1.0
       }
     },
-    { "type": "Feature",
+    {
+      "type": "Feature",
       "geometry": {
         "type": "Polygon",
         "coordinates": [
@@ -26,7 +29,8 @@
         "prop1": 0.0
       }
     },
-    { "type": "Feature",
+    {
+      "type": "Feature",
       "geometry": {
         "type": "Polygon",
         "coordinates": [

--- a/docs/src/main/resources/templates/jasperreports.html
+++ b/docs/src/main/resources/templates/jasperreports.html
@@ -528,7 +528,7 @@ In order to add a numeric scale you have to create a text field with the
 following expression:
 </p>
 <div class="highlight"><pre>
-   String.format("Massstab 1: %.0f", $P{mapContext}.getRoundedScale())
+   String.format("Massstab 1: %.0f", $P{mapContext}.getRoundedScaleDenominator())
 </pre></div>
 <p>
 Finally add the missing mapContext parameter with the following properties:
@@ -554,7 +554,7 @@ such modification for fixing this type of error:
 &lt;parameter name="mapSubReport" class="java.lang.String"
 isForPrompting="false"/&gt;
     ...
-    &lt;textFieldExpression&gt;&lt;![CDATA[String.format("Massstab 1: %.0f", $P{mapContext}.getRoundedScale())]]&gt;&lt;/textFieldExpression&gt;
+    &lt;textFieldExpression&gt;&lt;![CDATA[String.format("Massstab 1: %.0f", $P{mapContext}.getRoundedScaleDenominator())]]&gt;&lt;/textFieldExpression&gt;
     ...
 ==>
     ...

--- a/examples/src/test/resources/examples/paging/simpleReport.jrxml
+++ b/examples/src/test/resources/examples/paging/simpleReport.jrxml
@@ -70,7 +70,7 @@
 				<textElement textAlignment="Right">
 					<font size="16"/>
 				</textElement>
-				<textFieldExpression><![CDATA[String.format("1:%.0f", $P{mapContext}.getRoundedScale())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[String.format("1:%.0f", $P{mapContext}.getRoundedScaleDenominator())]]></textFieldExpression>
 			</textField>
 		</band>
 	</title>
@@ -165,7 +165,7 @@
 				<textElement textAlignment="Right">
 					<font size="16"/>
 				</textElement>
-				<textFieldExpression><![CDATA[String.format("1:%.0f", $F{mapContext}.getRoundedScale())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[String.format("1:%.0f", $F{mapContext}.getRoundedScaleDenominator())]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>


### PR DESCRIPTION
A scale detached from his DPI hasn't "any sense", then I store the resolution in the Scale object.

I also move the geodetic scale method in the Scale object.

I just have a question, In the scale object I store a resolution in [px/projection unit], shouldn't alway be in [px/m], it will simplify the code but I don't know if the result will me good for non meter projection especially degree projections...

replaced #473 who is automatically closed :-(