### PR TITLE
Make print-apps location configurable by using a spring property

### DIFF
--- a/core/src/main/resources/mapfish-spring.properties
+++ b/core/src/main/resources/mapfish-spring.properties
@@ -43,3 +43,6 @@ cacheDuration=3600
 
 # The default DB schema to use
 db.schema=public
+
+# The default print-apps location
+printapps.location=servlet:///print-apps

--- a/core/src/main/webapp/WEB-INF/mapfish-print-printer-factory.xml
+++ b/core/src/main/webapp/WEB-INF/mapfish-print-printer-factory.xml
@@ -3,6 +3,6 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
     <bean id="mapPrinterFactory" class="org.mapfish.print.servlet.ServletMapPrinterFactory">
-        <property name="appsRootDirectory" value="servlet:///print-apps" />
+        <property name="appsRootDirectory" value="${printapps.location}" />
     </bean>
 </beans>


### PR DESCRIPTION
This simple modification allows the configuration of the print-apps location by using a spring property. 
The default behaviour, to use servlet:///print-apps, is preserved.