### PR TITLE
Fix javadoc

### DIFF
--- a/checkstyle_checks.xml
+++ b/checkstyle_checks.xml
@@ -32,6 +32,7 @@
         </module>
         <module name="JavadocVariable">
             <property name="scope" value="protected"/>
+            <property name="ignoreNamePattern" value="^[A-Z_]*$"/>
         </module>
         <module name="JavadocStyle"/>
         <module name="ConstantName"/>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,7 +43,8 @@ installDist.doFirst {
 }
 tasks.withType(Javadoc) {
     options.encoding = 'utf-8'
-    options.addStringOption('Xwerror', '-quiet')  // make javadoc fail on warnings
+//    options.addStringOption('Xwerror', '-quiet')  // make javadoc fail on warnings
+//    options.addStringOption('Xdoclint', 'all')
     title = "Mapfish Print Core Module $version"
     if (JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,7 @@ installDist.doFirst {
 }
 tasks.withType(Javadoc) {
     options.encoding = 'utf-8'
+    options.addStringOption('Xwerror', '-quiet')  // make javadoc fail on warnings
     title = "Mapfish Print Core Module $version"
     if (JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)

--- a/core/src/main/java/org/mapfish/print/Constants.java
+++ b/core/src/main/java/org/mapfish/print/Constants.java
@@ -4,7 +4,7 @@ import java.nio.charset.Charset;
 
 /**
  * Strings used in configurations etc... User: jeichar Date: Sep 30, 2010 Time: 4:27:46 PM
- * <p></p>
+ *
  */
 public interface Constants {
     /**
@@ -19,9 +19,9 @@ public interface Constants {
 
     /**
      * The default encoding to use throughout the system.  This can be set by setting the system property:
-     * <p></p>
+     *
      * <em>mapfish.file.encoding</em>
-     * <p></p>
+     *
      * before starting the JVM.
      */
     String DEFAULT_ENCODING = System.getProperty("mapfish.file.encoding", "UTF-8");

--- a/core/src/main/java/org/mapfish/print/FileUtils.java
+++ b/core/src/main/java/org/mapfish/print/FileUtils.java
@@ -24,7 +24,7 @@ public final class FileUtils {
     /**
      * Check if the url is a file url which is either relative to the configuration directory or refers to a
      * file in the configuration directory.
-     * <p></p>
+     *
      * The correct file url is returned or the original if not a file url.  If an illegal file url (one that
      * does not refer to a file within the configuration directory or is relative to the configuration
      * directory) then an exception is thrown.

--- a/core/src/main/java/org/mapfish/print/FloatingPointUtil.java
+++ b/core/src/main/java/org/mapfish/print/FloatingPointUtil.java
@@ -15,7 +15,6 @@ public final class FloatingPointUtil {
      *
      * @param f1 Float 1.
      * @param f2 Float 2.
-     * @return
      */
     public static boolean equals(final float f1, final float f2) {
         return Math.abs(f1 - f2) <= EPSILON;
@@ -27,7 +26,6 @@ public final class FloatingPointUtil {
      *
      * @param d1 Double 1.
      * @param d2 Double 2.
-     * @return
      */
     public static boolean equals(final double d1, final double d2) {
         return Math.abs(d1 - d2) <= EPSILON;

--- a/core/src/main/java/org/mapfish/print/MapPrinter.java
+++ b/core/src/main/java/org/mapfish/print/MapPrinter.java
@@ -25,7 +25,7 @@ import java.util.TreeSet;
 
 /**
  * The main class for printing maps. Will parse the spec, create the PDF document and generate it.
- * <p></p>
+ *
  * This class should not be directly created but rather obtained from an application context object so that
  * all plugins and dependencies are correctly injected into it
  */

--- a/core/src/main/java/org/mapfish/print/VersionInfo.java
+++ b/core/src/main/java/org/mapfish/print/VersionInfo.java
@@ -37,7 +37,9 @@ public class VersionInfo {
     @PostConstruct
     public final void init() {
         this.attrs = getAttributes();
-        LOGGER.warn("Starting print version {} ({})", getVersion(), getGitHash());
+        if (this.attrs != null) {
+            LOGGER.warn("Starting print version {} ({})", getVersion(), getGitHash());
+        }
     }
 
     /**
@@ -64,7 +66,8 @@ public class VersionInfo {
     }
 
     private Attributes getAttributes() {
-        if (this.servletContext == null) {
+        if (this.servletContext == null ||
+                this.servletContext.getClass().getSimpleName().startsWith("Mock")) {
             return null;
         }
         try {

--- a/core/src/main/java/org/mapfish/print/attribute/Attribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/Attribute.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 /**
  * Represents an attribute passed in from a web-client to be used to populate the report.  It reads a value
  * from the request data
- * <p></p>
+ *
  */
 public interface Attribute extends ConfigurationObject {
 

--- a/core/src/main/java/org/mapfish/print/attribute/PrimitiveAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/PrimitiveAttribute.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
  * A type of attribute whose value is a primitive type.
  * <ul>
  * <li>{@link java.lang.String}</li>
- * <li>{@link java.lang.String[]}</li>
+ * <li>{@link java.lang.String}[]</li>
  * <li>{@link java.lang.Integer}</li>
  * <li>{@link java.lang.Double}</li>
  * <li>{@link java.lang.Boolean}</li>

--- a/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
@@ -174,16 +174,16 @@ public abstract class ReflectiveAttribute<Value> implements Attribute {
     /**
      * Create an instance of a attribute value object.  Each instance must be new and unique. Instances must
      * <em>NOT</em> be shared.
-     * <p></p>
+     *
      * The object will be populated from the json.  Each public field will be populated by looking up the
      * value in the json.
-     * <p></p>
+     *
      * If a field in the object has the {@link HasDefaultValue} annotation then no
      * exception will be thrown if the json does not contain a value.
-     * <p></p>
+     *
      * Fields in the object with the {@link OneOf} annotation must have one of the
      * fields in the request data.
-     * <p></p>
+     *
      * <ul>
      * <li>{@link String}</li>
      * <li>{@link Integer}</li>
@@ -201,15 +201,15 @@ public abstract class ReflectiveAttribute<Value> implements Attribute {
      * <li>any type with a 0 argument constructor</li>
      * <li>array of any of the above (String[], boolean[], PJsonObject[], ...)</li>
      * </ul>
-     * <p></p>
+     *
      * If there is a public
      * <code>{@value org.mapfish.print.parser.MapfishParser#POST_CONSTRUCT_METHOD_NAME}()</code>
      * method then it will be called after the fields are all set.
-     * <p></p>
+     *
      * In the case where the a parameter type is a normal POJO (not a special case like PJsonObject, URL,
      * enum, double, etc...) then it will be assumed that the json data is a json object and the parameters
      * will be recursively parsed into the new object as if it is also MapLayer parameter object.
-     * <p></p>
+     *
      * It is important to put values in the value object as public fields because reflection is used when
      * printing client config as well as generating documentation.  If a field is intended for the client
      * software as information but is not intended to be set (or sent as part of the request data), the field
@@ -222,12 +222,12 @@ public abstract class ReflectiveAttribute<Value> implements Attribute {
     /**
      * Uses reflection on the object created by {@link #createValue(Template)} to
      * create the options.
-     * <p></p>
+     *
      * The public final fields are written as the field name as the key and the value as the value.
-     * <p></p>
+     *
      * The public (non-final) mandatory fields are written as part of clientParams and are written with the
      * field name as the key and the field type as the value.
-     * <p></p>
+     *
      * The public (non-final) {@link HasDefaultValue} fields are written as part of
      * clientOptions and are written with the field name as the key and an object as a value with a type
      * property with the type and a default property containing the default value.

--- a/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
@@ -203,7 +203,7 @@ public abstract class ReflectiveAttribute<Value> implements Attribute {
      * </ul>
      * <p></p>
      * If there is a public
-     * <code>{@value MapfishParser#POST_CONSTRUCT_METHOD_NAME}()</code>
+     * <code>{@value org.mapfish.print.parser.MapfishParser#POST_CONSTRUCT_METHOD_NAME}()</code>
      * method then it will be called after the fields are all set.
      * <p></p>
      * In the case where the a parameter type is a normal POJO (not a special case like PJsonObject, URL,

--- a/core/src/main/java/org/mapfish/print/attribute/map/AreaOfInterest.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/AreaOfInterest.java
@@ -44,7 +44,7 @@ public final class AreaOfInterest {
     public String style;
     /**
      * If true the Area of Interest will be rendered as SVG (if display == RENDER).
-     * <p></p>
+     *
      * (will default to {@link org.mapfish.print.config.Configuration#defaultStyle}).
      */
     @HasDefaultValue

--- a/core/src/main/java/org/mapfish/print/attribute/map/BBoxMapBounds.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/BBoxMapBounds.java
@@ -13,7 +13,7 @@ import java.awt.Rectangle;
 
 /**
  * Represent the map bounds with a bounding box.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public final class BBoxMapBounds extends MapBounds {

--- a/core/src/main/java/org/mapfish/print/attribute/map/CenterScaleMapBounds.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/CenterScaleMapBounds.java
@@ -17,7 +17,7 @@ import static org.mapfish.print.Constants.PDF_DPI;
 
 /**
  * Represent Map Bounds with a center location and a scale of the map.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public final class CenterScaleMapBounds extends MapBounds {

--- a/core/src/main/java/org/mapfish/print/attribute/map/GenericMapAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/GenericMapAttribute.java
@@ -351,7 +351,7 @@ public abstract class GenericMapAttribute
         /**
          * Indicates if the map should adjust its scale/zoom level to be equal to one of those defined in the
          * configuration file.
-         * <p></p>
+         *
          *
          * @see #isUseNearestScale()
          */
@@ -359,7 +359,7 @@ public abstract class GenericMapAttribute
         public Boolean useNearestScale = null;
         /**
          * Indicates if the map should adjust its bounds.
-         * <p></p>
+         *
          *
          * @see #isUseAdjustBounds()
          */
@@ -373,11 +373,11 @@ public abstract class GenericMapAttribute
         public Boolean longitudeFirst = null;
         /**
          * Should the vector style definitions be adapted to the target DPI resolution? (Default: true)
-         * <p></p>
+         *
          * The style definitions are often optimized for a use with OpenLayers (which uses a DPI value of 72).
          * When these styles are used to print with a higher DPI value, lines often look too thin, label are
          * too small, etc.
-         * <p></p>
+         *
          * If this property is set to `true`, the style definitions will be scaled to the target DPI value.
          */
         @HasDefaultValue

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapAttribute.java
@@ -52,15 +52,15 @@ public final class MapAttribute extends GenericMapAttribute {
         private static final double DEFAULT_ROTATION = 0.0;
         /**
          * An array of 4 doubles, minX, minY, maxX, maxY.  The bounding box of the map.
-         * <p></p>
+         *
          * Either the bbox or the center + scale must be defined
-         * <p></p>
+         *
          */
         @OneOf("MapBounds")
         public double[] bbox;
         /**
          * A GeoJSON geometry that is essentially the area of the area to draw on the map.
-         * <p></p>
+         *
          */
         @CanSatisfyOneOf("MapBounds")
         @HasDefaultValue

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapBounds.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapBounds.java
@@ -31,7 +31,7 @@ public abstract class MapBounds {
 
     /**
      * Create a {@link org.geotools.geometry.jts.ReferencedEnvelope} representing the bounds.
-     * <p></p>
+     *
      *
      * @param paintArea the size of the map that will be drawn (at 72 DPI).
      */
@@ -39,7 +39,7 @@ public abstract class MapBounds {
 
     /**
      * Create a {@link org.geotools.geometry.jts.ReferencedEnvelope} representing the bounds.
-     * <p></p>
+     *
      *
      * @param paintArea the size of the map that will be drawn.
      */

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapLayer.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapLayer.java
@@ -14,7 +14,7 @@ public interface MapLayer {
 
     /**
      * Attempt to add the layer this layer so that both can be rendered as a single layer.
-     * <p></p>
+     *
      * For example: 2 WMS layers from the same WMS server can be combined into a single WMS layer and the map
      * can be rendered with a single WMS request.
      *

--- a/core/src/main/java/org/mapfish/print/attribute/map/MapfishMapContext.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/MapfishMapContext.java
@@ -104,7 +104,6 @@ public final class MapfishMapContext {
      * Round the size of a rectangle with double values.
      *
      * @param rectangle The rectangle.
-     * @return
      */
     public static Dimension rectangleDoubleToDimension(final Rectangle2D.Double rectangle) {
         return new Dimension(
@@ -367,8 +366,6 @@ public final class MapfishMapContext {
     /**
      * Return the root context which is this context or the context found by recursively calling
      * parent.getRootContext().
-     *
-     * @return
      */
     @Nonnull
     public MapfishMapContext getRootContext() {

--- a/core/src/main/java/org/mapfish/print/attribute/map/OverviewMapAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/map/OverviewMapAttribute.java
@@ -71,7 +71,7 @@ public final class OverviewMapAttribute extends GenericMapAttribute {
         public Double dpi = null;
         /**
          * An array of 4 doubles, minX, minY, maxX, maxY.  The bounding box of the overview-map.
-         * <p></p>
+         *
          * If a bounding box is given, the overview-map shows a fixed extent. The configuration parameter
          * <code>zoomFactor</code> is ignored in this case.
          */
@@ -79,7 +79,7 @@ public final class OverviewMapAttribute extends GenericMapAttribute {
         public double[] bbox;
         /**
          * An array of 2 doubles, (x, y).  The center of the overview-map.
-         * <p></p>
+         *
          * If center and scale are given, the overview-map shows a fixed extent. The configuration parameter
          * <code>zoomFactor</code> is ignored in this case.
          */

--- a/core/src/main/java/org/mapfish/print/config/Configuration.java
+++ b/core/src/main/java/org/mapfish/print/config/Configuration.java
@@ -56,7 +56,7 @@ import javax.annotation.PostConstruct;
 
 /**
  * The Main Configuration Bean.
- * <p></p>
+ *
  */
 public class Configuration implements ConfigurationObject {
     private static final Map<String, String> GEOMETRY_NAME_ALIASES;
@@ -219,7 +219,7 @@ public class Configuration implements ConfigurationObject {
     /**
      * Configuration for proxying http requests.  Each proxy can be configured with authentication and with
      * the uris that they apply to.
-     * <p></p>
+     *
      * See {@link org.mapfish.print.http.HttpProxy} for details on how to configure them.
      *
      * @param proxies the proxy configuration objects
@@ -605,7 +605,7 @@ public class Configuration implements ConfigurationObject {
      * The roles required to access this configuration/app.  If empty or not set then it is a
      * <em>public</em> app.  If there are many roles then a user must have one of the roles in order to
      * access the configuration/app.
-     * <p></p>
+     *
      * The security (how authentication/authorization is done) is configured in the
      * /WEB-INF/classes/mapfish-spring-security.xml
      * <p>

--- a/core/src/main/java/org/mapfish/print/config/ConfigurationObject.java
+++ b/core/src/main/java/org/mapfish/print/config/ConfigurationObject.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 /**
  * A flag interface for a configuration object.  This to allow spring to find them as plugins.
- * <p></p>
+ *
  */
 public interface ConfigurationObject {
     /**

--- a/core/src/main/java/org/mapfish/print/config/MapfishPrintConstructor.java
+++ b/core/src/main/java/org/mapfish/print/config/MapfishPrintConstructor.java
@@ -13,13 +13,13 @@ import java.util.Map;
 /**
  * The interface to SnakeYaml that is responsible for creating the different objects during parsing the config
  * yaml files.
- * <p></p>
+ *
  * The objects are created using spring dependency injection so that the methods are correctly wired using
  * spring.
- * <p></p>
+ *
  * If an object has the interface HashConfiguration then this class will inject the configuration object after
  * creating the object.
- * <p></p>
+ *
  */
 public final class MapfishPrintConstructor extends Constructor {
     private static final String CONFIGURATION_TAG = "configuration";

--- a/core/src/main/java/org/mapfish/print/config/Template.java
+++ b/core/src/main/java/org/mapfish/print/config/Template.java
@@ -351,7 +351,7 @@ public class Template implements ConfigurationObject, HasConfiguration {
     /**
      * The roles required to access this template.  If empty or not set then it is a <em>public</em> template.
      * If there are many roles then a user must have one of the roles in order to access the template.
-     * <p></p>
+     *
      * The security (how authentication/authorization is done) is configured in the
      * /WEB-INF/classes/mapfish-spring-security.xml
      * <p>

--- a/core/src/main/java/org/mapfish/print/config/WorkingDirectories.java
+++ b/core/src/main/java/org/mapfish/print/config/WorkingDirectories.java
@@ -18,7 +18,7 @@ import javax.servlet.ServletContext;
 
 /**
  * Class for configuring the working directories and ensuring they exist correctly.
- * <p></p>
+ *
  */
 public class WorkingDirectories {
     private static final String TASK_DIR_PREFIX = "task-";

--- a/core/src/main/java/org/mapfish/print/config/access/AccessAssertion.java
+++ b/core/src/main/java/org/mapfish/print/config/access/AccessAssertion.java
@@ -13,11 +13,11 @@ import org.mapfish.print.config.ConfigurationObject;
 public interface AccessAssertion extends ConfigurationObject {
     /**
      * Checks that the user can access the resource.
-     * <p></p>
+     *
      * Will throw
      * {@link org.springframework.security.authentication.AuthenticationCredentialsNotFoundException}
      * if the user has not logged in or supplied credentials.
-     * <p></p>
+     *
      * Will throw {@link org.springframework.security.access.AccessDeniedException} if the user is logged in
      * but may not access the resource.
      *

--- a/core/src/main/java/org/mapfish/print/http/CertificateStore.java
+++ b/core/src/main/java/org/mapfish/print/http/CertificateStore.java
@@ -15,7 +15,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 /**
  * A configuration object for configuring a custom certificate/trust store.
- * <p></p>
+ *
  * It is a uri to a java jks keystore file along with the password for unlocking the store.
  */
 public final class CertificateStore implements ConfigurationObject, HasConfiguration {

--- a/core/src/main/java/org/mapfish/print/http/HttpCredential.java
+++ b/core/src/main/java/org/mapfish/print/http/HttpCredential.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a set of credentials to use for an http request.  These can be configured in the Configuration
  * yaml file.
- * <p></p>
+ *
  * <p>
  * <em>Note: proxies are also HttpCredentials and when searching for credentials, the proxies will also be
  * searched for credentials.</em>

--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -117,7 +117,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
 
     /**
      * A request that can be configured at a low level.
-     * <p></p>
+     *
      * It is an http components based request.
      */
     public static final class Request extends AbstractClientHttpRequest implements ConfigurableRequest {

--- a/core/src/main/java/org/mapfish/print/http/MfCredentialsProvider.java
+++ b/core/src/main/java/org/mapfish/print/http/MfCredentialsProvider.java
@@ -13,10 +13,10 @@ import java.util.List;
 /**
  * A Route planner that obtains credentials from the configuration that is currently in {@link
  * org.mapfish.print.http.MfClientHttpRequestFactoryImpl#CURRENT_CONFIGURATION}.
- * <p></p>
+ *
  * If authentication is not found in configuration then it will fall back to {@link
  * org.apache.http.impl.client.SystemDefaultCredentialsProvider}
- * <p></p>
+ *
  * {@link MfClientHttpRequestFactoryImpl.Request} will set the correct configuration before the request is
  * executed so that correct proxies will be set.
  */

--- a/core/src/main/java/org/mapfish/print/map/MapLayerFactoryPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/MapLayerFactoryPlugin.java
@@ -24,10 +24,10 @@ public interface MapLayerFactoryPlugin<Param> {
     /**
      * Create an instance of a param object.  Each instance must be new and unique. Instances must
      * <em>NOT</em> be shared.
-     * <p></p>
+     *
      * The object will be populated from the json.  Each public field will be populated by looking up the
      * value in the json.
-     * <p></p>
+     *
      * The same mechanism used for reading from the JSON into the param object is also used for parsing the
      * JSON into {@link org.mapfish.print.attribute.Attribute} value objects. See {@link
      * org.mapfish.print.attribute.ReflectiveAttribute#createValue(org.mapfish.print.config.Template)}()} for

--- a/core/src/main/java/org/mapfish/print/map/geotools/AbstractVectorLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/AbstractVectorLayerParam.java
@@ -10,14 +10,14 @@ public abstract class AbstractVectorLayerParam extends AbstractLayerParams {
     /**
      * The style name of a style to apply to the features during rendering.  The style name must map to a
      * style in the template or the configuration objects.
-     * <p></p>
+     *
      * If no style is defined then the default style for the geometry type will be used.
      */
     @HasDefaultValue
     public String style;
     /**
      * Indicates if the layer is rendered as SVG.
-     * <p></p>
+     *
      * (will default to {@link org.mapfish.print.config.Configuration#defaultToSvg}).
      */
     @HasDefaultValue

--- a/core/src/main/java/org/mapfish/print/map/geotools/FeatureLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/FeatureLayer.java
@@ -131,7 +131,7 @@ public final class FeatureLayer extends AbstractFeatureSourceLayer {
         /**
          * The style name of a style to apply to the features during rendering.  The style name must map to a
          * style in the template or the configuration objects.
-         * <p></p>
+         *
          * If no style is defined then the default style for the geometry type will be used.
          */
         public String style;
@@ -142,7 +142,7 @@ public final class FeatureLayer extends AbstractFeatureSourceLayer {
         public String defaultStyle;
         /**
          * Indicates if the layer is rendered as SVG.
-         * <p></p>
+         *
          * (will default to {@link org.mapfish.print.config.Configuration#defaultToSvg}).
          */
         public Boolean renderAsSvg;

--- a/core/src/main/java/org/mapfish/print/map/geotools/FeaturesParser.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/FeaturesParser.java
@@ -41,7 +41,7 @@ import javax.annotation.Nonnull;
 
 /**
  * Parser for GeoJson features collection.
- * <p></p>
+ *
  * Created by Stéphane Brunner on 16/4/14.
  */
 public class FeaturesParser {

--- a/core/src/main/java/org/mapfish/print/map/geotools/GeoJsonLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/GeoJsonLayer.java
@@ -104,7 +104,7 @@ public final class GeoJsonLayer extends AbstractFeatureSourceLayer {
     public static class GeoJsonParam extends AbstractVectorLayerParam {
         /**
          * A geojson formatted string or url to the geoJson or the raw GeoJSON data.
-         * <p></p>
+         *
          * The url can be a file url, however if it is it must be relative to the configuration directory.
          */
         @HasDefaultValue

--- a/core/src/main/java/org/mapfish/print/map/geotools/GmlLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/GmlLayer.java
@@ -202,7 +202,7 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
     public static class GmlParam extends AbstractVectorLayerParam {
         /**
          * A url to the gml or the raw Gml data.
-         * <p></p>
+         *
          * The url can be a file url, however if it is it must be relative to the configuration directory.
          */
         public String url;

--- a/core/src/main/java/org/mapfish/print/map/geotools/grid/GridParam.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/grid/GridParam.java
@@ -30,16 +30,16 @@ public final class GridParam extends AbstractLayerParams {
     public static final String DEFAULT_GRID_COLOR = "gray";
     /**
      * The type of grid to render.
-     * <p></p>
+     *
      * Can be LINES or POINTS. Default is LINES.
      */
     @HasDefaultValue
     public GridType gridType = GridType.LINES;
     /**
      * The x,y spacing between grid lines.
-     * <p></p>
+     *
      * Either {@link #spacing} or {@link #numberOfLines}
-     * <p></p>
+     *
      * If spacing is defined then {@link #origin} must also be defined
      */
     @OneOf("spacing")
@@ -48,7 +48,7 @@ public final class GridParam extends AbstractLayerParams {
 
     /**
      * The x,y point of grid origin.
-     * <p></p>
+     *
      * This is required if {@link #spacing} is defined.
      */
     @HasDefaultValue
@@ -56,7 +56,7 @@ public final class GridParam extends AbstractLayerParams {
 
     /**
      * The x,y number of grid lines.
-     * <p></p>
+     *
      * The x is the number of lines that run vertically along the page.
      */
     @OneOf("spacing")
@@ -64,18 +64,18 @@ public final class GridParam extends AbstractLayerParams {
     /**
      * The style name of a style to apply to the features during rendering.  The style name must map to a
      * style in the template or the configuration objects.
-     * <p></p>
+     *
      * If no style is defined then the default grid style will be used.  The default will depend if the type
      * is point or line and will respect {@link #gridColor} and {@link #haloColor} and {@link #haloRadius}. If
      * {@link #gridType} is {@link GridType#POINTS} then the style will be crosses with a haloRadius sized
      * halo around the cross.  If {@link GridType#LINES} then the style will be a dashed line with no halo.
-     * <p></p>
+     *
      */
     @HasDefaultValue
     public String style;
     /**
      * Indicates if the layer is rendered as SVG.
-     * <p></p>
+     *
      * (will default to {@link org.mapfish.print.config.Configuration#defaultToSvg}).
      */
     @HasDefaultValue
@@ -84,7 +84,7 @@ public final class GridParam extends AbstractLayerParams {
     /**
      * The number of points that will be in the grid line (if the gridType is LINES).  If the line will be
      * curved (for certain projections) then the more points the smoother the curve.
-     * <p></p>
+     *
      * The default number of points is {@value DEFAULT_POINTS_IN_GRID_LINE}.
      */
     @HasDefaultValue

--- a/core/src/main/java/org/mapfish/print/map/geotools/grid/GridParam.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/grid/GridParam.java
@@ -22,14 +22,16 @@ public final class GridParam extends AbstractLayerParams {
      * Grid label default format pattern for the unit (if valueFormat is used).
      */
     public static final String DEFAULT_UNIT_FORMAT = " %s";
-    private static final int DEFAULT_POINTS_IN_GRID_LINE = 10000;
-    private static final int DEFAULT_HALO_RADIUS = 1;
-    private static final int DEFAULT_INDENT = 5;
-    private static final String DEFAULT_HALO_COLOR = "#FFF";
-    private static final String DEFAULT_LABEL_COLOR = "#444";
-    private static final String DEFAULT_GRID_COLOR = "gray";
+    public static final int DEFAULT_POINTS_IN_GRID_LINE = 10000;
+    public static final int DEFAULT_HALO_RADIUS = 1;
+    public static final int DEFAULT_INDENT = 5;
+    public static final String DEFAULT_HALO_COLOR = "#FFF";
+    public static final String DEFAULT_LABEL_COLOR = "#444";
+    public static final String DEFAULT_GRID_COLOR = "gray";
     /**
-     * The type of grid to render.  By default it is LINES
+     * The type of grid to render.
+     * <p></p>
+     * Can be LINES or POINTS. Default is LINES.
      */
     @HasDefaultValue
     public GridType gridType = GridType.LINES;
@@ -83,7 +85,7 @@ public final class GridParam extends AbstractLayerParams {
      * The number of points that will be in the grid line (if the gridType is LINES).  If the line will be
      * curved (for certain projections) then the more points the smoother the curve.
      * <p></p>
-     * The default number of points is {@value #DEFAULT_POINTS_IN_GRID_LINE}.
+     * The default number of points is {@value DEFAULT_POINTS_IN_GRID_LINE}.
      */
     @HasDefaultValue
     public int pointsInLine = DEFAULT_POINTS_IN_GRID_LINE;

--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsLayerParam.java
@@ -24,7 +24,7 @@ public class WmsLayerParam extends AbstractWMXLayerParams {
     /**
      * The wms layer to request in the GetMap request.  The order is important.  It is the order that they
      * will appear in the request.
-     * <p></p>
+     *
      * As with the WMS specification, the first layer will be the first layer drawn on the map (the
      * bottom/base layer) of the map.  This means that layer at position 0 in the array will covered by layer
      * 1 (where not transparent) and so on.
@@ -66,7 +66,7 @@ public class WmsLayerParam extends AbstractWMXLayerParams {
 
     /**
      * The HTTP verb to use for fetching the images. Can be either "GET" (the default) or "POST".
-     * <p></p>
+     *
      * In case of "POST", the parameters are send in the body of the request using an
      * "application/x-www-form-urlencoded" content type. This can be used when the parameters are too long.
      * Tested only with GeoServer.

--- a/core/src/main/java/org/mapfish/print/map/style/json/MapfishStyleParserPlugin.java
+++ b/core/src/main/java/org/mapfish/print/map/style/json/MapfishStyleParserPlugin.java
@@ -66,7 +66,7 @@ import static org.mapfish.print.map.style.json.MapfishJsonStyleVersion1.DEFAULT_
  *    }
  * }
  * </code></pre>
- * <p></p>
+ *
  * <h2 id="stylev2">Mapfish JSON Style Version 2 <a class="headerlink" href="#stylev2">¶</a></h2>
  * <p>
  * Version 2 uses the same property names as version 1 but has a different structure. The layout is as
@@ -217,7 +217,7 @@ import static org.mapfish.print.map.style.json.MapfishJsonStyleVersion1.DEFAULT_
  * </ul>
  * </li>
  * </ul>
- * <p></p>
+ *
  * <h2 id="config">Configuration Elements <a class="headerlink" href="#config">¶</a></h2>
  * The items in the list below are the properties that can be set on the different symbolizers. In brackets
  * list the symbolizers the values can apply to.
@@ -338,7 +338,7 @@ import static org.mapfish.print.map.style.json.MapfishJsonStyleVersion1.DEFAULT_
  * it will be assumed that the geometry is a line and this property defines how far from the center of the
  * line the label should be drawn.</li>
  * </ul>
- * <p></p>
+ *
  * <h2 id="labels">Labelling: <a class="headerlink" href="#labels">¶</a></h2>
  * <p>
  * Labelling in this style format is done by defining a text symbolizer ("type":"text").  All text symbolizers
@@ -460,7 +460,7 @@ import static org.mapfish.print.map.style.json.MapfishJsonStyleVersion1.DEFAULT_
  * <a href="http://docs.geotools.org/latest/userguide/library/render/style.html#textsymbolizer">GeoTools
  * documentation</a>.
  * </p>
- * <p></p>
+ *
  * <h2>ECQL references:</h2>
  * <ul>
  * <li><a href="http://docs.geoserver.org/stable/en/user/filter/ecql_reference.html#ecql-expr">

--- a/core/src/main/java/org/mapfish/print/map/tiled/AbstractWMXLayerParams.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/AbstractWMXLayerParams.java
@@ -22,7 +22,7 @@ public abstract class AbstractWMXLayerParams extends AbstractTiledLayerParams {
      * #mergeableParams} except they are the parameters that will prevent two layers from the same server from
      * being merged into a single request with both layers. See {@link #mergeableParams} for a more detailed
      * example of the difference between {@link #mergeableParams} and {@link #customParams}.
-     * <p></p>
+     *
      * The json should look something like:
      * <pre><code>
      * {
@@ -36,7 +36,7 @@ public abstract class AbstractWMXLayerParams extends AbstractTiledLayerParams {
     /**
      * Custom query parameters that can be merged if multiple layers are merged together into a single
      * request.
-     * <p></p>
+     *
      * The json should look something like:
      * <pre><code>
      * {
@@ -44,11 +44,11 @@ public abstract class AbstractWMXLayerParams extends AbstractTiledLayerParams {
      *     "param2Name": ["value1", "value2"]
      * }
      * </code></pre>
-     * <p></p>
+     *
      * For example in WMS the style parameter can be merged.  If there are several wms layers that can be
      * merged except they have different style parameters they can be merged because the style parameter can
      * be merged.
-     * <p></p>
+     *
      * Compare that to DPI parameter (for QGIS wms mapserver).  if two layers have different DPI then the
      * layers cannot be merged.  In this case the DPI should <em>NOT</em> be one of the {@link
      * #mergeableParams} it should be one of the {@link #customParams}.

--- a/core/src/main/java/org/mapfish/print/map/tiled/TileCacheInformation.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/TileCacheInformation.java
@@ -76,7 +76,7 @@ public abstract class TileCacheInformation {
      * Get the resolution that the layer uses for its calculations.  The map isn't always at a resolution that
      * a tiled layer supports so a scale is chosen for the layer that is close to the map scale. This method
      * returns the layer's scale.
-     * <p></p>
+     *
      * This is used for calculating the bounds of tiles, the size number and indices of the tiles to be
      * returned.
      */
@@ -104,7 +104,7 @@ public abstract class TileCacheInformation {
     /**
      * Calculate the minx and miny coordinate of the tile that is the minx and miny tile.  It is the starting
      * point of counting tiles to render.
-     * <p></p>
+     *
      * This equates to the minX and minY of the GridCoverage as well.
      *
      * @param envelope the area that will be displayed.
@@ -147,7 +147,7 @@ public abstract class TileCacheInformation {
 
     /**
      * Return the image to draw in place of a tile that is missing.
-     * <p></p>
+     *
      * If this method returns null nothing will be drawn at the location of the missing image.
      */
     @Nullable

--- a/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/osm/OsmLayerParam.java
@@ -96,7 +96,7 @@ public final class OsmLayerParam extends AbstractTiledLayerParams {
     public String imageExtension = "png";
     /**
      * Custom query parameters to use when making http requests. {@link #customParams}.
-     * <p></p>
+     *
      * The json should look something like:
      * <pre><code>
      * {

--- a/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayerParam.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/wmts/WMTSLayerParam.java
@@ -22,12 +22,12 @@ public final class WMTSLayerParam extends AbstractWMXLayerParams {
 
     /**
      * The ‘ResourceURL’ available in the WMTS capabilities.
-     * <p></p>
+     *
      * Example (for <code>requestEncoding: "KVP"</code>):
      * <pre><code>
      * baseUrl: "http://domain.com/wmts"
      * </code></pre>
-     * <p></p>
+     *
      * Example (for <code>requestEncoding: "REST"</code>):
      * <pre><code>
      * baseUrl: "http://domain.com/wmts/roads/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"
@@ -65,10 +65,10 @@ public final class WMTSLayerParam extends AbstractWMXLayerParams {
     public String style = "";
     /**
      * The "sample" dimensions or image color bands to retrieve.
-     * <p></p>
+     *
      * This can be null, if so then the default dimensions will be returned. If specified they must be
      * dimensions supported by the server.
-     * <p></p>
+     *
      * These are keys to the {@link #dimensionParams}.
      */
     @HasDefaultValue
@@ -91,7 +91,7 @@ public final class WMTSLayerParam extends AbstractWMXLayerParams {
     public String matrixSet;
     /**
      * Array of matrix ids.
-     * <p></p>
+     *
      * Example:
      * <pre><code>
      * [{

--- a/core/src/main/java/org/mapfish/print/metrics/MapfishPrintInstrumentedFilterContextListener.java
+++ b/core/src/main/java/org/mapfish/print/metrics/MapfishPrintInstrumentedFilterContextListener.java
@@ -12,7 +12,7 @@ import static org.springframework.web.context.support.WebApplicationContextUtils
 /**
  * Allows the AdminServlet to get access to the MetricRegistry so it can display the statistics via the admin
  * servlet.
- * <p></p>
+ *
  */
 public class MapfishPrintInstrumentedFilterContextListener extends InstrumentedFilterContextListener {
     private ServletContext servletContext;

--- a/core/src/main/java/org/mapfish/print/metrics/MetricsNameStrategyFactory.java
+++ b/core/src/main/java/org/mapfish/print/metrics/MetricsNameStrategyFactory.java
@@ -6,7 +6,7 @@ import com.codahale.metrics.httpclient.HttpClientMetricNameStrategy;
 /**
  * Used as a factory for the spring configuration for configuring the {@link
  * com.codahale.metrics.httpclient.InstrumentedHttpClients}.
- * <p></p>
+ *
  */
 public final class MetricsNameStrategyFactory {
     private MetricsNameStrategyFactory() {

--- a/core/src/main/java/org/mapfish/print/output/OutputFormat.java
+++ b/core/src/main/java/org/mapfish/print/output/OutputFormat.java
@@ -9,7 +9,7 @@ import java.io.OutputStream;
 
 /**
  * Interface for exporting the generated PDF from MapPrinter.
- * <p></p>
+ *
  * User: jeichar Date: Oct 18, 2010 Time: 1:49:41 PM
  */
 public interface OutputFormat {

--- a/core/src/main/java/org/mapfish/print/parser/CanSatisfyOneOf.java
+++ b/core/src/main/java/org/mapfish/print/parser/CanSatisfyOneOf.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 /**
  * Indicates that the annotated field or can satisfy the {@link org.mapfish.print.parser.OneOf} requirements
  * or can co-exist with that requirement.
- * <p></p>
+ *
  * If this annotation is present then {@link org.mapfish.print.parser.HasDefaultValue} is not required.
  *
  * @see org.mapfish.print.parser.OneOf

--- a/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
+++ b/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
@@ -44,7 +44,7 @@ import static org.mapfish.print.parser.ParserUtils.getAttributeNames;
  */
 public final class MapfishParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(MapfishParser.class);
-    private static final String POST_CONSTRUCT_METHOD_NAME = "postConstruct";
+    public static final String POST_CONSTRUCT_METHOD_NAME = "postConstruct";
 
     private MapfishParser() {
     }

--- a/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
+++ b/core/src/main/java/org/mapfish/print/parser/MapfishParser.java
@@ -32,10 +32,10 @@ import static org.mapfish.print.parser.ParserUtils.getAttributeNames;
  * org.mapfish.print.map.MapLayerFactoryPlugin} instances and into
  * {@link org.mapfish.print.attribute.ReflectiveAttribute}
  * value objects
- * <p></p>
+ *
  * Essentially it maps the keys in the json object to public fields in the object obtained from the {@link
  * org.mapfish.print.map.MapLayerFactoryPlugin#createParameter()} method.
- * <p></p>
+ *
  * There is a more explicit explanation in
  * {@link org.mapfish.print.attribute.ReflectiveAttribute#createValue(org.mapfish.print.config.Template)}
  *

--- a/core/src/main/java/org/mapfish/print/parser/Requires.java
+++ b/core/src/main/java/org/mapfish/print/parser/Requires.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that if one field in a value/param object, then one or more other attributes are required.
- * <p></p>
+ *
  * Note: If the field with the {@link org.mapfish.print.parser.Requires} annotation is NOT in the json then
  * the required are not required as long as they have the {@link org.mapfish.print.parser.HasDefaultValue}
  * annotation.

--- a/core/src/main/java/org/mapfish/print/processor/AbstractProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/AbstractProcessor.java
@@ -189,7 +189,7 @@ public abstract class AbstractProcessor<In, Out> implements Processor<In, Out> {
     // CHECKSTYLE:ON
 
     /**
-     * Default implementation of {@link ExecutionContext}.
+     * Default implementation of {@link org.mapfish.print.processor.Processor.ExecutionContext}.
      */
     public static final class Context implements ExecutionContext {
         private final String jobId;

--- a/core/src/main/java/org/mapfish/print/processor/PdfConfigurationProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/PdfConfigurationProcessor.java
@@ -45,7 +45,7 @@ public final class PdfConfigurationProcessor extends AbstractProcessor<PdfConfig
      * The pdf metadata property -&gt; attribute name map.  The keys must be one of the values in {@link
      * org.mapfish.print.config.PDFConfig} and the values must be the name of the attribute to obtain the the
      * data from.  Example Configuration:
-     * <p></p>
+     *
      * <pre><code>
      * processors:
      *   - !updatePdfConfig
@@ -53,10 +53,10 @@ public final class PdfConfigurationProcessor extends AbstractProcessor<PdfConfig
      *       title: "titleAttribute"
      *       subject: "subjectAttribute"
      * </code></pre>
-     * <p></p>
+     *
      * The type of the attribute must be of the correct type, for example title mus be a string, keywords must
      * be an array of strings, compress must be a boolean.
-     * <p></p>
+     *
      * If the value is within the attribute output object then you can use dot separators for each level. For
      * example suppose there is a custom attribute: myconfig, if and it has a property title then the
      * configuration would be:
@@ -65,7 +65,7 @@ public final class PdfConfigurationProcessor extends AbstractProcessor<PdfConfig
      *   - updatePdfConfig
      *     updates: {title: :myconfig.title"}
      * </code></pre>
-     * <p></p>
+     *
      * For more power a "format" can be defined.  The format is a printf style format string which will be
      * called with a single value that is identified by the value key/path.  In this case the short hand key:
      * value can't be used instead it is as follows:
@@ -310,7 +310,7 @@ public final class PdfConfigurationProcessor extends AbstractProcessor<PdfConfig
         /**
          * The key to use to look up the value in the values object.  It can be a path that can reach into
          * nested objects.
-         * <p></p>
+         *
          * Examples 1 a simple lookup key: "key" Example 2 a path.  First part (before .) is the lookup key,
          * the second part is the field name to load: "key.fieldName"
          *
@@ -323,7 +323,7 @@ public final class PdfConfigurationProcessor extends AbstractProcessor<PdfConfig
         /**
          * The replacement format.  It is a printf style format.  The documentation is in the Formatter class
          * (just google/bing java.util.Formatter).
-         * <p></p>
+         *
          * Example: "Report for %s"
          *
          * @param format the update format.  There can only be a single value.

--- a/core/src/main/java/org/mapfish/print/processor/Processor.java
+++ b/core/src/main/java/org/mapfish/print/processor/Processor.java
@@ -27,7 +27,7 @@ public interface Processor<In, Out> extends ConfigurationObject {
 
     /**
      * Get the class of the output type.  This is used when determining the outputs this processor produces.
-     * <p></p>
+     *
      * The <em>public fields</em> of the Processor will be the output of the processor and thus can be mapped
      * to inputs of another processor.
      */
@@ -43,7 +43,7 @@ public interface Processor<In, Out> extends ConfigurationObject {
      * Returns a <em>new/clean</em> instance of a parameter object.  This instance's will be inspected using
      * reflection to find its public fields and the properties will be set from the {@link
      * org.mapfish.print.output.Values} object.
-     * <p></p>
+     *
      * The way the properties will be looked up is to
      * <ol>
      * <li>
@@ -64,12 +64,12 @@ public interface Processor<In, Out> extends ConfigurationObject {
      * the property.
      * </li>
      * </ol>
-     * <p></p>
+     *
      * The populated instance will be passed to the execute method.  It is <em>imperative</em> that a new
      * instance is created each time because they will be used in a multi-threaded environment and thus the
      * same processor instance may be ran in multiple threads with different instances of the parameter
      * object.
-     * <p></p>
+     *
      * It is important to realize that super classes will also be analyzed, so care must be had with
      * inheritance.
      */

--- a/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraph.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraph.java
@@ -22,7 +22,7 @@ import static org.mapfish.print.parser.ParserUtils.getAttributeNames;
 /**
  * Represents a graph of the processors dependencies.  The root nodes can execute in parallel but processors
  * with dependencies must wait for their dependencies to complete before execution.
- * <p></p>
+ *
  */
 public final class ProcessorDependencyGraph {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessorDependencyGraph.class);

--- a/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraphFactory.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorDependencyGraphFactory.java
@@ -31,7 +31,7 @@ import static org.mapfish.print.parser.ParserUtils.getAllAttributes;
 
 /**
  * Class for constructing {@link org.mapfish.print.processor.ProcessorDependencyGraph} instances.
- * <p></p>
+ *
  */
 public final class ProcessorDependencyGraphFactory {
 

--- a/core/src/main/java/org/mapfish/print/processor/ProcessorExecutionContext.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorExecutionContext.java
@@ -10,7 +10,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Contains information shared across all nodes being executed.
- * <p></p>
+ *
  */
 public final class ProcessorExecutionContext {
     private final Values values;

--- a/core/src/main/java/org/mapfish/print/processor/ProcessorGraphNode.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorGraphNode.java
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 
 /**
  * Represents one node in the Processor dependency graph ({@link ProcessorDependencyGraph}).
- * <p></p>
+ *
  *
  * @param <In> Same as {@link Processor} <em>In</em> parameter
  * @param <Out> Same as {@link Processor} <em>Out</em> parameter

--- a/core/src/main/java/org/mapfish/print/processor/ProcessorUtils.java
+++ b/core/src/main/java/org/mapfish/print/processor/ProcessorUtils.java
@@ -27,7 +27,7 @@ public final class ProcessorUtils {
 
     /**
      * Create the input object required by the processor and populate all the fields from the values object.
-     * <p></p>
+     *
      * If {@link Processor#createInputParameter()} returns an instance of values then the values object will
      * be returned.
      *

--- a/core/src/main/java/org/mapfish/print/processor/http/AddHeadersProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/AddHeadersProcessor.java
@@ -39,7 +39,6 @@ public final class AddHeadersProcessor extends AbstractClientHttpRequestFactoryP
      *         a proxy class.
      * @param matchers The matchers.
      * @param headers The headers.
-     * @return
      */
     public static MfClientHttpRequestFactory createFactoryWrapper(
             final MfClientHttpRequestFactory requestFactory,

--- a/core/src/main/java/org/mapfish/print/processor/http/RestrictUrisProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/RestrictUrisProcessor.java
@@ -36,7 +36,7 @@ import java.net.URI;
  *       host: www.geocat.ch
  *       port: 80
  * </code></pre>
- * <p></p>
+ *
  * <p>
  * By default a matcher allows the URL, but it can be setup to reject the URL (by setting reject to true). The
  * first matcher that matches will be the one picking the final outcome. If no matcher matches, the URI is
@@ -51,7 +51,7 @@ import java.net.URI;
  *       reject: true
  *     - !acceptAll
  * </code></pre>
- * <p></p>
+ *
  * <p>
  * If the Print service is in your DMZ and needs to allow access to any WMS server, it is strongly recommended
  * to have a configuration like the previous one in order to avoid having the Print service being used as a

--- a/core/src/main/java/org/mapfish/print/processor/http/matcher/DnsHostMatcher.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/matcher/DnsHostMatcher.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *       host : www.camptocamp.com
  *       port : 80
  * </code></pre>
- * <p></p>
+ *
  * Example 4: Accept www.camptocamp.com urls with paths that start with /print/.
  * <p>
  * If the regular expression give does not start with / then it will be added because all paths start with /

--- a/core/src/main/java/org/mapfish/print/processor/http/matcher/HostnameMatcher.java
+++ b/core/src/main/java/org/mapfish/print/processor/http/matcher/HostnameMatcher.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  *       host : www.camptocamp.com
  *       port : 80
  * </code></pre>
- * <p></p>
+ *
  * Example 4: Accept www.camptocamp.com urls with paths that start with /print/.
  * <p>
  * If the regular expression give does not start with / then it will be added because all paths start with /

--- a/core/src/main/java/org/mapfish/print/processor/jasper/DataSourceProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/DataSourceProcessor.java
@@ -132,7 +132,7 @@ public final class DataSourceProcessor
      * All the processors that will executed for each value retrieved from the {@link
      * org.mapfish.print.output.Values} object with the datasource name.  All output values from the processor
      * graph will be the datasource values.
-     * <p></p>
+     *
      * <p>
      * Each value retrieved from values with the datasource name will be the input of the processor graph and
      * all the output values for that execution will be the values of a single row in the datasource. The

--- a/core/src/main/java/org/mapfish/print/processor/jasper/TableProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/TableProcessor.java
@@ -130,7 +130,7 @@ public final class TableProcessor extends AbstractProcessor<TableProcessor.Input
     /**
      * Set strategies for converting the textual representation of each column to some other object (image,
      * other text, etc...).
-     * <p></p>
+     *
      * Note: The type returned by the column converter must match the type in the jasper template.
      *
      * @param columnConverters Map from column name -&gt; {@link TableColumnConverter}
@@ -142,7 +142,7 @@ public final class TableProcessor extends AbstractProcessor<TableProcessor.Input
     /**
      * Set strategies for converting the textual representation of each cell to some other object (image,
      * other text, etc...).
-     * <p></p>
+     *
      * This is similar to the converters specified for a particular column. The difference is that these
      * converters are applied to every cell of the table (except for the cells of those columns that are
      * assigned a specific converter).

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateOverviewMapProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateOverviewMapProcessor.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 /**
  * Processor to create overview maps. Internally {@link CreateMapProcessor} is used.
- * <p></p>
+ *
  * Example Configuration:
  * <pre><code>
  * attributes:
@@ -49,13 +49,13 @@ import java.util.List;
  *      outputMapper:
  *        layerGraphics: overviewMapLayerGraphics
  * </code></pre>
- * <p></p>
+ *
  * <strong>Features:</strong>
- * <p></p>
+ *
  * The attribute overviewMap allows to overwrite all properties of the main map, for example to use different
  * layers. The overview map can have a different rotation than the main map. For example the main map is
  * rotated and the overview map faces north. But the overview map can also be rotated.
- * <p></p>
+ *
  * <p>The style of the bbox rectangle can be changed by setting the <code>style</code> property.</p>
  * <p>See also: <a href="attributes.html#!overviewMap">!overviewMap</a> attribute</p>
  * [[examples=verboseExample,overviewmap_tyger_ny_EPSG_3857]]

--- a/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
@@ -142,7 +142,7 @@ public class ScalebarGraphic {
 
     /**
      * Called when the position of the labels and their content is known.
-     * <p></p>
+     *
      * Creates the drawer which draws the scalebar.
      */
     private static void doLayout(

--- a/core/src/main/java/org/mapfish/print/servlet/ConfigBasedServletInfo.java
+++ b/core/src/main/java/org/mapfish/print/servlet/ConfigBasedServletInfo.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 /**
  * A servlet info that can be configured through the spring configuration (or programmatically).
- * <p></p>
+ *
  * A default random id will be created by default.
  */
 public final class ConfigBasedServletInfo implements ServletInfo {

--- a/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
+++ b/core/src/main/java/org/mapfish/print/servlet/MapPrinterServlet.java
@@ -120,7 +120,7 @@ public class MapPrinterServlet extends BaseMapServlet {
     /* Registry keys */
     /**
      * If the job is done (value is true) or not (value is false).
-     * <p></p>
+     *
      * Part of the {@link #getStatus(String, String, javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)} response.
      */
@@ -141,14 +141,14 @@ public class MapPrinterServlet extends BaseMapServlet {
     /**
      * The elapsed time in ms from the point the job started. If the job is finished, this is the duration it
      * took to process the job.
-     * <p></p>
+     *
      * Part of the {@link #getStatus(String, String, javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)} response.
      */
     public static final String JSON_ELAPSED_TIME = "elapsedTime";
     /**
      * A rough estimate for the time in ms the job still has to wait in the queue until it starts processing.
-     * <p></p>
+     *
      * Part of the {@link #getStatus(String, String, javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)} response.
      */
@@ -277,7 +277,7 @@ public class MapPrinterServlet extends BaseMapServlet {
 
     /**
      * Get a status report on a job.  Returns the following json:
-     * <p></p>
+     *
      * <pre><code>
      *  {"time":0,"count":0,"done":false}
      * </code></pre>
@@ -300,7 +300,7 @@ public class MapPrinterServlet extends BaseMapServlet {
 
     /**
      * Get a status report on a job.  Returns the following json:
-     * <p></p>
+     *
      * <pre><code>
      *  {"time":0,"count":0,"done":false}
      * </code></pre>

--- a/core/src/main/java/org/mapfish/print/servlet/ServletInfo.java
+++ b/core/src/main/java/org/mapfish/print/servlet/ServletInfo.java
@@ -8,7 +8,7 @@ public interface ServletInfo {
      * Return an id that identifies this server. This information is incorporated into the print request id so
      * that it is possible for load balancers to redirect a request to the same server without having to keep
      * sticky sessions.  Or to find the same server after a session has expired.
-     * <p></p>
+     *
      * This provides an option for simple clusters to be created without having to have a shared registry for
      * storing the look up when needing to retrieve the results of a print job.
      */

--- a/core/src/main/java/org/mapfish/print/servlet/ServletMapPrinterFactory.java
+++ b/core/src/main/java/org/mapfish/print/servlet/ServletMapPrinterFactory.java
@@ -32,7 +32,7 @@ import javax.annotation.PostConstruct;
 /**
  * A {@link org.mapfish.print.MapPrinterFactory} that reads configuration from files and uses servlet's
  * methods for resolving the paths to the files.
- * <p></p>
+ *
  */
 public class ServletMapPrinterFactory implements MapPrinterFactory {
 

--- a/core/src/main/java/org/mapfish/print/servlet/fileloader/ClasspathConfigFileLoader.java
+++ b/core/src/main/java/org/mapfish/print/servlet/fileloader/ClasspathConfigFileLoader.java
@@ -17,14 +17,13 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 /**
- * A plugin that loads the config resources from urls starting with prefix: {@value
- * ClasspathConfigFileLoader#PREFIX}://.
+ * A plugin that loads the config resources from urls starting with prefix: {@value #PREFIX}://.
  */
 public final class ClasspathConfigFileLoader implements ConfigFileLoaderPlugin {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClasspathConfigFileLoader.class);
 
-    private static final String PREFIX = "classpath";
-    private static final int PREFIX_LENGTH = (PREFIX + "://").length();
+    public static final String PREFIX = "classpath";
+    public static final int PREFIX_LENGTH = (PREFIX + "://").length();
 
     @Override
     public Optional<File> toFile(final URI fileUri) {

--- a/core/src/main/java/org/mapfish/print/servlet/fileloader/FileConfigFileLoader.java
+++ b/core/src/main/java/org/mapfish/print/servlet/fileloader/FileConfigFileLoader.java
@@ -6,11 +6,10 @@ import java.util.Collections;
 import java.util.Iterator;
 
 /**
- * A plugin that loads the config resources from urls starting with prefix: {@value
- * org.mapfish.print.servlet.fileloader.FileConfigFileLoader#PREFIX}://.
+ * A plugin that loads the config resources from urls starting with prefix: {@value #PREFIX}://.
  */
 public final class FileConfigFileLoader extends AbstractFileConfigFileLoader {
-    static final String PREFIX = "file";
+    public static final String PREFIX = "file";
 
     @Override
     protected Iterator<File> resolveFiles(final URI fileURI) {

--- a/core/src/main/java/org/mapfish/print/servlet/fileloader/ServletConfigFileLoader.java
+++ b/core/src/main/java/org/mapfish/print/servlet/fileloader/ServletConfigFileLoader.java
@@ -9,13 +9,12 @@ import java.util.Iterator;
 import javax.servlet.ServletContext;
 
 /**
- * A plugin that loads the config resources from urls starting with prefix: {@value
- * org.mapfish.print.servlet.fileloader.ServletConfigFileLoader#PREFIX}://.
+ * A plugin that loads the config resources from urls starting with prefix: {@value #PREFIX}://.
  */
 public final class ServletConfigFileLoader extends AbstractFileConfigFileLoader {
 
-    private static final String PREFIX = "servlet";
-    private static final int PREFIX_LENGTH = (PREFIX + "://").length();
+    public static final String PREFIX = "servlet";
+    public static final int PREFIX_LENGTH = (PREFIX + "://").length();
 
     @Autowired
     private ServletContext servletContext;

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/FilePrintJob.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/FilePrintJob.java
@@ -5,7 +5,7 @@ import org.mapfish.print.servlet.job.PrintJobResult;
 
 /**
  * A PrintJob implementation that write results to files.
- * <p></p>
+ *
  */
 public class FilePrintJob extends PrintJob {
     @Override

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
@@ -67,7 +67,7 @@ public class ThreadPoolJobManager implements JobManager {
     private int maxNumberOfRunningPrintJobs = Runtime.getRuntime().availableProcessors();
     /**
      * The maximum number of print job requests that are waiting to be executed.
-     * <p></p>
+     *
      * This prevents spikes in requests from completely destroying the server.
      */
     private int maxNumberOfWaitingJobs = DEFAULT_MAX_WAITING_JOBS;
@@ -100,7 +100,7 @@ public class ThreadPoolJobManager implements JobManager {
     /**
      * A comparator for comparing {@link org.mapfish.print.servlet.job.impl.SubmittedPrintJob}s and
      * prioritizing them.
-     * <p></p>
+     *
      * For example it could be that requests from certain users (like executive officers) are prioritized over
      * requests from other users.
      */

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernatePrintJob.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernatePrintJob.java
@@ -11,7 +11,7 @@ import java.net.URISyntaxException;
 
 /**
  * A PrintJob implementation that write results to the database.
- * <p></p>
+ *
  */
 public class HibernatePrintJob extends PrintJob {
     @Override

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernateReportLoader.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernateReportLoader.java
@@ -10,7 +10,7 @@ import java.net.URI;
 
 /**
  * Loads reports from hibernate uris.
- * <p></p>
+ *
  */
 public class HibernateReportLoader implements ReportLoader {
 

--- a/core/src/main/java/org/mapfish/print/servlet/job/loader/FileReportLoader.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/loader/FileReportLoader.java
@@ -9,7 +9,7 @@ import java.net.URI;
 
 /**
  * Loads reports from file uris.
- * <p></p>
+ *
  */
 public class FileReportLoader implements ReportLoader {
     @Override

--- a/core/src/test/java/org/mapfish/print/config/ConfigurationFactoryAllConfigObjectMustBePrototypeTest.java
+++ b/core/src/test/java/org/mapfish/print/config/ConfigurationFactoryAllConfigObjectMustBePrototypeTest.java
@@ -11,7 +11,7 @@ import static org.mapfish.print.AbstractMapfishSpringTest.DEFAULT_SPRING_XML;
 
 /**
  * Test ConfigurationFactory.
- * <p></p>
+ *
  */
 public class ConfigurationFactoryAllConfigObjectMustBePrototypeTest {
 

--- a/core/src/test/java/org/mapfish/print/config/ConfigurationFactoryTest.java
+++ b/core/src/test/java/org/mapfish/print/config/ConfigurationFactoryTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Test ConfigurationFactory.
- * <p></p>
+ *
  */
 
 @ContextConfiguration(locations = {ConfigurationFactoryTest.TEST_SPRING_XML})

--- a/core/src/test/java/org/mapfish/print/processor/ProcessorDependencyGraphFactoryTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/ProcessorDependencyGraphFactoryTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.fail;
 
 /**
  * Test building processor graphs.
- * <p></p>
+ *
  */
 public class ProcessorDependencyGraphFactoryTest extends AbstractMapfishSpringTest {
     private static final String EXECUTION_TRACKER = "executionOrder";

--- a/core/src/test/java/org/mapfish/print/processor/map/AddBackgroundLayersTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/AddBackgroundLayersTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the background-layer processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class AddBackgroundLayersTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/AddOverlayLayersTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/AddOverlayLayersTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the background-layer processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class AddOverlayLayersTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapPagesProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapPagesProcessorTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapPagesProcessorTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorAoiForBoundsTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorAoiForBoundsTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorAoiForBoundsTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorAoiTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorAoiTest.java
@@ -34,7 +34,7 @@ import static org.mapfish.print.attribute.map.AreaOfInterest.AoiDisplay.RENDER;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorAoiTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToExtentFlexibleScaleTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToExtentFlexibleScaleTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorCenterGeoJsonZoomToExtentFlexibleScaleTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToExtentMinScaleTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToExtentMinScaleTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorCenterGeoJsonZoomToExtentMinScaleTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToExtentTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToExtentTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorCenterGeoJsonZoomToExtentTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeoJsonZoomToTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorCenterGeoJsonZoomToTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeojsonJsonStyleV1.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorCenterGeojsonJsonStyleV1.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorCenterGeojsonJsonStyleV1 extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSRestTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSRestTest.java
@@ -29,7 +29,7 @@ import static org.mapfish.print.Constants.PDF_DPI;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleAndCenterWMTSRestTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleAndCenterWMTSTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleAndCenterWMTSTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleBBoxGeoJsonTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleBBoxGeoJsonTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleBBoxGeoJsonTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridFixedNumlinesPointTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridFixedNumlinesPointTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleCenterGridFixedNumlinesPointTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridFixedNumlinesTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridFixedNumlinesTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleCenterGridFixedNumlinesTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridFixedSpacingPointTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridFixedSpacingPointTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleCenterGridFixedSpacingPointTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridSpacingTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterGridSpacingTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleCenterGridSpacingTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmDpiTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmDpiTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleCenterOsmDpiTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFixedScaleCenterOsmTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFixedScaleCenterOsmTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleAndCenterGeoTiffTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleAndCenterGeoTiffTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFlexibleScaleAndCenterGeoTiffTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleBBoxGeoJsonTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleBBoxGeoJsonTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFlexibleScaleBBoxGeoJsonTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleBBoxGmlTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleBBoxGmlTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFlexibleScaleBBoxGmlTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterTiledWmsTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterTiledWmsTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFlexibleScaleCenterTiledWmsTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterWms1_0_0Test.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterWms1_0_0Test.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFlexibleScaleCenterWms1_0_0Test extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterWms1_0_0_DPITest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterWms1_0_0_DPITest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFlexibleScaleCenterWms1_0_0_DPITest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterWms1_0_0_DPI_SVG_Test.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleCenterWms1_0_0_DPI_SVG_Test.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorFlexibleScaleCenterWms1_0_0_DPI_SVG_Test extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesLinesNoRotateLabelsTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesLinesNoRotateLabelsTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorGridFixedNumlinesLinesNoRotateLabelsTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesPointAltLabelProjTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesPointAltLabelProjTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorGridFixedNumlinesPointAltLabelProjTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesPointCRS84Test.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesPointCRS84Test.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorGridFixedNumlinesPointCRS84Test extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesPointRotatedTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorGridFixedNumlinesPointRotatedTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorGridFixedNumlinesPointRotatedTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorImageLayerTest1.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorImageLayerTest1.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by MaxComse on 11/09/16.
  */
 public class CreateMapProcessorImageLayerTest1 extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorLineVsPolygonStyleGeoJsonTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorLineVsPolygonStyleGeoJsonTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorLineVsPolygonStyleGeoJsonTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorOpacityWMTSTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorOpacityWMTSTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorOpacityWMTSTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorWmtsBufferTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorWmtsBufferTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the Map processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class CreateMapProcessorWmtsBufferTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/SetFeaturesProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/SetFeaturesProcessorTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Basic test of the set features to vector layers processor.
- * <p></p>
+ *
  * Created by Stéphane Brunner on 16/4/14.
  */
 public class SetFeaturesProcessorTest extends AbstractMapfishSpringTest {

--- a/core/src/test/java/org/mapfish/print/processor/map/SetWmsCustomParamProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/SetWmsCustomParamProcessorTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Basic test of the set param to WMS layers processor.
- * <p></p>
+ *
  * Created by Jesse on 3/26/14.
  */
 public class SetWmsCustomParamProcessorTest extends AbstractMapfishSpringTest {

--- a/docs/src/main/groovy/GenerateDocs.groovy
+++ b/docs/src/main/groovy/GenerateDocs.groovy
@@ -21,6 +21,8 @@ import org.springframework.beans.BeanUtils
 import org.springframework.mock.web.MockServletContext
 import org.springframework.web.context.support.XmlWebApplicationContext
 
+import java.lang.reflect.Modifier
+
 class GenerateDocs {
     static def javadocParser;
     static HashMultimap<String, Record> plugins = HashMultimap.create()
@@ -266,17 +268,19 @@ class GenerateDocs {
     private static Collection<Detail> findAllAttributes(Class cls, String beanName) {
         def details = []
         ParserUtils.getAllAttributes(cls).each { att ->
-            def desc = cleanUpCodeTags(javadocParser.findFieldDescription(beanName, cls, att))
-            def required = att.getAnnotation(HasDefaultValue.class) == null
-            def annotations = att.getAnnotations().collect { it.toString() }
-            def rec = new Detail([
-                    title      : att.name,
-                    desc       : desc,
-                    required   : required,
-                    annotations: annotations
-            ])
+            if (!Modifier.isStatic(att.getModifiers())) {
+                def desc = cleanUpCodeTags(javadocParser.findFieldDescription(beanName, cls, att))
+                def required = att.getAnnotation(HasDefaultValue.class) == null
+                def annotations = att.getAnnotations().collect { it.toString() }
+                def rec = new Detail([
+                        title      : att.name,
+                        desc       : desc,
+                        required   : required,
+                        annotations: annotations
+                ])
 
-            details << rec
+                details << rec
+            }
         }
         details.sort({ a, b -> a.title <=> b.title })
         return details

--- a/examples/src/test/java/org/mapfish/print/ExamplesTest.java
+++ b/examples/src/test/java/org/mapfish/print/ExamplesTest.java
@@ -43,11 +43,11 @@ import static org.mapfish.print.servlet.MapPrinterServlet.JSON_REQUEST_HEADERS;
 
 /**
  * To run this test make sure that the test GeoServer is running:
- * <p></p>
+ *
  * ./gradlew examples:farmRun
- * <p></p>
+ *
  * Or run the tests with the following task (which automatically starts the server):
- * <p></p>
+ *
  * ./gradlew examples:farmIntegrationTest
  */
 @RunWith(SpringJUnit4ClassRunner.class)


### PR DESCRIPTION
A few fronts:
* have javadoc warnings treated as errors
* fix the javadoc warnings
* for not going mad, disable the mandatory javadoc on constants
* remove the error message about MANIFEST.MF not found when not in a
  real servlet
* remove the static fields from the input parameters documentation