### PR TITLE
Fix a few invalid metric names

### DIFF
--- a/core/src/main/java/org/mapfish/print/StatsUtils.java
+++ b/core/src/main/java/org/mapfish/print/StatsUtils.java
@@ -1,0 +1,21 @@
+package org.mapfish.print;
+
+/**
+ * Utility functions for metrics.
+ */
+public final class StatsUtils {
+    private StatsUtils() {
+    }
+
+    /**
+     * Convert the given name into a proper metric part (what lies between dots).
+     *
+     * @param name the name
+     */
+    public static String quotePart(final String name) {
+        if (name == null) {
+            return "NULL";
+        }
+        return name.replaceAll("[^A-Za-z0-9_]", "_");
+    }
+}

--- a/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
+++ b/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
@@ -3,6 +3,7 @@ package org.mapfish.print.http;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.apache.commons.io.IOUtils;
+import org.mapfish.print.StatsUtils;
 import org.mapfish.print.processor.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,7 +193,8 @@ public final class HttpRequestFetcher {
         public Void call() throws Exception {
             return context.mdcContextEx(() -> {
                 final String baseMetricName =
-                        HttpRequestFetcher.class.getName() + ".read." + getURI().getHost();
+                        HttpRequestFetcher.class.getName() + ".read." +
+                                StatsUtils.quotePart(getURI().getHost());
                 final Timer.Context timerDownload =
                         HttpRequestFetcher.this.registry.timer(baseMetricName).time();
                 try (ClientHttpResponse originalResponse = this.originalRequest.execute()) {

--- a/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
@@ -12,6 +12,7 @@ import org.geotools.map.GridCoverageLayer;
 import org.geotools.map.Layer;
 import org.geotools.styling.Style;
 import org.mapfish.print.ExceptionUtils;
+import org.mapfish.print.StatsUtils;
 import org.mapfish.print.attribute.map.MapBounds;
 import org.mapfish.print.attribute.map.MapfishMapContext;
 import org.mapfish.print.config.Configuration;
@@ -151,7 +152,8 @@ public abstract class AbstractSingleImageLayer extends AbstractGeotoolsLayer {
     protected BufferedImage fetchImage(
             @Nonnull final ClientHttpRequest request, @Nonnull final MapfishMapContext transformer)
             throws IOException {
-        final String baseMetricName = getClass().getName() + ".read." + request.getURI().getHost();
+        final String baseMetricName = getClass().getName() + ".read." +
+                StatsUtils.quotePart(request.getURI().getHost());
         final Timer.Context timerDownload = this.registry.timer(baseMetricName).time();
         try (ClientHttpResponse httpResponse = request.execute()) {
             if (httpResponse.getStatusCode() != HttpStatus.OK) {

--- a/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
@@ -8,6 +8,7 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.geometry.GeneralEnvelope;
 import org.mapfish.print.ExceptionUtils;
+import org.mapfish.print.StatsUtils;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.map.style.json.ColorParser;
 import org.mapfish.print.map.tiled.TilePreparationInfo.SingleTilePreparationInfo;
@@ -192,7 +193,7 @@ public final class CoverageTask implements Callable<GridCoverage2D> {
         protected Tile compute() {
             return this.context.mdcContext(() -> {
                 final String baseMetricName = TilePreparationTask.class.getName() + ".read." +
-                        this.tileRequest.getURI().getHost();
+                        StatsUtils.quotePart(this.tileRequest.getURI().getHost());
                 LOGGER.debug("\n\t{} -- {}", this.tileRequest.getMethod(), this.tileRequest.getURI());
                 final Timer.Context timerDownload = this.registry.timer(baseMetricName).time();
                 try (ClientHttpResponse response = this.tileRequest.execute()) {

--- a/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/LegendProcessor.java
@@ -6,6 +6,7 @@ import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.data.JRTableModelDataSource;
 import org.mapfish.print.Constants;
 import org.mapfish.print.ImageUtils;
+import org.mapfish.print.StatsUtils;
 import org.mapfish.print.attribute.LegendAttribute.LegendAttributeValue;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.config.Template;
@@ -353,7 +354,8 @@ public final class LegendProcessor extends AbstractProcessor<LegendProcessor.Inp
             return context.mdcContextEx(() -> {
                 BufferedImage image = null;
                 final URI uri = this.icon.toURI();
-                final String metricName = LegendProcessor.class.getName() + ".read." + uri.getHost();
+                final String metricName =
+                        LegendProcessor.class.getName() + ".read." + StatsUtils.quotePart(uri.getHost());
                 try {
                     this.context.stopIfCanceled();
                     final ClientHttpRequest request = this.clientHttpRequestFactory.createRequest(

--- a/core/src/main/java/org/mapfish/print/servlet/job/Accounting.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/Accounting.java
@@ -2,6 +2,7 @@ package org.mapfish.print.servlet.job;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import org.mapfish.print.StatsUtils;
 import org.mapfish.print.config.Configuration;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -51,9 +52,7 @@ public class Accounting {
         protected JobTracker(final PrintJobEntry entry, final Configuration configuration) {
             this.entry = entry;
             this.configuration = configuration;
-            this.successTimer = Accounting.this.metricRegistry.timer(getClass().getName() + "." +
-                                                                             this.entry.getAppId() +
-                                                                             ".success").time();
+            this.successTimer = Accounting.this.metricRegistry.timer(getMetricName("success")).time();
         }
 
         /**
@@ -70,16 +69,18 @@ public class Accounting {
          * To be called when a job is cancelled.
          */
         public void onJobCancel() {
-            Accounting.this.metricRegistry.counter(getClass().getName() + "." +
-                                                           this.entry.getAppId() + ".cancel").inc();
+            Accounting.this.metricRegistry.counter(getMetricName("cancel")).inc();
         }
 
         /**
          * To be called when a job is on error.
          */
         public void onJobError() {
-            Accounting.this.metricRegistry.counter(getClass().getName() + "." +
-                                                           this.entry.getAppId() + ".error").inc();
+            Accounting.this.metricRegistry.counter(getMetricName("error")).inc();
+        }
+
+        private String getMetricName(final String kind) {
+            return getClass().getName() + "." + StatsUtils.quotePart(this.entry.getAppId()) + "." + kind;
         }
     }
 }

--- a/core/src/test/java/org/mapfish/print/StatsUtilsTest.java
+++ b/core/src/test/java/org/mapfish/print/StatsUtilsTest.java
@@ -1,0 +1,13 @@
+package org.mapfish.print;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StatsUtilsTest {
+    @Test
+    public void testQuotePart() {
+        assertEquals("toto_tutu_titi", StatsUtils.quotePart("toto.tutu:titi"));
+        assertEquals("NULL", StatsUtils.quotePart(null));
+    }
+}


### PR DESCRIPTION
Without that, we have tons of errors like that in the statsd exporter:
```
Bad component on line: mutualized-print.prod.prod-mutualized-print-print-1-kzpkq.print.org.mapfish.print.servlet.job.HibernateAccounting$JobTracker.examples:simple.success.p99:319.44|g
```