### PR TITLE
Did a pass on the logs to improve them

### DIFF
--- a/core/src/main/java/org/mapfish/print/FileUtils.java
+++ b/core/src/main/java/org/mapfish/print/FileUtils.java
@@ -109,8 +109,9 @@ public final class FileUtils {
             }
         }
         LOGGER.warn(
-                "A user attempted to access a file not within the '" + descriptorOfBase + "' directories (" +
-                        Arrays.toString(baseFiles) + "). " + "Attempted access to :" + canonicalChild);
+                "A user attempted to access a file not within the '{}' directories ({}). Attempted access " +
+                        "to: {}",
+                descriptorOfBase, Arrays.toString(baseFiles), canonicalChild);
         throw new IllegalFileAccessException(
                 "'" + canonicalChild + "' identifies a file that is not within the '" +
                         descriptorOfBase +

--- a/core/src/main/java/org/mapfish/print/cli/Main.java
+++ b/core/src/main/java/org/mapfish/print/cli/Main.java
@@ -205,7 +205,9 @@ public final class Main {
 
                 outFile = getOutputStream(cli.output,
                                           this.mapPrinter.getOutputFormat(jsonSpec).getFileSuffix());
-                LOGGER.debug("Request Data: \n" + jsonSpec.getInternalObj().toString(2));
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Request Data: \n" + jsonSpec.getInternalObj().toString(2));
+                }
                 this.mapPrinter.print("main", jsonSpec, outFile);
             }
         } finally {

--- a/core/src/main/java/org/mapfish/print/config/ConfigurationFactory.java
+++ b/core/src/main/java/org/mapfish/print/config/ConfigurationFactory.java
@@ -69,7 +69,7 @@ public class ConfigurationFactory {
                 StringBuilder errors = new StringBuilder();
                 for (Throwable throwable: validate) {
                     errors.append("\n\t* ").append(throwable.getMessage());
-                    LOGGER.error("Configuration Error found: ", throwable);
+                    LOGGER.error("Configuration Error found", throwable);
                 }
                 throw new Error(errors.toString(), validate.get(0));
             }

--- a/core/src/main/java/org/mapfish/print/config/CustomFontLoader.java
+++ b/core/src/main/java/org/mapfish/print/config/CustomFontLoader.java
@@ -57,11 +57,10 @@ public final class CustomFontLoader {
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         boolean registered = ge.registerFont(font);
         if (!registered) {
-            LOGGER.warn(
-                    "Font " + fontFile.getAbsolutePath() + " could not be registered. " +
-                            "Is there already a system font with the same name?");
+            LOGGER.warn("Font {} could not be registered. Is there already a system font with the same name?",
+                        fontFile.getAbsolutePath());
         } else {
-            LOGGER.info("Font " + fontFile.getAbsolutePath() + " registered successfully");
+            LOGGER.info("Font {} registered successfully", fontFile.getAbsolutePath());
         }
     }
 }

