### PR TITLE
Another go at fixing transparentTileErrorColor and opaqueTileErrorColor

### DIFF
--- a/core/src/main/java/org/mapfish/print/config/Configuration.java
+++ b/core/src/main/java/org/mapfish/print/config/Configuration.java
@@ -31,7 +31,6 @@ import org.mapfish.print.http.HttpCredential;
 import org.mapfish.print.http.HttpProxy;
 import org.mapfish.print.map.style.StyleParser;
 import org.mapfish.print.map.style.json.ColorParser;
-import org.mapfish.print.parser.HasDefaultValue;
 import org.mapfish.print.servlet.fileloader.ConfigFileLoaderManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -102,12 +101,10 @@ public class Configuration {
     /**
      * The color used to draw the WMS tiles error default: transparent pink.
      */
-    @HasDefaultValue
     private String transparentTileErrorColor = "rgba(255, 78, 78, 125)";
     /**
      * The color used to draw the other tiles error default: pink.
      */
-    @HasDefaultValue
     private String opaqueTileErrorColor = "rgba(255, 155, 155, 0)";
 
     @Autowired
@@ -500,6 +497,18 @@ public class Configuration {
             proxy.validate(validationErrors, this);
         }
 
+        try {
+            ColorParser.toColor(this.opaqueTileErrorColor);
+        } catch (RuntimeException ex) {
+            validationErrors.add(new ConfigurationException("Cannot parse opaqueTileErrorColor", ex));
+        }
+
+        try {
+            ColorParser.toColor(this.transparentTileErrorColor);
+        } catch (RuntimeException ex) {
+            validationErrors.add(new ConfigurationException("Cannot parse transparentTileErrorColor", ex));
+        }
+
         return validationErrors;
     }
 
@@ -612,29 +621,29 @@ public class Configuration {
      * Color used for tiles in error on transparent layers.
      * @param transparentTileErrorColor The color
      */
-    public void setTransparentTileErrorColor(final String transparentTileErrorColor) {
+    public final void setTransparentTileErrorColor(final String transparentTileErrorColor) {
         this.transparentTileErrorColor = transparentTileErrorColor;
     }
 
     /**
      * Get the color used to draw the WMS tiles error default: transparent pink.
      */
-    public Color getTransparentTileErrorColor() {
-        return ColorParser.toColor(this.transparentTileErrorColor);
+    public final String getTransparentTileErrorColor() {
+        return this.transparentTileErrorColor;
     }
 
     /**
      * Color used for tiles in error on opaque layers.
      * @param opaqueTileErrorColor The color
      */
-    public void setOpaqueTileErrorColor(final String opaqueTileErrorColor) {
+    public final void setOpaqueTileErrorColor(final String opaqueTileErrorColor) {
         this.opaqueTileErrorColor = opaqueTileErrorColor;
     }
 
     /**
      * Get the color used to draw the other tiles error default: pink.
      */
-    public Color getOpaqueTileErrorColor() {
-        return ColorParser.toColor(this.opaqueTileErrorColor);
+    public final String getOpaqueTileErrorColor() {
+        return this.opaqueTileErrorColor;
     }
 }

--- a/core/src/main/java/org/mapfish/print/map/image/ImageLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/image/ImageLayer.java
@@ -25,6 +25,7 @@ import org.mapfish.print.map.AbstractLayerParams;
 import org.mapfish.print.map.MapLayerFactoryPlugin;
 import org.mapfish.print.map.geotools.AbstractGridCoverageLayerPlugin;
 import org.mapfish.print.map.geotools.StyleSupplier;
+import org.mapfish.print.map.style.json.ColorParser;
 import org.mapfish.print.parser.HasDefaultValue;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -238,7 +239,7 @@ public final class ImageLayer extends AbstractSingleImageLayer {
         final BufferedImage bufferedImage = new BufferedImage(area.width, area.height, TYPE_INT_ARGB_PRE);
         final Graphics2D graphics = bufferedImage.createGraphics();
         try {
-            graphics.setBackground(this.configuration.getTransparentTileErrorColor());
+            graphics.setBackground(ColorParser.toColor(this.configuration.getTransparentTileErrorColor()));
 
             graphics.clearRect(0, 0, area.width, area.height);
             return bufferedImage;

--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsLayer.java
@@ -12,6 +12,7 @@ import org.mapfish.print.http.HttpRequestCache;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.map.geotools.StyleSupplier;
 import org.mapfish.print.map.image.AbstractSingleImageLayer;
+import org.mapfish.print.map.style.json.ColorParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -113,7 +114,7 @@ public final class WmsLayer extends AbstractSingleImageLayer {
         final BufferedImage bufferedImage = new BufferedImage(area.width, area.height, TYPE_INT_ARGB_PRE);
         final Graphics2D graphics = bufferedImage.createGraphics();
         try {
-            graphics.setBackground(this.configuration.getTransparentTileErrorColor());
+            graphics.setBackground(ColorParser.toColor(this.configuration.getTransparentTileErrorColor()));
             graphics.clearRect(0, 0, area.width, area.height);
             return bufferedImage;
         } finally {

--- a/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
@@ -10,6 +10,7 @@ import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.geometry.GeneralEnvelope;
 import org.mapfish.print.ExceptionUtils;
 import org.mapfish.print.config.Configuration;
+import org.mapfish.print.map.style.json.ColorParser;
 import org.mapfish.print.map.tiled.TilePreparationInfo.SingleTilePreparationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +65,7 @@ public final class CoverageTask implements Callable<GridCoverage2D> {
         this.errorImage = new BufferedImage(tileSize.width, tileSize.height, BufferedImage.TYPE_4BYTE_ABGR);
         Graphics2D graphics = this.errorImage.createGraphics();
         try {
-            graphics.setBackground(configuration.getOpaqueTileErrorColor());
+            graphics.setBackground(ColorParser.toColor(configuration.getOpaqueTileErrorColor()));
             graphics.clearRect(0, 0, tileSize.width, tileSize.height);
         } finally {
             graphics.dispose();

--- a/examples/src/test/resources/examples/simple/config.yaml
+++ b/examples/src/test/resources/examples/simple/config.yaml
@@ -1,4 +1,6 @@
 throwErrorOnExtraParameters: true
+transparentTileErrorColor: "rgba(78, 78, 255, 125)"
+opaqueTileErrorColor: "rgba(255, 155, 155, 0)"
 
 templates:
   A4 portrait: !template


### PR DESCRIPTION
Java didn't find the fields because the getter is not returning same type as
the setter is taking.