### PR TITLE
Remove MaxPermSize

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ configure(subprojects.findAll {['core', 'examples'].contains(it.name)}) {
     }
 
     test {
-        jvmArgs '-XX:MaxPermSize=256m', '-XX:+UseConcMarkSweepGC', '-XX:+CMSClassUnloadingEnabled'
+        jvmArgs '-XX:+UseConcMarkSweepGC', '-XX:+CMSClassUnloadingEnabled'
         minHeapSize = "128m"
         maxHeapSize = "512m"
         testLogging {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -51,7 +51,7 @@ farm {
     // configuration to start a server running mfp, geoserver and the web-app
     // containing test data. start with `./gradlew examples:farmRun`
     systemProperty "path_to_examples", examplesDir
-    jvmArgs = ["-Xmx1G", "-XX:MaxPermSize=1G", "-DGEOSERVER_DATA_DIR=$buildDir/geoserver/data"]
+    jvmArgs = ["-Xmx1G", "-DGEOSERVER_DATA_DIR=$buildDir/geoserver/data"]
     scanInterval = 0
 
     webapp "org.geoserver.web:gs-web-app:$geoserverVersion"

--- a/gradlew
+++ b/gradlew
@@ -164,4 +164,4 @@ function splitJvmOpts() {
 eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
 JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
 
-exec "$JAVACMD" "${JVM_OPTS[@]}" "-XX:MaxPermSize=512M" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"
+exec "$JAVACMD" "${JVM_OPTS[@]}" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -72,7 +72,7 @@ set CMD_LINE_ARGS=%$
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 @rem Execute Gradle
-"%JAVA_EXE%" "-XX:MaxPermSize=512M" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
To avoid this kind of warning:
`ignoring option MaxPermSize=256m; support was removed in 8.0`