### PR TITLE
Cascade delete records in the result table

### DIFF
--- a/BREAKING-CHANGES.rst
+++ b/BREAKING-CHANGES.rst
@@ -1,6 +1,13 @@
 Known breaking changes
 ======================
 
+Version 3.10
+------------
+
+The DB schema in multi-instance mode has been changed. You can drop the
+printjobresultimpl and printjobstatusimpl tables since they are not used anymore.
+
+
 Version 3.9
 -----------
 

--- a/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
@@ -68,9 +68,9 @@ public abstract class PrintJob implements Callable<PrintJobResult> {
      */
     //CHECKSTYLE:OFF
     protected PrintJobResult createResult(final URI reportURI, final String fileName, final String fileExtension,
-            final String mimeType) {
+            final String mimeType, final String referenceId) {
     //CHECKSTYLE:ON
-        return new PrintJobResultImpl(reportURI, fileName, fileExtension, mimeType);
+        return new PrintJobResultImpl(reportURI, fileName, fileExtension, mimeType, referenceId);
     }
 
     @Override
@@ -103,7 +103,7 @@ public abstract class PrintJob implements Callable<PrintJobResult> {
                 mimeType = outputFormat.getContentType();
                 fileExtension = outputFormat.getFileSuffix();
             }
-            return createResult(reportURI, fileName, fileExtension, mimeType);
+            return createResult(reportURI, fileName, fileExtension, mimeType, this.entry.getReferenceId());
         } catch (Exception e) {
             String canceledText = "";
             if (Thread.currentThread().isInterrupted()) {

--- a/core/src/main/java/org/mapfish/print/servlet/job/PrintJobResult.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/PrintJobResult.java
@@ -32,5 +32,4 @@ public interface PrintJobResult {
      * Get the report URI as String.
      */
     String getReportURIString();
-
 }

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobResultImpl.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobResultImpl.java
@@ -1,14 +1,20 @@
 package org.mapfish.print.servlet.job.impl;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.mapfish.print.ExceptionUtils;
 import org.mapfish.print.servlet.job.PrintJobResult;
+import org.mapfish.print.servlet.job.PrintJobStatus;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 /**
@@ -16,7 +22,7 @@ import javax.persistence.Table;
  *
  */
 @Entity
-@Table
+@Table(name = "print_job_results")
 public class PrintJobResultImpl implements PrintJobResult {
 
     @Column
@@ -32,6 +38,14 @@ public class PrintJobResultImpl implements PrintJobResult {
     @Column
     private final String fileName;
 
+    @OneToOne(targetEntity = PrintJobStatusImpl.class, fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "referenceId", insertable = false, updatable = false)
+    private PrintJobStatus status = null;
+
+    @Column(insertable = true, updatable = true)
+    private String referenceId;
+
     /**
      * Default Constructor.
      */
@@ -40,6 +54,7 @@ public class PrintJobResultImpl implements PrintJobResult {
         this.mimeType = null;
         this.fileExtension = null;
         this.fileName = null;
+        this.referenceId = null;
     }
 
     /**
@@ -49,13 +64,15 @@ public class PrintJobResultImpl implements PrintJobResult {
      * @param fileName the file name
      * @param fileExtension the file extension
      * @param mimeType the mime type
+     * @param referenceId the reference ID
      */
     public PrintJobResultImpl(final URI reportURI, final String fileName, final String fileExtension,
-            final String mimeType) {
+                              final String mimeType, final String referenceId) {
         this.reportURI = reportURI.toString();
         this.mimeType = mimeType;
         this.fileName = fileName;
         this.fileExtension = fileExtension;
+        this.referenceId = referenceId;
     }
 
     @Override
@@ -86,5 +103,4 @@ public class PrintJobResultImpl implements PrintJobResult {
     public final String getFileName() {
         return this.fileName;
     }
-
 }

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobStatusImpl.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobStatusImpl.java
@@ -23,7 +23,7 @@ import javax.persistence.Table;
  * Represent a print job that has completed.  Contains the information about the print job.
  */
 @Entity
-@Table
+@Table(name = "print_job_statuses")
 public class PrintJobStatusImpl implements PrintJobStatus {
 
     private static final int LENGTH_ERROR = 1024;
@@ -48,8 +48,8 @@ public class PrintJobStatusImpl implements PrintJobStatus {
     @Column(length = LENGTH_ERROR)
     private String error;
 
-    @OneToOne(targetEntity = PrintJobResultImpl.class, cascade = CascadeType.ALL)
-    @JoinColumn
+    @OneToOne(targetEntity = PrintJobResultImpl.class, cascade = CascadeType.ALL, mappedBy = "status")
+    @JoinColumn(name = "reference_id")
     private PrintJobResult result;
 
     private transient long waitingTime;
@@ -122,6 +122,10 @@ public class PrintJobStatusImpl implements PrintJobStatus {
         return this.result;
     }
 
+    /**
+     * Set the result.
+     * @param result The result
+     */
     public final void setResult(final PrintJobResult result) {
         this.result = result;
     }

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/RegistryJobQueue.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/RegistryJobQueue.java
@@ -280,7 +280,7 @@ public class RegistryJobQueue implements JobQueue {
                 String fileExt = metadata.getString(JSON_FILE_EXT);
                 String mimeType = metadata.getString(JSON_MIME_TYPE);
 
-                PrintJobResult result = new PrintJobResultImpl(reportURI, fileName, fileExt, mimeType);
+                PrintJobResult result = new PrintJobResultImpl(reportURI, fileName, fileExt, mimeType, referenceId);
                 report.setResult(result);
             }
 

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernatePrintJob.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernatePrintJob.java
@@ -30,7 +30,8 @@ public class HibernatePrintJob extends PrintJob {
 
     @Override
     protected final PrintJobResult createResult(final URI reportURI, final String fileName,
-            final String fileExtension, final String mimeType) {
-        return new PrintJobResultExtImpl(reportURI, fileName, fileExtension, mimeType, this.data);
+            final String fileExtension, final String mimeType, final String referenceId) {
+        return new PrintJobResultExtImpl(reportURI, fileName, fileExtension, mimeType, this.data,
+                referenceId);
     }
 }

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/PrintJobResultExtImpl.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/PrintJobResultExtImpl.java
@@ -32,10 +32,11 @@ public class PrintJobResultExtImpl extends PrintJobResultImpl {
      * @param fileExtension the file extension
      * @param mimeType the mime type
      * @param data the data
+     * @param referenceId the reference ID
      */
     public PrintJobResultExtImpl(final URI reportURI, final String fileName, final String fileExtension, final String mimeType,
-            final byte[] data) {
-        super(reportURI, fileName, fileExtension, mimeType);
+            final byte[] data, final String referenceId) {
+        super(reportURI, fileName, fileExtension, mimeType, referenceId);
         this.data = data;
     }
 


### PR DESCRIPTION
That solves the leak in this table when the status is deleted.

The table names are changed. So an existing setup would be upgradable
without manual operation in the DB. The user can just drop the old tables when
he wants.