### PR TITLE
Ignore CVE used in code style

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,20 +2,24 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-    SNYK-JAVA-COMPUPPYCRAWLTOOLS-543266:
-        - '*':
-              reason: Used in check style
-              created: 2022-10-06T13:13:54.748Z
-    SNYK-JAVA-COMPUPPYCRAWLTOOLS-173770:
-        - '*':
-              reason: Used in check style
-              created: 2022-10-06T13:13:54.748Z
-    SNYK-JAVA-COMGOOGLEGUAVA-32236:
-        - '*':
-              reason: Used in check style
-              created: 2022-10-06T13:13:54.748Z
-    SNYK-JAVA-COMMONSBEANUTILS-460111:
-        - '*':
-              reason: Used in check style
-              created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-COMPUPPYCRAWLTOOLS-543266:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-COMPUPPYCRAWLTOOLS-173770:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-COMGOOGLEGUAVA-32236:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-COMMONSBEANUTILS-460111:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-06T13:13:54.748Z
+  SNYK-JAVA-ORGAPACHECOMMONS-3043138:
+    - '*':
+        reason: Used in check style
+        created: 2022-10-18T05:49:44.892Z
 patch: {}


### PR DESCRIPTION
    Upgrade com.github.spotbugs:spotbugs@4.1.4 to com.github.spotbugs:spotbugs@4.7.3 to fix
    ✗ Arbitrary Code Execution (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-3043138] in org.apache.commons:commons-text@1.9
      introduced by com.github.spotbugs:spotbugs@4.1.4 > org.apache.commons:commons-text@1.9 and 1 other path(s)