### PR TITLE
Vector layer labels fonts fixes and improvements

### DIFF
--- a/src/main/java/org/mapfish/print/PDFUtils.java
+++ b/src/main/java/org/mapfish/print/PDFUtils.java
@@ -28,6 +28,7 @@ import com.itextpdf.text.Chunk;
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Element;
 import com.itextpdf.text.Font;
+import com.itextpdf.text.FontFactory;
 import com.itextpdf.text.Image;
 import com.itextpdf.text.Phrase;
 import com.itextpdf.text.pdf.BaseFont;
@@ -674,22 +675,12 @@ public class PDFUtils {
         return image;
     }
 
-    public static BaseFont getBaseFont(String fontFamily, String fontSize,
-            String fontWeight) {
-        Font.FontFamily myFontValue;
-        float myFontSize;
-        int myFontWeight;
-        if (fontFamily.toUpperCase().contains("COURIER")) {
-            myFontValue = Font.FontFamily.COURIER;
-        } else if (fontFamily.toUpperCase().contains("HELVETICA")) {
-            myFontValue = Font.FontFamily.HELVETICA;
-        } else if (fontFamily.toUpperCase().contains("ROMAN")) {
-            myFontValue = Font.FontFamily.TIMES_ROMAN;
-        } else {
-            myFontValue = Font.FontFamily.HELVETICA;
-        }
-        myFontSize = (float) Double.parseDouble(fontSize.toLowerCase()
+    public static BaseFont getBaseFont(String font, String fontEncoding, String fontFamily,
+    		String fontSize, String fontWeight) {
+        float myFontSize = (float) Double.parseDouble(fontSize.toLowerCase()
                 .replaceAll("px", ""));
+        
+        int myFontWeight;
         if (fontWeight.toUpperCase().contains("NORMAL")) {
             myFontWeight = Font.NORMAL;
         } else if (fontWeight.toUpperCase().contains("BOLD")) {
@@ -699,7 +690,24 @@ public class PDFUtils {
         } else {
             myFontWeight = Font.NORMAL;
         }
-        Font pdfFont = new Font(myFontValue, myFontSize, myFontWeight);
+
+    	Font pdfFont;
+    	if (font != null && FontFactory.isRegistered(font)) {
+    		pdfFont = FontFactory.getFont(font, fontEncoding, myFontSize, myFontWeight);
+    	}
+    	else {
+	        Font.FontFamily myFontValue;
+	        if (fontFamily.toUpperCase().contains("COURIER")) {
+	            myFontValue = Font.FontFamily.COURIER;
+	        } else if (fontFamily.toUpperCase().contains("HELVETICA")) {
+	            myFontValue = Font.FontFamily.HELVETICA;
+	        } else if (fontFamily.toUpperCase().contains("ROMAN")) {
+	            myFontValue = Font.FontFamily.TIMES_ROMAN;
+	        } else {
+	            myFontValue = Font.FontFamily.HELVETICA;
+	        }
+	        pdfFont = new Font(myFontValue, myFontSize, myFontWeight);
+    	}
         return pdfFont.getCalculatedBaseFont(false);
     }
 

--- a/src/main/java/org/mapfish/print/map/renderers/vector/LabelRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/LabelRenderer.java
@@ -57,8 +57,8 @@ public class LabelRenderer {
             /* Supported itext fonts: COURIER, HELVETICA, TIMES_ROMAN */
             String fontFamily = style.optString("fontFamily", "HELVETICA");
             if (!"COURIER".equalsIgnoreCase(fontFamily)
-                    || !"HELVETICA".equalsIgnoreCase(fontFamily)
-                    || !"TIMES_ROMAN".equalsIgnoreCase(fontFamily)) {
+                    && !"HELVETICA".equalsIgnoreCase(fontFamily)
+                    && !"TIMES_ROMAN".equalsIgnoreCase(fontFamily)) {
 
                 LOGGER.info("Font: '"+ fontFamily +
                         "' not supported, supported fonts are 'HELVETICA', " +

--- a/src/main/java/org/mapfish/print/map/renderers/vector/LabelRenderer.java
+++ b/src/main/java/org/mapfish/print/map/renderers/vector/LabelRenderer.java
@@ -27,6 +27,7 @@ import org.mapfish.print.RenderingContext;
 import org.mapfish.print.config.ColorWrapper;
 import org.mapfish.print.utils.PJsonObject;
 
+import com.itextpdf.text.FontFactory;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.PdfContentByte;
 import org.locationtech.jts.geom.Coordinate;
@@ -54,14 +55,20 @@ public class LabelRenderer {
             float labelYOffset = style.optFloat("labelYOffset", (float) 0.0);
             float labelRotation = style.optFloat("labelRotation", (float) 0.0);
             String fontColor = style.optString("fontColor", "#000000");
-            /* Supported itext fonts: COURIER, HELVETICA, TIMES_ROMAN */
+            /* Supported itext fonts: COURIER, HELVETICA, TIMES_ROMAN and registered fonts from configuration */
             String fontFamily = style.optString("fontFamily", "HELVETICA");
-            if (!"COURIER".equalsIgnoreCase(fontFamily)
+            String font = style.optString("font");
+            String fontEncoding = style.optString("fontEncoding");
+            if (font != null && !FontFactory.isRegistered(font)) {
+                LOGGER.info("Font: '" + font +
+                		"' not registered, one of the supported fonts from 'fontFamily' will be used");            	
+            }
+            else if (!"COURIER".equalsIgnoreCase(fontFamily)
                     && !"HELVETICA".equalsIgnoreCase(fontFamily)
                     && !"TIMES_ROMAN".equalsIgnoreCase(fontFamily)) {
 
-                LOGGER.info("Font: '"+ fontFamily +
-                        "' not supported, supported fonts are 'HELVETICA', " +
+                LOGGER.info("Font family: '" + fontFamily +
+                        "' not supported, supported ones are 'HELVETICA', " +
                         "'COURIER', 'TIMES_ROMAN', defaults to 'HELVETICA'");
                 fontFamily = "HELVETICA";
             }
@@ -73,7 +80,7 @@ public class LabelRenderer {
             center = GeometriesRenderer.transformCoordinate(center, affineTransform);
             float f = context.getStyleFactor();
             BaseFont bf = PDFUtils
-                    .getBaseFont(fontFamily, fontSize, fontWeight);
+                    .getBaseFont(font, fontEncoding, fontFamily, fontSize, fontWeight);
             float fontHeight = (float) Double.parseDouble(fontSize
                     .toLowerCase().replaceAll("px", "")) * f;
             dc.setFontAndSize(bf, fontHeight);


### PR DESCRIPTION
[fix] fontFamily for labels was always set to "HELVETICA" despite specified value
[+] possibility to specify one of registered fonts for label's style same way as for text or legend blocks