### PR TITLE
Add missing jcenter repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ configure(subprojects.findAll { ['core', 'examples', 'docs'].contains(it.name) }
         mavenLocal()
         maven { url "http://download.osgeo.org/webdav/geotools" }
         mavenCentral()
+        jcenter()
         maven { url "https://dl.bintray.com/readytalk/maven" }
         maven { url "https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts" }
         maven { url "https://repo.boundlessgeo.com/main/" }


### PR DESCRIPTION
this PR fixes the dependencies if someone wants to develop locally. Useful for instance for `./gradlew tomcatRun` and similar