### PR TITLE
X-Request-ID support

### DIFF
--- a/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
+++ b/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
@@ -294,6 +294,7 @@ public class MapPrinterServletTest extends AbstractMapfishSpringTest {
         final MockHttpServletRequest servletCreateRequest = new MockHttpServletRequest("POST", "http://localhost:9834/context/print/report.png");
         servletCreateRequest.setContextPath("/print");
         addHeaders(servletCreateRequest);
+        servletCreateRequest.addHeader("X-Request-ID", "totoIs/TheBest");
         final MockHttpServletResponse servletCreateResponse = createReport.apply(servletCreateRequest);
 
         final PJsonObject createResponseJson = parseJSONObjectFromString(servletCreateResponse.getContentAsString());
@@ -306,9 +307,11 @@ public class MapPrinterServletTest extends AbstractMapfishSpringTest {
         assertEquals("/print/status/" + ref + ".json", statusURL);
         assertEquals("/print/report/" + ref, downloadURL);
 
-        final String atHostRefSegment = "@" + this.servletInfo.getServletId();
-        assertTrue(ref.endsWith(atHostRefSegment));
-        assertTrue(ref.indexOf(atHostRefSegment) > 0);
+        // Check the X-Request-ID has been included in the ref
+        final String[] splittedRef = ref.split("@");
+        assertEquals(3, splittedRef.length);
+        assertEquals("totoIs_TheBest", splittedRef[2]);
+        assertEquals(this.servletInfo.getServletId(), splittedRef[1]);
 
         boolean reportReady = false;
         int lastTimeElapsed = 0;


### PR DESCRIPTION
If the client specifies a X-Request-ID header (or other), the print includes
it in the reference ID of the job. This will be in every logs of the job and
will allow easy tracking.