### PR TITLE
Fix NullPointerException when a cached tile had an error while downloading

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
@@ -213,14 +213,15 @@ public final class CoverageTask implements Callable<GridCoverage2D> {
                     String errorMessage = String.format("Error making tile request: %s\n\t" +
                             "Status: %s\n" +
                             "\toutMessage: %s",
-                            this.tileRequest.getURI(), statusCode, response.getStatusText());
+                            this.tileRequest.getURI(), statusCode,
+                            response != null ? response.getStatusText() : "-");
                     LOGGER.error(errorMessage);
                     this.registry.counter(baseMetricName + ".error").inc();
                     if (this.failOnError) {
                         throw new RuntimeException(errorMessage);
                     }
                     return new Tile(this.errorImage, getTileIndexX(), getTileIndexY());
-                    }
+                }
 
                 BufferedImage image = ImageIO.read(response.getBody());
                 if (image == null) {


### PR DESCRIPTION
The displaying of the error message was causing a NPE. The previous fix
in 1457de0c164fb19bc562920837b048354fa016ad was incomplete.