### PR TITLE
Stop all pending tasks in case of error.

### DIFF
--- a/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
+++ b/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
@@ -196,6 +196,7 @@ public final class HttpRequestFetcher {
                 final Timer.Context timerDownload =
                         HttpRequestFetcher.this.registry.timer(baseMetricName).time();
                 try (ClientHttpResponse originalResponse = this.originalRequest.execute()) {
+                    context.stopIfCanceled();
                     this.response = new CachedClientHttpResponse(originalResponse);
                 } catch (IOException e) {
                     LOGGER.error("Request failed {}", this.originalRequest.getURI(), e);

--- a/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraph.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraph.java
@@ -208,6 +208,9 @@ public final class ProcessorDependencyGraph {
                 LOGGER.debug("Starting to execute processor graph: \n{}", graph);
                 try {
                     tryExecuteNodes(graph.roots, this.execContext, false);
+                } catch (Throwable ex) {
+                    this.execContext.cancel();  // cancel all pending computations in case of error
+                    throw ex;
                 } finally {
                     LOGGER.debug("Finished executing processor graph: \n{}", graph);
                 }


### PR DESCRIPTION
This is to avoid having tons of HTTP queries going out when the job is
stopped anyway. They end with an error anyway (cannot create a
temporary file).