### PR TITLE
BatikRenderer has been deprecated and replaced by ResourceRenderer

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/jasper/ImagesSubReport.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/ImagesSubReport.java
@@ -1,7 +1,6 @@
 package org.mapfish.print.processor.jasper;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.Files;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperCompileManager;
 import net.sf.jasperreports.engine.design.JRDesignBand;
@@ -70,16 +69,8 @@ public class ImagesSubReport {
     private void addGraphics(final List<URI> graphics, final JRDesignBand band,
             final Dimension size, final JasperDesign design) {
         for (URI graphicFile : graphics) {
-            String imageExpression;
-
             final String fileName = new File(graphicFile).getAbsolutePath().replace('\\', '/');
-            if (Files.getFileExtension(fileName).equals("svg")) {
-                imageExpression = "net.sf.jasperreports.renderers.BatikRenderer.getInstance(new java.io.File(\""
-                        + fileName + "\"))";
-            } else {
-                imageExpression = "\"" + fileName + "\"";
-            }
-
+            final String imageExpression = "\"" + fileName + "\"";
             band.addElement(getImage(imageExpression, size, design));
         }
     }

--- a/core/src/test/java/org/mapfish/print/processor/jasper/MapSubReportTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/jasper/MapSubReportTest.java
@@ -50,9 +50,7 @@ public class MapSubReportTest {
         JRDesignImage image3 = (JRDesignImage) report.getNoData().getChildren().get(3);
         assertEquals(400, image3.getWidth());
         assertEquals(500, image3.getHeight());
-        assertEquals("net.sf.jasperreports.renderers.BatikRenderer.getInstance(new java.io.File(\"" + layer3SVG.getPath().replace('\\',
-                        '/') + "\"))",
-                image3.getExpression().getText());
+        assertEquals("\"" + layer3SVG.getPath().replace('\\', '/') + "\"", image3.getExpression().getText());
 
         File compiledReportFile = folder.newFile();
         subReport.compile(compiledReportFile);


### PR DESCRIPTION
Which is what is used when the image expression contains a string anyway.