### PR TITLE
Fix CVE

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -194,7 +194,7 @@ dependencies {
     compile(configurations.geotools)
     compile(configurations.jasper)
 
-    def batikVersion = '1.15'
+    def batikVersion = '1.16'
     compile(
             'org.apache.xmlgraphics:xmlgraphics-commons:2.6',
             "org.apache.xmlgraphics:batik-transcoder:$batikVersion",


### PR DESCRIPTION
    Upgrade org.apache.xmlgraphics:batik-bridge@1.15 to org.apache.xmlgraphics:batik-bridge@1.16 to fix
    ✗ Information Exposure (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3063442] in org.apache.xmlgraphics:batik-bridge@1.15
      introduced by org.apache.xmlgraphics:batik-bridge@1.15 and 2 other path(s)
    ✗ Remote Code Execution (RCE) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3063691] in org.apache.xmlgraphics:batik-script@1.15
      introduced by org.apache.xmlgraphics:batik-bridge@1.15 > org.apache.xmlgraphics:batik-script@1.15

    Upgrade org.apache.xmlgraphics:batik-codec@1.15 to org.apache.xmlgraphics:batik-codec@1.16 to fix
    ✗ Information Exposure (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3063442] in org.apache.xmlgraphics:batik-bridge@1.15
      introduced by org.apache.xmlgraphics:batik-bridge@1.15 and 2 other path(s)

    Upgrade org.apache.xmlgraphics:batik-transcoder@1.15 to org.apache.xmlgraphics:batik-transcoder@1.16 to fix
    ✗ Information Exposure (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-3063442] in org.apache.xmlgraphics:batik-bridge@1.15
      introduced by org.apache.xmlgraphics:batik-bridge@1.15 and 2 other path(s)