### PR TITLE
Upgrade geoserver/geotools maven repository locations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,12 +47,12 @@ task appRun(type: AppStartTask) {
 configure(subprojects.findAll { ['core', 'examples', 'docs'].contains(it.name) }) {
     repositories {
         mavenLocal()
-        maven { url "http://download.osgeo.org/webdav/geotools" }
+        maven { url "https://repo.osgeo.org/repository/snapshot" }
         mavenCentral()
         jcenter()
         maven { url "https://dl.bintray.com/readytalk/maven" }
         maven { url "https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts" }
-        maven { url "https://repo.boundlessgeo.com/main/" }
+        maven { url "https://repo.osgeo.org/repository/release" }
         maven { url "https://jaspersoft.jfrog.io/jaspersoft/jr-ce-releases" }
     }
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'org.gretty'
 def geoserverVersion = "2.8.2"
 
 repositories {
-    maven { url 'http://repo.boundlessgeo.com/main' }
+    maven { url 'https://repo.osgeo.org/repository/release' }
     maven { url 'http://maven.restlet.org' }
     jcenter()
 }


### PR DESCRIPTION
repo.boundlessgeo.com is gone, canonical geotools and
geoserver maven repositories have moved to osgeo.