--- a/core/src/main/java/org/mapfish/print/config/Template.java
+++ b/core/src/main/java/org/mapfish/print/config/Template.java
@@ -139,7 +139,7 @@ public class Template implements ConfigurationObject, HasConfiguration {
             if (!(attribute instanceof Attribute)) {
                 final String msg =
                         "Attribute: '" + entry.getKey() + "' is not an attribute. It is a: " + attribute;
-                LOGGER.error("Error setting the Attributes: " + msg);
+                LOGGER.error("Error setting the Attributes: {}", msg);
                 throw new IllegalArgumentException(msg);
             } else {
                 ((Attribute) attribute).setConfigName(entry.getKey());
@@ -174,7 +174,7 @@ public class Template implements ConfigurationObject, HasConfiguration {
         for (Processor entry: processorsToCheck) {
             if (!(entry instanceof Processor)) {
                 final String msg = "Processor: " + entry + " is not a processor.";
-                LOGGER.error("Error setting the Attributes: " + msg);
+                LOGGER.error("Error setting the Attributes: {}", msg);
                 throw new IllegalArgumentException(msg);
             }
         }

--- a/core/src/main/java/org/mapfish/print/config/WorkingDirectories.java
+++ b/core/src/main/java/org/mapfish/print/config/WorkingDirectories.java
@@ -114,7 +114,7 @@ public class WorkingDirectories {
         try {
             FileUtils.deleteDirectory(directory);
         } catch (IOException e) {
-            LOGGER.error("Unable to delete directory '" + directory + "'");
+            LOGGER.error("Unable to delete directory '{}'", directory);
         }
     }
 
@@ -154,8 +154,8 @@ public class WorkingDirectories {
         final File buildFile = new File(getJasperCompilation(configuration), relativePathToFile + extension);
 
         if (!buildFile.getParentFile().exists() && !buildFile.getParentFile().mkdirs()) {
-            logger.error("Unable to create directory for containing compiled jasper report templates: " +
-                                 buildFile.getParentFile());
+            logger.error("Unable to create directory for containing compiled jasper report templates: {}",
+                         buildFile.getParentFile());
         }
         return buildFile;
     }
@@ -219,14 +219,14 @@ public class WorkingDirectories {
                     if ((prefix == null || file.getName().startsWith(prefix))
                             && file.lastModified() < ageThreshold) {
                         if (!FileUtils.deleteQuietly(file)) {
-                            LOGGER.warn("failed to delete file " + file.getAbsolutePath());
+                            LOGGER.warn("failed to delete file {}", file.getAbsolutePath());
                         } else {
                             deletedFiles++;
                         }
                     }
                 }
             }
-            LOGGER.info("deleted " + deletedFiles + " old file(s) in " + dir.getPath());
+            LOGGER.info("deleted {} old file(s) in {}", deletedFiles, dir.getPath());
         }
     }
 }

--- a/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingHttpRequestFactory.java
+++ b/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingHttpRequestFactory.java
@@ -105,7 +105,7 @@ public final class ConfigFileResolvingHttpRequestFactory implements MfClientHttp
             }
             try {
                 if (this.request != null) {
-                    LOGGER.debug("Executing http request: " + this.request.getURI());
+                    LOGGER.debug("Executing http request: {}", this.request.getURI());
                     return executeCallbacksAndRequest(this.request);
                 }
                 if (this.httpMethod == HttpMethod.GET) {
@@ -115,15 +115,15 @@ public final class ConfigFileResolvingHttpRequestFactory implements MfClientHttp
                         final byte[] bytes = configuration.loadFile(uriString);
                         final ConfigFileResolverHttpResponse response =
                                 new ConfigFileResolverHttpResponse(bytes, headers);
-                        LOGGER.debug(String.format(
-                                "Resolved request: %s using mapfish print config file loaders.", uriString));
+                        LOGGER.debug("Resolved request: {} using mapfish print config file loaders.",
+                                     uriString);
                         return response;
                     } catch (NoSuchElementException e) {
                         // cannot be loaded by configuration so try http
                     }
                 }
 
