### PR TITLE
Fix concurency issue in the addHeaders processor

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/http/AddHeadersProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/AddHeadersProcessor.java
@@ -6,6 +6,7 @@ import com.vividsolutions.jts.util.Assert;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.http.AbstractMfClientHttpRequestFactoryWrapper;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
+import org.mapfish.print.processor.http.matcher.UriMatchers;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
 
@@ -71,6 +72,19 @@ public final class AddHeadersProcessor extends AbstractClientHttpRequestFactoryP
     public MfClientHttpRequestFactory createFactoryWrapper(
             final ClientHttpFactoryProcessorParam clientHttpFactoryProcessorParam,
             final MfClientHttpRequestFactory requestFactory) {
+        return createFactoryWrapper(requestFactory, this.matchers, this.headers);
+    }
+
+    /**
+     * Create a MfClientHttpRequestFactory for adding the specified headers.
+     * @param requestFactory the basic request factory.  It should be unmodified and just wrapped with a proxy class.
+     * @param matchers The matchers.
+     * @param headers The headers.
+     * @return
+     */
+    public static MfClientHttpRequestFactory createFactoryWrapper(
+            final MfClientHttpRequestFactory requestFactory,
+            final UriMatchers matchers, final Map<String, List<String>> headers) {
         return new AbstractMfClientHttpRequestFactoryWrapper(requestFactory, matchers, false) {
             @Override
             protected ClientHttpRequest createRequest(
@@ -78,7 +92,7 @@ public final class AddHeadersProcessor extends AbstractClientHttpRequestFactoryP
                     final HttpMethod httpMethod,
                     final MfClientHttpRequestFactory requestFactory) throws IOException {
                 final ClientHttpRequest request = requestFactory.createRequest(uri, httpMethod);
-                request.getHeaders().putAll(AddHeadersProcessor.this.headers);
+                request.getHeaders().putAll(headers);
                 return request;
             }
         };

--- a/core/src/main/java/org/mapfish/print/processor/http/ForwardHeadersProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/ForwardHeadersProcessor.java
@@ -8,6 +8,7 @@ import org.mapfish.print.config.Configuration;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.processor.AbstractProcessor;
 import org.mapfish.print.processor.http.matcher.URIMatcher;
+import org.mapfish.print.processor.http.matcher.UriMatchers;
 
 import java.util.HashSet;
 import java.util.List;
@@ -39,10 +40,9 @@ public final class ForwardHeadersProcessor
         extends AbstractProcessor<ForwardHeadersProcessor.Param, Void>
         implements HttpProcessor<ForwardHeadersProcessor.Param> {
 
-    private final AddHeadersProcessor addHeadersProcessor = new AddHeadersProcessor();
-
     private Set<String> headerNames = Sets.newHashSet();
     private boolean forwardAll = false;
+    private final UriMatchers matchers = new UriMatchers();
 
     /**
      * Constructor.
@@ -95,7 +95,7 @@ public final class ForwardHeadersProcessor
      * @param matchers the list of matcher to use to check if a url is permitted
      */
     public void setMatchers(final List<? extends URIMatcher> matchers) {
-        this.addHeadersProcessor.setMatchers(matchers);
+        this.matchers.setMatchers(matchers);
     }
 
     /**
@@ -122,7 +122,7 @@ public final class ForwardHeadersProcessor
     public MfClientHttpRequestFactory createFactoryWrapper(
             final Param param,
             final MfClientHttpRequestFactory requestFactory) {
-        Map<String, Object> headers = Maps.newHashMap();
+        Map<String, List<String>> headers = Maps.newHashMap();
 
         for (Map.Entry<String, List<String>> entry : param.requestHeaders.getHeaders().entrySet()) {
             if (ForwardHeadersProcessor.this.forwardAll ||
@@ -130,9 +130,8 @@ public final class ForwardHeadersProcessor
                 headers.put(entry.getKey(), entry.getValue());
             }
         }
-        this.addHeadersProcessor.setHeaders(headers);
 
-        return this.addHeadersProcessor.createFactoryWrapper(param, requestFactory);
+        return AddHeadersProcessor.createFactoryWrapper(requestFactory, this.matchers, headers);
     }
 
     @Nullable


### PR DESCRIPTION
We sometimes had stack traces like that:
```
java.util.ConcurrentModificationException: null
    at java.util.HashMap$HashIterator.nextNode(HashMap.java:1437)
    at java.util.HashMap$EntryIterator.next(HashMap.java:1471)
    at java.util.HashMap$EntryIterator.next(HashMap.java:1469)
    at org.springframework.util.LinkedCaseInsensitiveMap.putAll(LinkedCaseInsensitiveMap.java:104)
    at org.springframework.http.HttpHeaders.putAll(HttpHeaders.java:620)
    at org.mapfish.print.processor.http.AddHeadersProcessor$1.createRequest(AddHeadersProcessor.java:81)
    at org.mapfish.print.http.AbstractMfClientHttpRequestFactoryWrapper.createRequest(AbstractMfClientHttpRequestFactoryWrapper.java:48)
    at org.mapfish.print.http.AbstractMfClientHttpRequestFactoryWrapper.createRequest(AbstractMfClientHttpRequestFactoryWrapper.java:52)
    at org.mapfish.print.URIUtils.toString(URIUtils.java:231)
    at org.mapfish.print.map.geotools.GmlLayer$Plugin.createFeatureSource(GmlLayer.java:120)
    at org.mapfish.print.map.geotools.GmlLayer$Plugin.access$000(GmlLayer.java:55)
    at org.mapfish.print.map.geotools.GmlLayer$Plugin$1.load(GmlLayer.java:101)
    at org.mapfish.print.map.geotools.AbstractFeatureSourceLayer.getFeatureSource(AbstractFeatureSourceLayer.java:66)
    at org.mapfish.print.processor.map.CreateMapProcessor.getFeatureBounds(CreateMapProcessor.java:599)
    at org.mapfish.print.processor.map.CreateMapProcessor.zoomToFeatures(CreateMapProcessor.java:519)
    at org.mapfish.print.processor.map.CreateMapProcessor.execute(CreateMapProcessor.java:132)
    at org.mapfish.print.processor.map.CreateMapProcessor.execute(CreateMapProcessor.java:103)
    at org.mapfish.print.processor.ProcessorGraphNode$ProcessorNodeForkJoinTask.compute(ProcessorGraphNode.java:200)
    at org.mapfish.print.processor.ProcessorGraphNode$ProcessorNodeForkJoinTask.compute(ProcessorGraphNode.java:176)
    at jsr166y.RecursiveTask.exec(RecursiveTask.java:64)
    at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:305)
    at jsr166y.ForkJoinWorkerThread.execTask(ForkJoinWorkerThread.java:575)
    at jsr166y.ForkJoinPool.scan(ForkJoinPool.java:733)
    at jsr166y.ForkJoinPool.work(ForkJoinPool.java:617)
    at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:369)
```