### PR TITLE
Allow to have sub_apps and allow to have apps appear at runtime

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="PROJECT_RELATIVE:$PRJ_DIR$/checkstyle_checks.xml:MFPrint" />
+        <entry key="active-configuration" value="PROJECT_RELATIVE:$PROJECT_DIR$/checkstyle_checks.xml:MFPrint" />
         <entry key="checkstyle-version" value="7.8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="PROJECT_RELATIVE:$PRJ_DIR$/checkstyle_checks.xml:MFPrint" />
+        <entry key="location-2" value="PROJECT_RELATIVE:$PROJECT_DIR$/checkstyle_checks.xml:MFPrint" />
         <entry key="property-2.basedir" value="$PROJECT_DIR$" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="JavaOnly" />

--- a/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
@@ -65,6 +65,7 @@ public abstract class BaseMapServlet {
         try {
             httpServletResponse.setContentType("text/plain");
             httpServletResponse.setStatus(code.value());
+            setNoCache(httpServletResponse);
             out = httpServletResponse.getWriter();
             out.println("Error while processing request:");
             out.println(message);
@@ -77,6 +78,15 @@ public abstract class BaseMapServlet {
                 out.close();
             }
         }
+    }
+
+    /**
+     * Disable caching of the response.
+     *
+     * @param response the response
+     */
+    protected static void setNoCache(final HttpServletResponse response) {
+        response.setHeader("Cache-Control", "max-age=0, must-revalidate, no-cache, no-store");
     }
 
     /**
@@ -125,15 +135,6 @@ public abstract class BaseMapServlet {
      */
     public final void setCacheDuration(final int cacheDurationInSeconds) {
         this.cacheDurationInSeconds = cacheDurationInSeconds;
-    }
-
-    /**
-     * Disable caching of the response.
-     *
-     * @param response the response
-     */
-    protected void setNoCache(final HttpServletResponse response) {
-        response.setHeader("Cache-Control", "max-age=0, must-revalidate, no-cache, no-store");
     }
 
     /**


### PR DESCRIPTION
In the application directory, you can have now directories containing sub-directories. The app name will be {dirname_level1}:{dirname_level2}.
    
Also, when an unknown app is referenced in the API, the print will try to see if the directory didn't appear in the mean time. And when a directory disappears, remove this app from the print.
    
Finally, the print can now start without application configured.

Closes #698