-                LOGGER.debug("Executing http request: " + this.getURI());
+                LOGGER.debug("Executing http request: {}", this.getURI());
                 return executeCallbacksAndRequest(createRequestFromWrapped(headers));
             } finally {
                 if (noJobId) {

--- a/core/src/main/java/org/mapfish/print/http/HttpRequestCache.java
+++ b/core/src/main/java/org/mapfish/print/http/HttpRequestCache.java
@@ -180,13 +180,13 @@ public final class HttpRequestCache {
         @Override
         public ClientHttpResponse execute() {
             if (!HttpRequestCache.this.cached) {
-                LOGGER.warn("Attempting to load cached URI before actual caching: " +
-                                    this.originalRequest.getURI());
+                LOGGER.warn("Attempting to load cached URI before actual caching: {}",
+                            this.originalRequest.getURI());
             } else if (this.response == null) {
-                LOGGER.warn("Attempting to load cached URI from failed request: " +
-                                    this.originalRequest.getURI());
+                LOGGER.warn("Attempting to load cached URI from failed request: {}",
+                            this.originalRequest.getURI());
             } else {
-                LOGGER.debug("Loading cached URI resource " + this.originalRequest.getURI());
+                LOGGER.debug("Loading cached URI resource {}", this.originalRequest.getURI());
             }
             return this.response;
         }
@@ -198,10 +198,10 @@ public final class HttpRequestCache {
             ClientHttpResponse originalResponse = null;
             try {
                 originalResponse = this.originalRequest.execute();
-                LOGGER.debug("Caching URI resource " + this.originalRequest.getURI());
+                LOGGER.debug("Caching URI resource {}", this.originalRequest.getURI());
                 this.response = new CachedClientHttpResponse(originalResponse);
             } catch (IOException e) {
-                LOGGER.error("Request failed " + this.originalRequest.getURI(), e);
+                LOGGER.error("Request failed {}", this.originalRequest.getURI());
                 this.response = new AbstractClientHttpResponse() {
                     @Override
                     public HttpHeaders getHeaders() {

--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -156,13 +156,13 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
         protected Response executeInternal(@Nonnull final HttpHeaders headers) throws IOException {
             CURRENT_CONFIGURATION.set(this.configuration);
 
-            LOGGER.debug("Preparing request " + this.getMethod() + " -- " + this.getURI());
+            LOGGER.debug("Preparing request {} -- {}", this.getMethod(), this.getURI());
             for (Map.Entry<String, List<String>> entry: headers.entrySet()) {
                 String headerName = entry.getKey();
                 if (!headerName.equalsIgnoreCase(HTTP.CONTENT_LEN) &&
                         !headerName.equalsIgnoreCase(HTTP.TRANSFER_ENCODING)) {
                     for (String headerValue: entry.getValue()) {
-                        LOGGER.debug("Setting header: " + headerName + " : " + headerValue);
+                        LOGGER.debug("Setting header: {} : {}", headerName, headerValue);
                         this.request.addHeader(headerName, headerValue);
                     }
                 }
@@ -174,7 +174,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
                 entityEnclosingRequest.setEntity(requestEntity);
             }
             HttpResponse response = this.client.execute(this.request, this.context);
-            LOGGER.debug("Response: " + response.getStatusLine().getStatusCode() + " -- " + this.getURI());
+            LOGGER.debug("Response: {} -- {}", response.getStatusLine().getStatusCode(), this.getURI());
 
             return new Response(response);
         }
@@ -191,7 +191,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
 
         Response(@Nonnull final HttpResponse response) {
             this.response = response;
-            LOGGER.trace("Creating Http Response object: " + this.id);
+            LOGGER.trace("Creating Http Response object: {}", this.id);
         }
 
 
@@ -215,17 +215,17 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
             try {
                 getBody();
             } catch (IOException e) {
-                LOGGER.error(String.format("Error occurred while trying to retrieve Http Response %s in " +
-                                                   "order to close it.", this.id), e);
+                LOGGER.error("Error occurred while trying to retrieve Http Response {} in order to close it.",
+                             this.id, e);
             } finally {
                 try {
                     this.closer.close();
                 } catch (IOException e) {
-                    LOGGER.trace("Error while closing Http Response object: " + this.id);
+                    LOGGER.trace("Error while closing Http Response object: {}", this.id);
                     throw new RuntimeException(e);
                 }
 
-                LOGGER.trace("Closed Http Response object: " + this.id);
+                LOGGER.trace("Closed Http Response object: {}", this.id);
             }
         }
 

--- a/core/src/main/java/org/mapfish/print/map/geotools/FeaturesParser.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/FeaturesParser.java
@@ -108,13 +108,13 @@ public class FeaturesParser {
                                 try {
                                     return CRS.parseWKT(wkt);
                                 } catch (FactoryException e) {
-                                    LOGGER.warn("Unable to load linked CRS from geojson: \n" + crsJson +
-                                                        "\n\nWKT loaded from:\n" + wkt);
+                                    LOGGER.warn("Unable to load linked CRS from geojson: \n{}\n\nWKT loaded" +
+                                                        " from:\n{}", crsJson, wkt);
                                 }
                             }
                         }
                     } else {
-                        LOGGER.warn("Unable to load linked CRS from geojson: \n" + crsJson);
+                        LOGGER.warn("Unable to load linked CRS from geojson: \n{}", crsJson);
                     }
                 } else {
                     code.append(getProperty(crsJson, "code"));
@@ -122,16 +122,16 @@ public class FeaturesParser {
 
             }
         } catch (JSONException | IOException | URISyntaxException e) {
-            LOGGER.warn("Error reading the required elements to parse crs of the geojson: \n" + geojson, e);
+            LOGGER.warn("Error reading the required elements to parse crs of the geojson: \n{}", geojson, e);
         }
         try {
             if (code.length() > 0) {
                 crs = CRS.decode(code.toString(), forceLongitudeFirst);
             }
         } catch (NoSuchAuthorityCodeException e) {
-            LOGGER.warn("No CRS with code: " + code + ".\nRead from geojson: \n" + geojson);
+            LOGGER.warn("No CRS with code: {}.\nRead from geojson: \n{}", code, geojson);
         } catch (FactoryException e) {
-            LOGGER.warn("Error loading CRS with code: " + code + ".\nRead from geojson: \n" + geojson);
+            LOGGER.warn("Error loading CRS with code: {}.\nRead from geojson: \n{}", code, geojson);
         }
         return crs;
     }

--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsLayerParam.java
@@ -103,7 +103,7 @@ public class WmsLayerParam extends AbstractWMXLayerParams {
         }
 
         if (this.imageFormat.indexOf('/') < 0) {
-            LOGGER.warn("The format should be a mime type");
+            LOGGER.warn("The format {} should be a mime type", this.imageFormat);
             this.imageFormat = "image/" + this.imageFormat;
         }
 

--- a/core/src/main/java/org/mapfish/print/map/style/SLDParserPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/style/SLDParserPlugin.java
@@ -185,7 +185,7 @@ public class SLDParserPlugin implements StyleParserPlugin {
          * @param e Exception
          */
         public final void error(final SAXParseException e) throws SAXException {
-            LOGGER.debug("XML error: " + e.getLocalizedMessage());
+            LOGGER.debug("XML error: {}", e.getLocalizedMessage());
             super.error(e);
         }
 
@@ -193,7 +193,7 @@ public class SLDParserPlugin implements StyleParserPlugin {
          * @param e Exception
          */
         public final void fatalError(final SAXParseException e) throws SAXException {
-            LOGGER.debug("XML fatal error: " + e.getLocalizedMessage());
+            LOGGER.debug("XML fatal error: {}", e.getLocalizedMessage());
             super.fatalError(e);
         }
 

--- a/core/src/main/java/org/mapfish/print/map/style/StyleParser.java
+++ b/core/src/main/java/org/mapfish/print/map/style/StyleParser.java
@@ -57,9 +57,9 @@ public final class StyleParser {
                                                  styleString, transformer.transform(sld));
                                 }
                             } catch (Exception e) {
-                                LOGGER.debug(String.format("Loaded style from: \n\n '%s' \n\n<Unable to " +
-                                                                   "transform it to xml>: %s", styleString,
-                                                           e), e);
+                                LOGGER.debug(
+                                        "Loaded style from: \n\n '{}' \n\n<Unable to transform it to xml>",
+                                        styleString, e);
                             }
                         }
                         return style;

--- a/core/src/main/java/org/mapfish/print/map/tiled/TilePreparationTask.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/TilePreparationTask.java
@@ -203,7 +203,7 @@ public final class TilePreparationTask implements Callable<TilePreparationInfo> 
             this.cachedRotatedMapBounds = Optional.of(rotatedBounds);
         } catch (TransformException e) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Failed to rotate map bounds: " + mapBounds.toString(), e);
