### PR TITLE
Configuration.java: Fix logging.

### DIFF
--- a/core/src/main/java/org/mapfish/print/config/Configuration.java
+++ b/core/src/main/java/org/mapfish/print/config/Configuration.java
@@ -318,7 +318,7 @@ public class Configuration implements ConfigurationObject {
             this.accessAssertion.assertAccess("Configuration", this);
             template.assertAccessible(name);
         } else {
-            LOGGER.warn("Template '%s' does not exist.  Options are: %s", name, this.templates.keySet());
+            LOGGER.warn("Template '{}' does not exist.  Options are: {}", name, this.templates.keySet());
         }
         return template;
     }


### PR DESCRIPTION
Replace `%s` with `{}`, wich is used in log4j.

Looks ugly and wrong: 
`22:32:54.142 [main] WARN  o.mapfish.print.config.Configuration - Template '%s' does not exist.  Options are: %s`

Now: 
`23:18:18.643 [main] WARN  o.mapfish.print.config.Configuration - Template 'Square' does not exist.  Options are: [A4 landscape, Auto tiling, Auto meta tiling]`
