### PR TITLE
Disable cookie management

### DIFF
--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -58,6 +58,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
 
     private static CloseableHttpClient createHttpClient(final int maxConnTotal, final int maxConnPerRoute) {
         final HttpClientBuilder httpClientBuilder = HttpClients.custom().
+                disableCookieManagement().
                 setRoutePlanner(new MfRoutePlanner()).
                 setSSLSocketFactory(new MfSSLSocketFactory()).
                 setDefaultCredentialsProvider(new MfCredentialsProvider()).


### PR DESCRIPTION
Fixes: #618.

It causes reliability and security issues:
- cookies (Set-Cookie) received in responses are kept on a global scope;
- cookies coming from the user are merged with kept cookies.

We only want to forward eventual cookies from the client.