+                LOGGER.debug("Failed to rotate map bounds: {}", mapBounds.toString(), e);
             }
             this.cachedRotatedMapBounds = Optional.absent();
         }

--- a/core/src/main/java/org/mapfish/print/output/AbstractJasperReportOutputFormat.java
+++ b/core/src/main/java/org/mapfish/print/output/AbstractJasperReportOutputFormat.java
@@ -266,10 +266,10 @@ public abstract class AbstractJasperReportOutputFormat implements OutputFormat {
                                 wrongType.append(" expected type: ").append(type).append("\n");
                             }
                         } else {
-                            LOGGER.warn(String.format(
-                                    "The field %s in %s is not available in at least one" +
-                                            " of the rows in the datasource.  This may not be an error.",
-                                    name, reportTemplate));
+                            LOGGER.warn(
+                                    "The field {} in {} is not available in at least one of the rows in the" +
+                                            " datasource.  This may not be an error.",
+                                    name, reportTemplate);
                         }
                     }
                 }

--- a/core/src/main/java/org/mapfish/print/output/MapfishPrintRepositoryService.java
+++ b/core/src/main/java/org/mapfish/print/output/MapfishPrintRepositoryService.java
@@ -87,7 +87,7 @@ class MapfishPrintRepositoryService implements StreamRepositoryService {
         } catch (IllegalStateException e) {
             LOGGER.info("Resource not found {} ({}).", uri, e.toString());
         } catch (Exception e) {
-            LOGGER.trace(String.format("Error on getting resource %s.", uri), e);
+            LOGGER.trace("Error on getting resource {}", uri, e);
         }
         return null;
     }

