### PR TITLE
Error when loading fonts, with configDir in windows machines

### DIFF
--- a/src/main/java/org/mapfish/print/MapPrinter.java
+++ b/src/main/java/org/mapfish/print/MapPrinter.java
@@ -144,8 +144,9 @@ public class MapPrinter {
 
                     final TreeSet<String> fontPaths = config.getFonts();
                     if (fontPaths != null) {
+                        String backSlashCompatiblePath = configDir.getPath().replace("\\", "/");
                         for (String fontPath : fontPaths) {
-                            fontPath = fontPath.replaceAll("\\$\\{configDir\\}", configDir.getPath());
+                            fontPath = fontPath.replaceAll("\\$\\{configDir\\}", backSlashCompatiblePath);
                             File fontFile = new File(fontPath);
                             if (fontFile.isDirectory()) {
                                 FontFactory.registerDirectory(fontPath, true);


### PR DESCRIPTION
Example of a config.yaml:
"
fonts:
  - "${configDir}/../styles/fonts/Rubik-Regular.ttf"
"
Doing a print like this in a windows machine, it replaces all the backslash incorrectly.

Do you aprove the change of this section of code?