### PR TITLE
set charset in index.html

### DIFF
--- a/core/src/main/webapp/index.html
+++ b/core/src/main/webapp/index.html
@@ -1,6 +1,7 @@
-
+<!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8">
     <link href="favicon.ico" rel="shortcut icon"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"
       type="text/javascript"></script>


### PR DESCRIPTION
When we use multi byte characters in `core/src/main/webapp/index.html`, the text is garbled.
To fix this problem, I set charset in the file.