### PR TITLE
Bump sprint to version 5.2.19

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -114,7 +114,7 @@ configurations {
 }
 
 ext {
-    springVersion = '5.2.2.RELEASE'
+    springVersion = '5.2.19.RELEASE'
 }
 
 dependencies {
@@ -127,8 +127,8 @@ dependencies {
             "org.springframework:spring-context:$springVersion",
             "org.springframework:spring-web:$springVersion",
             "org.springframework:spring-webmvc:$springVersion",
-            "org.springframework.security:spring-security-config:$springVersion",
-            "org.springframework.security:spring-security-web:$springVersion",
+            "org.springframework.security:spring-security-config:5.3.13.RELEASE",
+            "org.springframework.security:spring-security-web:5.3.13.RELEASE",
             'com.thetransactioncompany:cors-filter:2.10',
             // Hibernate & Postgres
             'org.hibernate:hibernate-core:5.6.7.Final',


### PR DESCRIPTION
See also:
https://tanzu.vmware.com/security/cve-2022-22965