### PR TITLE
Fix DB type to not use varchar

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobEntryImpl.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobEntryImpl.java
@@ -22,19 +22,18 @@ import javax.persistence.Embeddable;
 @Embeddable
 public class PrintJobEntryImpl implements PrintJobEntry {
 
-    private static final int LENGTH_JSON = 1024;
-
     @Column(insertable = false, updatable = false)
+    @Type(type = "org.hibernate.type.TextType")
     private String referenceId;
 
-    @Column(length = LENGTH_JSON)
+    @Column()
     @Type(type = "org.mapfish.print.servlet.job.impl.hibernate.PJsonObjectUserType")
     private PJsonObject requestData;
 
     @Column
     private long startTime;
 
-    @Column(length = LENGTH_JSON)
+    @Column()
     @Type(type = "org.mapfish.print.servlet.job.impl.hibernate.AccessAssertionUserType")
     private AccessAssertion access;
 

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobResultImpl.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobResultImpl.java
@@ -2,6 +2,7 @@ package org.mapfish.print.servlet.job.impl;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.Type;
 import org.mapfish.print.ExceptionUtils;
 import org.mapfish.print.servlet.job.PrintJobResult;
 import org.mapfish.print.servlet.job.PrintJobStatus;
@@ -25,17 +26,20 @@ import javax.persistence.Table;
 @Table(name = "print_job_results")
 public class PrintJobResultImpl implements PrintJobResult {
 
-    @Column
     @Id
+    @Type(type = "org.hibernate.type.TextType")
     private final String reportURI;
 
     @Column
+    @Type(type = "org.hibernate.type.TextType")
     private final String mimeType;
 
     @Column
+    @Type(type = "org.hibernate.type.TextType")
     private final String fileExtension;
 
     @Column
+    @Type(type = "org.hibernate.type.TextType")
     private final String fileName;
 
     @OneToOne(targetEntity = PrintJobStatusImpl.class, fetch = FetchType.LAZY)
@@ -44,6 +48,7 @@ public class PrintJobResultImpl implements PrintJobResult {
     private PrintJobStatus status = null;
 
     @Column(insertable = true, updatable = true)
+    @Type(type = "org.hibernate.type.TextType")
     private String referenceId;
 
     /**

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobStatusImpl.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/PrintJobStatusImpl.java
@@ -1,6 +1,7 @@
 package org.mapfish.print.servlet.job.impl;
 
 import org.hibernate.annotations.Target;
+import org.hibernate.annotations.Type;
 import org.mapfish.print.config.access.AccessAssertion;
 import org.mapfish.print.servlet.job.PrintJobEntry;
 import org.mapfish.print.servlet.job.PrintJobResult;
@@ -25,10 +26,8 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "print_job_statuses")
 public class PrintJobStatusImpl implements PrintJobStatus {
-
-    private static final int LENGTH_ERROR = 1024;
-
     @Id
+    @Type(type = "org.hibernate.type.TextType")
     private String referenceId;
 
     @Embedded
@@ -45,7 +44,7 @@ public class PrintJobStatusImpl implements PrintJobStatus {
     @Column
     private long requestCount;
 
-    @Column(length = LENGTH_ERROR)
+    @Type(type = "org.hibernate.type.TextType")
     private String error;
 
     @OneToOne(targetEntity = PrintJobResultImpl.class, cascade = CascadeType.ALL, mappedBy = "status")


### PR DESCRIPTION
This fixes a nasty error in multi-instance were the error is not
reaching the client when the message is too long.