### PR TITLE
Use getFailOnError when Content-type does not start with image

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
@@ -182,8 +182,12 @@ public abstract class AbstractSingleImageLayer extends AbstractGeotoolsLayer {
                 LOGGER.debug("We get a wrong image for {}, content type: {}\nresult:\n{}",
                              request.getURI(), contentType.get(0),
                              new String(data, StandardCharsets.UTF_8));
-                this.registry.counter(baseMetricName + ".error").inc();
-                return createErrorImage(transformer.getPaintArea());
+                this.registry.counter(baseMetricName + ".error").inc();             
+                if (getFailOnError()) {
+                    throw new RuntimeException("Wrong content-type : " + contentType.get(0));
+                } else {
+                	return createErrorImage(transformer.getPaintArea());
+                }
             }
 
             final BufferedImage image = ImageIO.read(httpResponse.getBody());

--- a/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
@@ -182,11 +182,11 @@ public abstract class AbstractSingleImageLayer extends AbstractGeotoolsLayer {
                 LOGGER.debug("We get a wrong image for {}, content type: {}\nresult:\n{}",
                              request.getURI(), contentType.get(0),
                              new String(data, StandardCharsets.UTF_8));
-                this.registry.counter(baseMetricName + ".error").inc();             
+                this.registry.counter(baseMetricName + ".error").inc();
                 if (getFailOnError()) {
                     throw new RuntimeException("Wrong content-type : " + contentType.get(0));
                 } else {
-                	return createErrorImage(transformer.getPaintArea());
+                    return createErrorImage(transformer.getPaintArea());
                 }
             }
 


### PR DESCRIPTION
This case can happen with Qgiserver, when for exemple the layer name is
wrong.
QgisServer will respond (Http 200) whith an XML containig the error
description.

link to #411 