### PR TITLE
Fix CVE

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -198,7 +198,7 @@ dependencies {
     compile(configurations.geotools)
     compile(configurations.jasper)
 
-    def batikVersion = '1.16'
+    def batikVersion = '1.17'
     compile(
             'org.apache.xmlgraphics:xmlgraphics-commons:2.8',
             "org.apache.xmlgraphics:batik-transcoder:$batikVersion",


### PR DESCRIPTION
    Upgrade org.apache.xmlgraphics:batik-bridge@1.16 to org.apache.xmlgraphics:batik-bridge@1.17 to fix
    ✗ Server-side Request Forgery (SSRF) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-5849961] in org.apache.xmlgraphics:batik-bridge@1.16
      introduced by org.apache.xmlgraphics:batik-bridge@1.16 and 2 other path(s)

    Upgrade org.apache.xmlgraphics:batik-codec@1.16 to org.apache.xmlgraphics:batik-codec@1.17 to fix
    ✗ Server-side Request Forgery (SSRF) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-5849961] in org.apache.xmlgraphics:batik-bridge@1.16
      introduced by org.apache.xmlgraphics:batik-bridge@1.16 and 2 other path(s)

    Upgrade org.apache.xmlgraphics:batik-transcoder@1.16 to org.apache.xmlgraphics:batik-transcoder@1.17 to fix
    ✗ Server-side Request Forgery (SSRF) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-5849961] in org.apache.xmlgraphics:batik-bridge@1.16
      introduced by org.apache.xmlgraphics:batik-bridge@1.16 and 2 other path(s)