### PR TITLE
Reduce PDF size when the base layer is JPEG and semi-transparent

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -177,11 +177,12 @@ dependencies {
     compile (configurations.geotools)
     compile (configurations.jasper)
 
-    def batikVersion = '1.8'
+    def batikVersion = '1.9.1'
     compile (
             'org.apache.xmlgraphics:xmlgraphics-commons:2.2',
             "org.apache.xmlgraphics:batik-transcoder:$batikVersion",
             "org.apache.xmlgraphics:batik-bridge:$batikVersion",
+            "org.apache.xmlgraphics:batik-codec:$batikVersion",
             "org.apache.xmlgraphics:batik-svg-dom:$batikVersion"
     )
 

--- a/core/src/main/java/org/mapfish/print/map/image/ImageLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/image/ImageLayer.java
@@ -166,12 +166,12 @@ public final class ImageLayer extends AbstractSingleImageLayer {
         final ReferencedEnvelope envelope = transformer.getBounds().toReferencedEnvelope(paintArea);
         final CoordinateReferenceSystem mapProjection = envelope.getCoordinateReferenceSystem();
 
-        Closer closer = Closer.create();
+        final Closer closer = Closer.create();
         final BufferedImage bufferedImage = new BufferedImage(paintArea.width, paintArea.height,
                 TYPE_INT_ARGB_PRE);
         final Graphics2D graphics = bufferedImage.createGraphics();
-        MapBounds bounds = transformer.getBounds();
-        MapContent content = new MapContent();
+        final MapBounds bounds = transformer.getBounds();
+        final MapContent content = new MapContent();
         try {
             final ClientHttpRequest request = requestFactory.createRequest(commonUri, HttpMethod.GET);
             final ClientHttpResponse httpResponse = closer.register(request.execute());
@@ -231,6 +231,7 @@ public final class ImageLayer extends AbstractSingleImageLayer {
         } finally {
             graphics.dispose();
             closer.close();
+            content.dispose();
         }
     }
 


### PR DESCRIPTION
Now, the print will try to keep the same format as the source layer.

Fix memory leak in image layers.
