### PR TITLE
Fix JSON error in getCapabilities

### DIFF
--- a/core/src/main/java/org/mapfish/print/attribute/DataSourceAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/DataSourceAttribute.java
@@ -140,7 +140,6 @@ public final class DataSourceAttribute implements Attribute {
                 Attribute attribute = entry.getValue();
                 if (attribute.getClass().getAnnotation(InternalAttribute.class) == null) {
                     json.object();
-                    json.key("name").value(entry.getKey());
                     attribute.printClientConfig(json, template);
                     json.endObject();
                 }

--- a/examples/src/test/java/org/mapfish/print/ExamplesTest.java
+++ b/examples/src/test/java/org/mapfish/print/ExamplesTest.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -173,7 +174,7 @@ public class ExamplesTest {
                 errorReport.append(exampleName.toString().replaceAll(".", "="));
                 errorReport.append('\n');
                 errorReport.append("Failed with the error:\n");
-                errorReport.append(error.getValue());
+                errorReport.append(ExceptionUtils.getFullStackTrace(error.getValue()));
                 errorReport.append('\n');
             }
             errorReport.append("\n\n");


### PR DESCRIPTION
The `name` key was added twice and this is not allowed by the new version
of the JSON library.