### PR TITLE
Fix CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     version = '1.0.0'
     ext.junitVersion = "4.13.2"
     ext.groovyVersion = "3.0.18"
-    ext.spotbugsVersion = '4.2.2'
+    ext.spotbugsVersion = '4.5.0'
     ext.jasperreportVersion = "6.20.5"
 
     apply plugin: 'org.owasp.dependencycheck'


### PR DESCRIPTION
    Upgrade com.github.spotbugs:spotbugs@4.2.2 to com.github.spotbugs:spotbugs@4.5.0 to fix
    ✗ Deserialization of Untrusted Data [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327] in com.google.code.gson:gson@2.8.6
      introduced by com.github.spotbugs:spotbugs@4.2.2 > com.google.code.gson:gson@2.8.6