### PR TITLE
Fix CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ allprojects {
     ext.junitVersion = "4.13.1"
     ext.groovyVersion = "3.0.7"
     ext.spotbugsVersion = '4.1.4'
-    ext.jasperreportVersion = "6.16.0"
+    ext.jasperreportVersion = "6.20.0"
 
     apply plugin: 'org.owasp.dependencycheck'
     dependencyCheck {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -118,7 +118,7 @@ ext {
 
 dependencies {
     def slf4jVersion = '1.7.36'
-    def metricsVersion = '4.1.33'
+    def metricsVersion = '4.2.10'
     def geotoolsVersion = '24.6'
     def logbackVersion = '1.2.11'
 
@@ -132,7 +132,7 @@ dependencies {
             // Hibernate & Postgres
             'org.hibernate:hibernate-core:5.4.33',
             'org.postgresql:postgresql:42.2.26',
-            'com.vladmihalcea:hibernate-types-52:2.10.4',
+            'com.vladmihalcea:hibernate-types-52:2.17.1',
             'com.mchange:c3p0:0.9.5.5',
             "org.springframework:spring-orm:$springVersion",
             "org.springframework:spring-jdbc:$springVersion",
@@ -176,14 +176,14 @@ dependencies {
             "ch.qos.logback:logback-classic:${logbackVersion}",
             "ch.qos.logback:logback-access:${logbackVersion}",
             'org.json:json:20201115',
-            'org.yaml:snakeyaml:1.27',
+            'org.yaml:snakeyaml:1.31',
             'com.github.spullara.cli-parser:cli-parser:1.1.6',
             'org.apache.httpcomponents:httpclient:4.5.13',
             'com.sun.mail:javax.mail:1.6.2',
-            'com.amazonaws:aws-java-sdk-s3:1.11.1034',
+            'com.amazonaws:aws-java-sdk-s3:1.12.317',
             'com.adobe.xmp:xmpcore:6.1.11',
-            'io.sentry:sentry-logback:4.1.0',
-            'net.logstash.logback:logstash-logback-encoder:6.6',
+            'io.sentry:sentry-logback:6.0.0',
+            'net.logstash.logback:logstash-logback-encoder:7.1',
     )
 
     compile(configurations.metrics) {
@@ -194,7 +194,7 @@ dependencies {
     compile(configurations.geotools)
     compile(configurations.jasper)
 
-    def batikVersion = '1.14'
+    def batikVersion = '1.15'
     compile(
             'org.apache.xmlgraphics:xmlgraphics-commons:2.6',
             "org.apache.xmlgraphics:batik-transcoder:$batikVersion",


### PR DESCRIPTION
    Upgrade com.amazonaws:aws-java-sdk-s3@1.11.1034 to com.amazonaws:aws-java-sdk-s3@1.12.317 to fix
    ✗ Directory Traversal [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMAMAZONAWS-2952700] in com.amazonaws:aws-java-sdk-s3@1.11.1034
      introduced by com.amazonaws:aws-java-sdk-s3@1.11.1034
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)
    ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)

    Upgrade com.puppycrawl.tools:checkstyle@7.8.2 to com.puppycrawl.tools:checkstyle@8.29 to fix
    ✗ XML External Entity (XXE) Injection [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMPUPPYCRAWLTOOLS-543266] in com.puppycrawl.tools:checkstyle@7.8.2
      introduced by com.puppycrawl.tools:checkstyle@7.8.2
    ✗ XML External Entity (XXE) Injection [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMPUPPYCRAWLTOOLS-173770] in com.puppycrawl.tools:checkstyle@7.8.2
      introduced by com.puppycrawl.tools:checkstyle@7.8.2
    ✗ Deserialization of Untrusted Data [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236] in com.google.guava:guava@21.0
      introduced by com.puppycrawl.tools:checkstyle@7.8.2 > com.google.guava:guava@21.0
    ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111] in commons-beanutils:commons-beanutils@1.9.3
      introduced by com.puppycrawl.tools:checkstyle@7.8.2 > commons-beanutils:commons-beanutils@1.9.3

    Upgrade com.vladmihalcea:hibernate-types-52@2.10.4 to com.vladmihalcea:hibernate-types-52@2.17.1 to fix
    ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)
    ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)

    Upgrade io.dropwizard.metrics:metrics-servlets@4.1.33 to io.dropwizard.metrics:metrics-servlets@4.2.10 to fix
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)
    ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)

    Upgrade io.sentry:sentry-logback@4.1.0 to io.sentry:sentry-logback@6.0.0 to fix
    ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327] in com.google.code.gson:gson@2.8.5
      introduced by io.sentry:sentry-logback@4.1.0 > io.sentry:sentry@4.1.0 > com.google.code.gson:gson@2.8.5

    Upgrade net.logstash.logback:logstash-logback-encoder@6.6 to net.logstash.logback:logstash-logback-encoder@7.1 to fix
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)
    ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)

    Upgrade net.sf.jasperreports:jasperreports@6.16.0 to net.sf.jasperreports:jasperreports@6.20.0 to fix
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)
    ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.12.0
      introduced by net.logstash.logback:logstash-logback-encoder@6.6 > com.fasterxml.jackson.core:jackson-databind@2.12.0 and 7 other path(s)

    Upgrade org.apache.xmlgraphics:batik-bridge@1.14 to org.apache.xmlgraphics:batik-bridge@1.15 to fix
    ✗ Server-side Request Forgery (SSRF) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031730] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)
    ✗ Server-side Request Forgery (SSRF) (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031728] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)
    ✗ Server-side Request Forgery (SSRF) (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031729] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)

    Upgrade org.apache.xmlgraphics:batik-codec@1.14 to org.apache.xmlgraphics:batik-codec@1.15 to fix
    ✗ Server-side Request Forgery (SSRF) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031730] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)
    ✗ Server-side Request Forgery (SSRF) (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031728] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)
    ✗ Server-side Request Forgery (SSRF) (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031729] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)

    Upgrade org.apache.xmlgraphics:batik-transcoder@1.14 to org.apache.xmlgraphics:batik-transcoder@1.15 to fix
    ✗ Server-side Request Forgery (SSRF) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031730] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)
    ✗ Server-side Request Forgery (SSRF) (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031728] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)
    ✗ Server-side Request Forgery (SSRF) (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3031729] in org.apache.xmlgraphics:batik-bridge@1.14
      introduced by org.apache.xmlgraphics:batik-bridge@1.14 and 2 other path(s)

    Upgrade org.postgresql:postgresql@42.2.26 to org.postgresql:postgresql@42.3.3 to fix
    ✗ Arbitrary Code Injection [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2401816] in org.postgresql:postgresql@42.2.26
      introduced by org.postgresql:postgresql@42.2.26

    Upgrade org.yaml:snakeyaml@1.27 to org.yaml:snakeyaml@1.31 to fix
    ✗ Stack-based Buffer Overflow [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3016891] in org.yaml:snakeyaml@1.27
      introduced by org.yaml:snakeyaml@1.27
    ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-2806360] in org.yaml:snakeyaml@1.27
      introduced by org.yaml:snakeyaml@1.27