### PR TITLE
Have the docker container stop cleanly

### DIFF
--- a/core/docker/usr/local/tomcat/bin/docker_start_print.sh
+++ b/core/docker/usr/local/tomcat/bin/docker_start_print.sh
@@ -9,4 +9,4 @@ fi
 
 mkdir -p print-apps
 rm -f /usr/local/tomcat/temp/mapfish-print/ROOT/stop /usr/local/tomcat/temp/mapfish-print/ROOT/stopped
-catalina.sh run
+exec catalina.sh run


### PR DESCRIPTION
Now, when Docker/Kubernetes/OpenShift wants to stop a container, it
sends a SIGTERM. This makes the signal to be handled and doesn't rely on
the timeout to stop the container.