### PR TITLE
Improves logs

### DIFF
--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -176,7 +176,11 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
         protected Response executeInternal(@Nonnull final HttpHeaders headers) throws IOException {
             CURRENT_CONFIGURATION.set(this.configuration);
 
-            LOGGER.debug("Preparing request {} {}: {}", this.getMethod(), this.getURI(), headers);
+            LOGGER.debug(
+                "Preparing request {} {}: {}", this.getMethod(), this.getURI(),
+                Utils.getPrintableHeadersList(headers)
+            );
+
             for (Map.Entry<String, List<String>> entry: headers.entrySet()) {
                 String headerName = entry.getKey();
                 if (!headerName.equalsIgnoreCase(HTTP.CONTENT_LEN) &&

--- a/core/src/main/java/org/mapfish/print/http/Utils.java
+++ b/core/src/main/java/org/mapfish/print/http/Utils.java
@@ -14,7 +14,7 @@ public final class Utils {
     }
 
     private static final List<String> AUTH_HEADERS = Arrays.asList(
-        new String[]{"cookie", "set-cookie", "authorization"}
+        new String[]{"cookie", "set-cookie", "authorization", "x-csrf-token"}
     );
 
     /**

--- a/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/image/AbstractSingleImageLayer.java
@@ -172,8 +172,10 @@ public abstract class AbstractSingleImageLayer extends AbstractGeotoolsLayer {
 
             if (httpResponse.getStatusCode() != HttpStatus.OK) {
                 String message = String.format(
-                        "Invalid status code for %s (%d!=%d).\nThe response was: '%s'\nWith Headers:\n%s",
-                        request.getURI(), httpResponse.getStatusCode().value(),
+                        "Invalid status code for %s (%d!=%d).With request headers:\n%s\n" +
+                        "The response was: '%s'\nWith response headers:\n%s",
+                        request.getURI(), Utils.getPrintableHeadersList(request.getHeaders()),
+                        httpResponse.getStatusCode().value(),
                         HttpStatus.OK.value(), httpResponse.getStatusText(),
                         String.join("\n", Utils.getPrintableHeadersList(httpResponse.getHeaders()))
                 );


### PR DESCRIPTION
Don't log auth headers in prepare request
Set `x-csrf-token` as auth header
Add request headers in Invalid status code... message.