### PR TITLE
Fix threadsafe issue with zoomToFeature

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/AbstractFeatureSourceLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/AbstractFeatureSourceLayer.java
@@ -1,5 +1,6 @@
 package org.mapfish.print.map.geotools;
 
+import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.collection.CollectionFeatureSource;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -93,13 +94,16 @@ public abstract class AbstractFeatureSourceLayer extends AbstractGeotoolsLayer {
 
     public final void setFeatureCollection(final SimpleFeatureCollection featureCollection) {
         this.featureSourceSupplier = new FeatureSourceSupplier() {
-
             @Nonnull
             @Override
             public FeatureSource load(
                     @Nonnull final MfClientHttpRequestFactory requestFactory,
                     @Nonnull final MapfishMapContext mapContext) {
-                return new CollectionFeatureSource(featureCollection);
+                // GeoTools is not always thread safe. In particular the DefaultFeatureCollection.getBounds
+                // method. If multiple maps are sharing the same features, this would cause zoomToFeature
+                // to result in funky bboxes. To avoid that, we use a copy of the featureCollection
+                final SimpleFeatureCollection copy = DataUtilities.collection(featureCollection);
+                return new CollectionFeatureSource(copy);
             }
         };
     }

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateMapProcessor.java
@@ -336,9 +336,10 @@ public final class CreateMapProcessor
     }
 
     private void warnIfDifferentRenderType(final RenderType renderType, final MapLayer layer) {
-        if (renderType != layer.getRenderType()) {
+        if (renderType != layer.getRenderType() && layer.getRenderType() != RenderType.UNKNOWN) {
             LOGGER.info("Layer {} has {} format, storing as PNG.",
-                        layer.getName(), layer.getRenderType().toString());
+                        layer.getName().isEmpty() ? layer : layer.getName(),
+                        layer.getRenderType().toString());
         }
     }
 
@@ -578,6 +579,8 @@ public final class CreateMapProcessor
                     mapValues.setMapBounds(mapBounds);
                 }
             }
+        } else {
+            LOGGER.warn("No BBOX found for zoomToFeature");
         }
     }
 
@@ -607,10 +610,11 @@ public final class CreateMapProcessor
                 }
 
                 if (!features.isEmpty()) {
+                    final ReferencedEnvelope curBounds = features.getBounds();
                     if (bounds == null) {
-                        bounds = features.getBounds();
+                        bounds = curBounds;
                     } else {
-                        bounds.expandToInclude(features.getBounds());
+                        bounds.expandToInclude(curBounds);
                     }
                 }
             }


### PR DESCRIPTION
When multiple maps are sharing the same features and are using zoomToFeature,
we had cases of empty maps because the computed BBOX was null. This was caused
by threadsafety issues in GeoTools.

Closes #819
Closes openoereb/pyramid_oereb#239
GeoTools discussion: https://sourceforge.net/p/geotools/mailman/message/36586913/