### PR TITLE
Disable authentication by default

### DIFF
--- a/core/jettyRunExtraFiles/mapfish-spring-application-context-override.xml
+++ b/core/jettyRunExtraFiles/mapfish-spring-application-context-override.xml
@@ -2,14 +2,36 @@
 
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:security="http://www.springframework.org/schema/security"
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
-    <context:property-placeholder system-properties-mode="FALLBACK" file-encoding="UTF-8" location="classpath:mapfish-spring.properties"/>
+    <context:property-placeholder system-properties-mode="FALLBACK" file-encoding="UTF-8"
+                                  location="classpath:mapfish-spring.properties"/>
 
     <bean id="mapPrinterFactory" class="org.mapfish.print.servlet.ServletMapPrinterFactory">
         <property name="appsRootDirectory" value="${path_to_examples}"/>
     </bean>
+
+    <bean name="bcryptEncoder"
+          class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"/>
+
+    <security:authentication-manager alias="authenticationManager">
+        <security:authentication-provider>
+            <security:password-encoder ref="bcryptEncoder"/>
+            <security:user-service>
+                <!-- password is jimi -->
+                <security:user name="jimi"
+                               password="$2a$10$OeKmMfVmL2IbF/3skK8l2.Gl3EqvvGhb.Pxr/K0dN7.ttPRHsOzVW"
+                               authorities="ROLE_USER, ROLE_ADMIN"/>
+                <!-- password is bob -->
+                <security:user name="bob"
+                               password="$2a$10$D5gwUewQQSpjfZPTcj9rpuTTfmxAqNEyJ19pzC7Z9.fHSCl3jtDj."
+                               authorities="ROLE_USER"/>
+            </security:user-service>
+        </security:authentication-provider>
+    </security:authentication-manager>
 </beans>

--- a/core/src/main/java/org/mapfish/print/servlet/NoOpAuthenticationManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/NoOpAuthenticationManager.java
@@ -1,0 +1,59 @@
+package org.mapfish.print.servlet;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A no-op AuthenticationManager.
+ */
+public class NoOpAuthenticationManager implements AuthenticationManager {
+    @Override
+    public Authentication authenticate(
+            final Authentication authentication) throws AuthenticationException {
+        return new Authentication() {
+            @Override
+            public Collection<? extends GrantedAuthority> getAuthorities() {
+                return Collections.EMPTY_LIST;
+            }
+
+            @Override
+            public Object getCredentials() {
+                return "";
+            }
+
+            @Override
+            public Object getDetails() {
+                return null;
+            }
+
+            @Override
+            public Object getPrincipal() {
+                return "";
+            }
+
+            @Override
+            public boolean isAuthenticated() {
+                return false;
+            }
+
+            @Override
+            public void setAuthenticated(final boolean isAuthenticated) throws IllegalArgumentException {
+
+            }
+
+            @Override
+            public String getName() {
+                return "anonymous";
+            }
+        };
+    }
+
+    public boolean isEraseCredentialsAfterAuthentication() {
+        return true;
+    }
+}

--- a/core/src/main/resources/mapfish-spring-security.xml
+++ b/core/src/main/resources/mapfish-spring-security.xml
@@ -4,7 +4,7 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xmlns="http://www.springframework.org/schema/security"
              xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
     <!-- needed to allow double slashes in the URLs -->
@@ -17,32 +17,17 @@
     <http use-expressions="true">
         <!-- in order to get a challenge (for capabilities for example) you need to use the print/sec/* urls -->
         <csrf disabled="true"/>
-        <intercept-url pattern="/sec/print/**" requires-channel="https" access="isAuthenticated()" />
+        <intercept-url pattern="/sec/print/**" requires-channel="https" access="isAuthenticated()"/>
         <intercept-url pattern="/**" access="permitAll()"/>
-        <http-basic />
-        <anonymous />
+        <http-basic/>
+        <anonymous/>
     </http>
 
-    <beans:bean name="bcryptEncoder"
-        class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"/>
-
     <!--
-        This authentication manager is not really production quality.  It will work if you don't have complex
-        needs but it is recommended to use ldap or database based authentication providers, etc..
-        See http://docs.spring.io/spring-security/site/docs/3.2.5.RELEASE/reference/htmlsingle/#ns-config for some
-        help
+        This authentication manager is not authenticating anything.
+        See https://docs.spring.io/spring-security/site/docs/5.1.3.RELEASE/reference/htmlsingle/#ns-config
+        for some help
     -->
-    <authentication-manager alias="authenticationManager">
-        <authentication-provider>
-            <password-encoder ref="bcryptEncoder" />
-            <user-service>
-                <!-- password is jimi -->
-                <user name="jimi" password="$2a$10$OeKmMfVmL2IbF/3skK8l2.Gl3EqvvGhb.Pxr/K0dN7.ttPRHsOzVW"
-                    authorities="ROLE_USER, ROLE_ADMIN" />
-                <!-- password is bob -->
-                <user name="bob" password="$2a$10$D5gwUewQQSpjfZPTcj9rpuTTfmxAqNEyJ19pzC7Z9.fHSCl3jtDj."
-                    authorities="ROLE_USER" />
-            </user-service>
-        </authentication-provider>
-    </authentication-manager>
+    <beans:bean name="org.springframework.security.authenticationManager"
+                class="org.mapfish.print.servlet.NoOpAuthenticationManager"/>
 </beans:beans>


### PR DESCRIPTION
Customers had problems with c2cgeoportal print proxy forwarding basic
auth to the print that didn't have any special auth setup.

Instead of failing, the print acts normal (not authenticated) when some random
user/password are used.

https://jira.camptocamp.com/browse/GEO-1816