--- a/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
+++ b/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
@@ -134,10 +134,10 @@ public final class MapfishParser {
 
         try {
             final Method method = objectToPopulate.getClass().getMethod(POST_CONSTRUCT_METHOD_NAME);
-            LOGGER.debug("Executing " + POST_CONSTRUCT_METHOD_NAME + " method on parameter object.");
+            LOGGER.debug("Executing {} method on parameter object.", POST_CONSTRUCT_METHOD_NAME);
             method.invoke(objectToPopulate);
         } catch (NoSuchMethodException e) {
-            LOGGER.debug("No " + POST_CONSTRUCT_METHOD_NAME + " method on parameter object.");
+            LOGGER.debug("No {} method on parameter object.", POST_CONSTRUCT_METHOD_NAME);
         } catch (InvocationTargetException e) {
             final Throwable targetException = e.getTargetException();
             if (targetException instanceof RuntimeException) {

--- a/core/src/main/java/org/mapfish/print/processor/ProcessorGraphNode.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorGraphNode.java
@@ -209,7 +209,7 @@ public final class ProcessorGraphNode<In, Out> {
                         // the processor is already canceled, so we don't care if something fails
                         throw new CancellationException();
                     } else {
-                        LOGGER.error("Error while executing process: " + process, e);
+                        LOGGER.error("Error while executing process: " + process);
                         registry.counter(name + ".error").inc();
                         throw ExceptionUtils.getRuntimeException(e);
                     }

--- a/core/src/main/java/org/mapfish/print/processor/http/matcher/InetHostMatcher.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/matcher/InetHostMatcher.java
@@ -23,8 +23,8 @@ public abstract class InetHostMatcher extends HostMatcher {
     private static byte[] mask(final byte[] address, final byte[] mask) {
         if (mask != null) {
             if (address.length != mask.length) {
-                LOGGER.warn("Cannot mask address [" + Arrays.toString(address) + "] with: " +
-                                    Arrays.toString(mask));
+                LOGGER.warn("Cannot mask address [{}] with: {}", Arrays.toString(address),
+                            Arrays.toString(mask));
                 return address;
             } else {
                 final byte[] result = new byte[address.length];
@@ -69,7 +69,7 @@ public abstract class InetHostMatcher extends HostMatcher {
                 return true;
             }
         }
-        LOGGER.debug("Address not in the authorized set: " + requestedIP);
+        LOGGER.debug("Address not in the authorized set: {}", requestedIP);
         return false;
     }
 

--- a/core/src/main/java/org/mapfish/print/processor/jasper/HttpImageResolver.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/HttpImageResolver.java
@@ -74,20 +74,19 @@ public final class HttpImageResolver implements TableColumnConverter<BufferedIma
                     try {
                         final BufferedImage image = ImageIO.read(response.getBody());
                         if (image == null) {
-                            LOGGER.warn("The URL: " + url + " is NOT an image format that can be decoded");
+                            LOGGER.warn("The URL: {} is NOT an image format that can be decoded", url);
                             return this.defaultImage;
                         }
                         return image;
                     } catch (IOException e) {
-                        LOGGER.warn("Image loaded from '" + url + "'is not valid: " + e.getMessage());
+                        LOGGER.warn("Image loaded from '{}'is not valid", url, e);
                     }
                 } else {
-                    LOGGER.warn("Error loading the table row image: " + url + ".\nStatus Code: " +
-                                        response.getStatusCode() +
-                                        "\nStatus Text: " + response.getStatusText());
+                    LOGGER.warn("Error loading the table row image: {}.\nStatus Code: {}\nStatus Text: {}",
+                                url, response.getStatusCode(), response.getStatusText());
                 }
             } catch (Throwable e) {
-                LOGGER.warn("Error loading table row image: " + uriString, e);
+                LOGGER.warn("Error loading table row image: {}", uriString, e);
             }
         }
 

--- a/core/src/main/java/org/mapfish/print/processor/jasper/JasperReportBuilder.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/JasperReportBuilder.java
@@ -107,7 +107,7 @@ public final class JasperReportBuilder extends AbstractProcessor<JasperReportBui
                 throw new JRException(e);
             }
         } else {
-            LOGGER.debug("Destination file is already up to date: " + buildFile.getAbsolutePath());
+            LOGGER.debug("Destination file is already up to date: {}", buildFile.getAbsolutePath());
         }
         return buildFile;
     }

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -360,7 +360,7 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
                     }
                 }
             } catch (Exception e) {
-                LOGGER.warn("Failed to load image from: " + this.icon, e);
+                LOGGER.warn("Failed to load image from: {}", this.icon, e);
             }
 
             if (image == null) {

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateMapPagesProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateMapPagesProcessor.java
@@ -129,7 +129,7 @@ public class CreateMapPagesProcessor
         final double minX = aoiBBox.getMinX() - marginWidth - overlapProj / 2;
         final double minY = aoiBBox.getMinY() - marginHeight - overlapProj / 2;
 
-        LOGGER.info("Paging generate a grid of " + nbWidth + "x" + nbHeight + " potential maps.");
+        LOGGER.info("Paging generate a grid of {}x{} potential maps.", nbWidth, nbHeight);
         final int[][] mapIndexes = new int[nbWidth][nbHeight];
         final Envelope[][] mapsBounds = new Envelope[nbWidth][nbHeight];
         int mapIndex = 0;

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
@@ -527,8 +527,8 @@ public final class CreateMapProcessor
                 mapValues.center = new double[]{center.x, center.y};
                 if (mapValues.zoomToFeatures.minScale != null) {
                     LOGGER.warn(
-                            "The map.zoomToFeatures.minScale is deprecated, " +
-                                    "please use directly the map.scale");
+                            "The map.zoomToFeatures.minScale is deprecated, please use directly the map" +
+                                    ".scale");
                     mapValues.scale = mapValues.zoomToFeatures.minScale;
                 }
                 mapValues.recalculateBounds();

