### PR TITLE
Fix NPE when getting status for unknown job

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/PrintJobDao.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/PrintJobDao.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 
 /**
@@ -60,9 +61,12 @@ public class PrintJobDao {
      * @param id the id
      * @return
      */
+    @Nullable
     public final PrintJobStatusExtImpl get(final String id) {
         final PrintJobStatusExtImpl result = get(id, false);
-        getSession().evict(result);
+        if (result != null) {
+            getSession().evict(result);
+        }
         return result;
     }
 
@@ -72,8 +76,9 @@ public class PrintJobDao {
      *
      * @param id the id
      * @param lock whether record should be locked for transaction
-     * @return the job status.
+     * @return the job status or null.
      */
+    @Nullable
     public final PrintJobStatusExtImpl get(final String id, final boolean lock) {
         Criteria c = getSession().createCriteria(PrintJobStatusExtImpl.class);
         c.add(Restrictions.idEq(id));


### PR DESCRIPTION
This kind of stack trace have been found in Sentry:
```
java.lang.NullPointerException: null passed to Session.evict()
    at org.hibernate.event.internal.DefaultEvictEventListener.onEvict(DefaultEvictEventListener.java:66)
    at org.hibernate.internal.SessionImpl.fireEvict(SessionImpl.java:1210)
    at org.hibernate.internal.SessionImpl.evict(SessionImpl.java:1203)
    at org.mapfish.print.servlet.job.impl.hibernate.PrintJobDao.get(PrintJobDao.java:63)
    at org.mapfish.print.servlet.job.impl.hibernate.HibernateJobQueue.get(HibernateJobQueue.java:92)
    at sun.reflect.GeneratedMethodAccessor108.invoke
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
    at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99)
    at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:282)
    at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
    at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
    at com.sun.proxy.$Proxy34.get
    at org.mapfish.print.servlet.job.impl.ThreadPoolJobManager.getStatus(ThreadPoolJobManager.java:367)
    at org.mapfish.print.servlet.MapPrinterServlet.loadReport(MapPrinterServlet.java:979)
    at org.mapfish.print.servlet.MapPrinterServlet.getReport(MapPrinterServlet.java:400)
    at org.mapfish.print.servlet.MapPrinterServlet.getReportSpecificAppId(MapPrinterServlet.java:385)
```