### PR TITLE
Use a PNG instead of a TIFF for the north arrow temporary

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/map/NorthArrowGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/NorthArrowGraphic.java
@@ -114,7 +114,7 @@ public final class NorthArrowGraphic {
             final Dimension targetSize, final RasterReference rasterReference,
             final Double rotation, final Color backgroundColor,
             final File workingDir) throws IOException {
-        final File path = File.createTempFile("north-arrow-", ".tiff", workingDir);
+        final File path = File.createTempFile("north-arrow-", ".png", workingDir);
 
         final BufferedImage newImage =
                 new BufferedImage(targetSize.width, targetSize.height, BufferedImage.TYPE_4BYTE_ABGR);
@@ -163,7 +163,7 @@ public final class NorthArrowGraphic {
                                         RenderingHints.VALUE_INTERPOLATION_BICUBIC);
             graphics2d.drawImage(originalImage, deltaX, deltaY, newWidth, newHeight, null);
 
-            ImageUtils.writeImage(newImage, "tiff", path);
+            ImageUtils.writeImage(newImage, "png", path);
         } finally {
             graphics2d.dispose();
         }


### PR DESCRIPTION
This may solve problems some of our customers are having with
Jasper/iText not liking the way some TIFFs are encoded. Looks like
this reproduces only with some versions of JRE.