### PR TITLE
Revert "Use tomcat without critical errors reported by snyk."

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,6 +1,6 @@
 FROM mapfish_print_builder AS builder
 
-FROM tomcat:9.0.78-jdk11-temurin AS runner
+FROM tomcat:9.0.65-jdk11-openjdk-slim-bullseye AS runner
 LABEL maintainer="Camptocamp <info@camptocamp.com>"
 
 RUN perl -0777 -i -pe 's/(<Valve className="org.apache.catalina.valves.AccessLogValve"[^>]*>)/<Valve className="ch.qos.logback.access.tomcat.LogbackValve" quiet="true"\/>/s' "${CATALINA_HOME}/conf/server.xml" \


### PR DESCRIPTION
Reverts mapfish/mapfish-print#2989

Dangerous change that didn't solve any Snyk issue...