--- a/core/src/main/java/org/mapfish/print/processor/map/NorthArrowGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/NorthArrowGraphic.java
@@ -124,8 +124,9 @@ public final class NorthArrowGraphic {
 
             final BufferedImage originalImage = ImageIO.read(rasterReference.inputStream);
             if (originalImage == null) {
-                LOGGER.warn("Unable to load NorthArrow graphic: " + rasterReference.uri +
-                                    ", it is not an image format that can be decoded");
+                LOGGER.warn("Unable to load NorthArrow graphic: {}, it is not an image format that can be " +
+                                    "decoded",
+                            rasterReference.uri);
                 throw new IllegalArgumentException();
             }
 

--- a/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
@@ -49,8 +49,7 @@ public class ScalebarGraphic {
             final int tryNumber) {
         if (tryNumber > MAX_NUMBER_LAYOUTING_TRIES) {
             // if no good layout can be found, stop. an empty scalebar graphic will be shown.
-            LOGGER.error("layouting the scalebar failed (unit: " + scaleUnit.toString()
-                                 + ", scale: " + scaleDenominator + ")");
+            LOGGER.error("layouting the scalebar failed (unit: {}, scale: {})", scaleUnit, scaleDenominator);
             return;
         }
 

--- a/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/BaseMapServlet.java
@@ -46,7 +46,7 @@ public abstract class BaseMapServlet {
             try {
                 return new SimpleDateFormat(variableName).format(date);
             } catch (Exception e) {
-                LOGGER.error("Unable to format timestamp according to pattern: " + variableName, e);
+                LOGGER.error("Unable to format timestamp according to pattern: {}", variableName, e);
                 return "${" + variableName + "}";
             }
         }
@@ -70,7 +70,7 @@ public abstract class BaseMapServlet {
             out.println("Error while processing request:");
             out.println(message);
 
-            LOGGER.error("Error while processing request: " + message);
+            LOGGER.error("Error while processing request: {}", message);
         } catch (IOException ex) {
             throw ExceptionUtils.getRuntimeException(ex);
         } finally {

--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -252,7 +252,7 @@ public class MapPrinterServlet extends BaseMapServlet {
                 }
             }
         } catch (RuntimeException e) {
-            LOGGER.warn("Error parsing request data: " + requestDataRaw);
+            LOGGER.warn("Error parsing request data: {}", requestDataRaw);
             throw e;
         }
     }
