### PR TITLE
Upgrade geoserver/geotools maven repository locations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,14 @@ task appRun(type: AppStartTask) {
 configure(subprojects.findAll { ['core', 'examples', 'docs'].contains(it.name) }) {
     repositories {
         mavenLocal()
-        maven { url "http://download.osgeo.org/webdav/geotools" }
+        maven { url "https://repo.osgeo.org/repository/snapshot" }
         mavenCentral()
+        jcenter()
+        maven { url "https://mvnrepository.com/artifact/javax.media/jai_core" }
         maven { url "https://dl.bintray.com/readytalk/maven" }
-        maven { url "http://jaspersoft.artifactoryonline.com/jaspersoft/third-party-ce-artifacts" }
-        maven { url "https://repo.boundlessgeo.com/main/" }
-        maven { url "https://jaspersoft.artifactoryonline.com/jaspersoft/jr-ce-releases" }
+        maven { url "http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts" }
+        maven { url "https://repo.osgeo.org/repository/release" }
+        maven { url "https://jaspersoft.jfrog.io/jaspersoft/jr-ce-releases" }
         maven { url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/" }
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -90,7 +90,7 @@ build.dependsOn tasks.distZip, tasks.testCLI
 
 configurations {
     compile.transitive = true
-    compile.exclude module: 'jai_core'
+    compile.exclude module: 'jai-core'
 
     metrics {
         description = 'Libraries for measuring performance and load.  See http://metrics.codahale.com/'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'org.gretty'
 def geoserverVersion = "2.8.2"
 
 repositories {
-    maven { url 'http://repo.boundlessgeo.com/main' }
+    maven { url 'https://repo.osgeo.org/repository/release' }
     maven { url 'http://maven.restlet.org' }
     jcenter()
 }
@@ -19,7 +19,7 @@ dependencies {
 }
 
 configurations {
-    compile.exclude module: 'jai_core'
+    compile.exclude module: 'jai-core'
 
     // need to exclude those two to get rid of stuff taken from geotools dependencies (they break the tests)
     compile.exclude group: 'org.eclipse.emf', module: 'ecore'


### PR DESCRIPTION
repo.boundlessgeo.com is gone, canonical geotools and
geoserver maven repositories have moved to osgeo.