### PR TITLE
check for null in WmsUtilities

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -52,9 +52,9 @@ public final class WmsUtilities {
             final double dpi,
             final double angle,
             final ReferencedEnvelope bounds) throws FactoryException, URISyntaxException, IOException {
-        if (commonURI == null || commonURI.getAuthority() == null )
+        if (commonURI == null || commonURI.getAuthority() == null) {
             throw new RuntimeException("Invalid WMS URI: " + commonURI);
-
+        }
         String[] authority = commonURI.getAuthority().split(":");
         URL url;
         if (authority.length == 2) {

--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -52,7 +52,10 @@ public final class WmsUtilities {
             final double dpi,
             final double angle,
             final ReferencedEnvelope bounds) throws FactoryException, URISyntaxException, IOException {
-        String[] authority = commonURI.getAuthority().split(":");
+        if (commonURI == null || commonURI.getAuthority() == null )
+            throw new RuntimeException("Invalid WMS URI: " + commonURI);
+
+	String[] authority = commonURI.getAuthority().split(":");
         URL url;
         if (authority.length == 2) {
             url = new URL(

--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -55,7 +55,7 @@ public final class WmsUtilities {
         if (commonURI == null || commonURI.getAuthority() == null )
             throw new RuntimeException("Invalid WMS URI: " + commonURI);
 
-	String[] authority = commonURI.getAuthority().split(":");
+        String[] authority = commonURI.getAuthority().split(":");
         URL url;
         if (authority.length == 2) {
             url = new URL(


### PR DESCRIPTION
check for null, to avoid NullPointerException and to provide a better error message.

Tested in https://github.com/camptocamp/schwyz_oereb