### PR TITLE
Disable automatic detection of WebApplicationInitializer

### DIFF
--- a/core/src/main/webapp/WEB-INF/web.xml
+++ b/core/src/main/webapp/WEB-INF/web.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<web-app version="3.0"
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="3.0"
          xmlns="http://java.sun.com/xml/ns/javaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          metadata-complete="true">
+
+    <absolute-ordering/>
 
     <context-param>
         <param-name>contextConfigLocation</param-name>


### PR DESCRIPTION
This shaves off 1s out of the deployment of the web application.