### PR TITLE
Ignore CVE on check style

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,21 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-COMPUPPYCRAWLTOOLS-543266:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-COMPUPPYCRAWLTOOLS-173770:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-COMGOOGLEGUAVA-32236:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-COMMONSBEANUTILS-460111:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+patch: {}


### PR DESCRIPTION
     Upgrade com.puppycrawl.tools:checkstyle@7.8.2 to com.puppycrawl.tools:checkstyle@8.29 to fix
    ✗ XML External Entity (XXE) Injection [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMPUPPYCRAWLTOOLS-543266] in com.puppycrawl.tools:checkstyle@7.8.2
      introduced by com.puppycrawl.tools:checkstyle@7.8.2
    ✗ XML External Entity (XXE) Injection [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMPUPPYCRAWLTOOLS-173770] in com.puppycrawl.tools:checkstyle@7.8.2
      introduced by com.puppycrawl.tools:checkstyle@7.8.2
    ✗ Deserialization of Untrusted Data [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236] in com.google.guava:guava@21.0
      introduced by com.puppycrawl.tools:checkstyle@7.8.2 > com.google.guava:guava@21.0
    ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111] in commons-beanutils:commons-beanutils@1.9.3
      introduced by com.puppycrawl.tools:checkstyle@7.8.2 > commons-beanutils:commons-beanutils@1.9.3