### PR TITLE
Set a default maxIdleTime for DB connections

### DIFF
--- a/core/src/main/resources/mapfish-spring-application-context-override-db.xml
+++ b/core/src/main/resources/mapfish-spring-application-context-override-db.xml
@@ -11,6 +11,7 @@
         <property name="password" value="${db.password}"/>
         <property name="minPoolSize" value="1"/>
         <property name="numHelperThreads" value="1"/>
+        <property name="maxIdleTime" value="30"/>
     </bean>
 
     <!-- Force the job manager the support clustering, by not taking submitted jobs automatically as its own.


### PR DESCRIPTION
This will make the connection pool keep postgresql connections open for
max 30s.