### PR TITLE
Fix CVE

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -196,7 +196,7 @@ dependencies {
 
     def batikVersion = '1.16'
     compile(
-            'org.apache.xmlgraphics:xmlgraphics-commons:2.6',
+            'org.apache.xmlgraphics:xmlgraphics-commons:2.8',
             "org.apache.xmlgraphics:batik-transcoder:$batikVersion",
             "org.apache.xmlgraphics:batik-bridge:$batikVersion",
             "org.apache.xmlgraphics:batik-codec:$batikVersion",


### PR DESCRIPTION
    Upgrade org.apache.xmlgraphics:xmlgraphics-commons@2.7 to org.apache.xmlgraphics:xmlgraphics-commons@2.8 to fix
    ✗ Directory Traversal [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109] in commons-io:commons-io@2.6
      introduced by org.apache.xmlgraphics:xmlgraphics-commons@2.7 > commons-io:commons-io@2.6 and 3 other path(s)