@@ -335,7 +335,6 @@ public class MapPrinterServlet extends BaseMapServlet {
             json.endObject();
             appendJsonpCallbackEnd(jsonpCallback, writer);
         } catch (JSONException | IOException e) {
-            LOGGER.error("Error obtaining status", e);
             throw ExceptionUtils.getRuntimeException(e);
         } catch (NoSuchReferenceException e) {
             error(statusResponse, e.getMessage(), HttpStatus.NOT_FOUND);

--- a/core/src/main/java/org/mapfish/print/servlet/RequestSizeFilter.java
+++ b/core/src/main/java/org/mapfish/print/servlet/RequestSizeFilter.java
@@ -37,7 +37,7 @@ public class RequestSizeFilter implements Filter {
             final FilterChain chain) throws IOException, ServletException {
         if (request.getContentLength() > this.maxContentLength) {
             HttpServletResponse httpResponse = (HttpServletResponse) response;
-            LOGGER.error("Request size exceeds limit: " + request.getContentLength() + " bytes");
+            LOGGER.error("Request size exceeds limit: {} bytes", request.getContentLength());
             httpResponse.sendError(HttpStatus.BAD_REQUEST.value(), "Request size exceeds limit");
         } else {
             chain.doFilter(request, response);

--- a/core/src/main/java/org/mapfish/print/servlet/ServletMapPrinterFactory.java
+++ b/core/src/main/java/org/mapfish/print/servlet/ServletMapPrinterFactory.java
@@ -111,7 +111,7 @@ public class ServletMapPrinterFactory implements MapPrinterFactory {
             }
 
             try {
-                LOGGER.info("Loading configuration file: " + configFile);
+                LOGGER.info("Loading configuration file: {}", configFile);
                 printer = this.applicationContext.getBean(MapPrinter.class);
                 byte[] bytes = this.configFileLoader.loadFile(configFile);
                 printer.setConfiguration(configFile, bytes);
@@ -122,14 +122,12 @@ public class ServletMapPrinterFactory implements MapPrinterFactory {
                 // when throwing a ClosedByInterruptException. so, we do it manually.
                 // see also http://bugs.java.com/view_bug.do?bug_id=7043425
                 Thread.currentThread().interrupt();
-                LOGGER.error(String.format(
-                        "Error occurred while reading configuration file '%s'", configFile), e);
+                LOGGER.error("Error occurred while reading configuration file '{}'", configFile);
                 throw new RuntimeException(String.format(
                         "Error occurred while reading configuration file '%s': ", configFile),
                                            e);
             } catch (Throwable e) {
-                LOGGER.error(String.format(
-                        "Error occurred while reading configuration file '%s'", configFile), e);
+                LOGGER.error("Error occurred while reading configuration file '{}'", configFile);
                 throw new RuntimeException(String.format(
                         "Error occurred while reading configuration file '%s'", configFile), e);
             }

--- a/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/PrintJob.java
@@ -147,8 +147,8 @@ public abstract class PrintJob implements Callable<PrintJobResult> {
                 this.metricRegistry.counter(getClass().getName() + ".error").inc();
                 jobTracker.onJobError();
             }
-            LOGGER.info("Error executing print job " + canceledText + this.entry.getReferenceId() + "\n" +
-                                this.entry.getRequestData(), e);
+            LOGGER.warn("Error executing print job {} {}\n{}",
+                        this.entry.getRequestData(), canceledText, this.entry.getReferenceId(), e);
             throw e;
         } finally {
             final long totalTimeMS = System.currentTimeMillis() - entry.getStartTime();

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
@@ -243,8 +243,8 @@ public class ThreadPoolJobManager implements JobManager {
                                 } catch (RuntimeException e) {
                                     LOGGER.error("failed to mark job as running", e);
                                 } catch (NoSuchReferenceException e) {
-                                    LOGGER.error("tried to mark non-existing job as 'running': " +
-                                                         printJob.getEntry().getReferenceId(), e);
+                                    LOGGER.error("tried to mark non-existing job as 'running': {}",
+                                                 printJob.getEntry().getReferenceId(), e);
                                 }
                             }
                         }
@@ -524,7 +524,7 @@ public class ThreadPoolJobManager implements JobManager {
             LOGGER.info("The print has finished processing jobs and can now stop");
             stoppedFile.createNewFile();
         } catch (IOException e) {
-            LOGGER.warn("Cannot create the {} file", stoppedFile);
+            LOGGER.warn("Cannot create the {} file", stoppedFile, e);
         }
     }
 

--- a/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIMapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIMapPrinterServlet.java
@@ -320,7 +320,7 @@ public class OldAPIMapPrinterServlet extends BaseMapServlet {
                     }
                 }
                 if (map == null) {
-                    LOGGER.warn(String.format("Template '%s' contains no map configuration.", name));
+                    LOGGER.warn("Template '{}' contains no map configuration.", name);
                 } else {
                     MapAttributeValues mapValues = map.createValue(template);
                     json.key("map");

--- a/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
+++ b/core/src/main/java/org/mapfish/print/servlet/oldapi/OldAPIRequestConverter.java
@@ -109,8 +109,8 @@ public final class OldAPIRequestConverter {
             } else {
                 LOGGER.warn(
                         "The request json data has attribute information for creating the map but config " +
-                                "does not have a" +
-                                "map attribute.  Check that the request and the config.yaml are correct.");
+                                "does not have a map attribute.  Check that the request and the config.yaml" +
+                                " are correct.");
                 return;
             }
         } else if (oldMapPage == null) {
@@ -243,8 +243,8 @@ public final class OldAPIRequestConverter {
             } else {
                 LOGGER.warn(
                         "The request json data has attribute information for creating the map but config " +
-                                "does not have a" +
-                                "map attribute.  Check that the request and the config.yaml are correct.");
+                                "does not have a map attribute.  Check that the request and the config.yaml" +
+                                " are correct.");
                 return;
             }
         } else if (oldLegendJson == null) {
@@ -254,8 +254,8 @@ public final class OldAPIRequestConverter {
 
         if (legendProcessors.size() != oldLegendJson.size()) {
             LOGGER.warn(
-                    "Not all legends processors have request data.  There are " + legendProcessors.size() +
-                            " and there are " + oldLegendJson.size() + " legend request objects.");
+                    "Not all legends processors have request data.  There are {} and there are {} legend " +
+                            "request objects.", legendProcessors.size(), oldLegendJson.size());
         }
 
         String legendAttName = "legend";
@@ -329,8 +329,8 @@ public final class OldAPIRequestConverter {
             } else {
                 LOGGER.warn(
                         "The request json data has attribute information for creating the map but config " +
-                                "does not have a" +
-                                "map attribute.  Check that the request and the config.yaml are correct.");
+                                "does not have a map attribute.  Check that the request and the config.yaml" +
+                                " are correct.");
                 return;
             }
         } else if (oldTablePage == null) {


### PR DESCRIPTION
Mostly changed them to use th `{}` formatting and improved a bit
exception handling. As a rule of thumb:

* if the catched exception is re-thrown, don't log it. It will be logged
up the stack.
* if it is not re-thrown, log it as an exception (not only the
description), it will be better for Sentry and debugging in general.