### PR TITLE
Be less dramatic on undefined referer

### DIFF
--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -1021,7 +1021,10 @@ public class MapPrinterServlet extends BaseMapServlet {
         if (allowedReferers == null) {
             return true;
         }
-        final String referer = request.getHeader("referer");
+        String referer = request.getHeader("referer");
+        if (referer == null) {
+            referer = "http://localhost/";
+        }
         try {
             return allowedReferers.matches(new URI(referer),
                                            HttpMethod.resolve(request.getMethod()));


### PR DESCRIPTION
Was doing a NullPointerException instead of a nice message.