### PR TITLE
Update geotools dependencies to current release

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -163,14 +163,14 @@ dependencies {
             "io.dropwizard.metrics:metrics-logback:4.2.19",
     )
     geotools(
-            "org.geotools:gt-epsg-hsql:30-SNAPSHOT",
-            "org.geotools:gt-render:30-SNAPSHOT",
-            "org.geotools:gt-geojson:30-SNAPSHOT",
-            "org.geotools:gt-geotiff:30-SNAPSHOT",
-            "org.geotools:gt-wms:30-SNAPSHOT",
-            "org.geotools.xsd:gt-xsd-gml3:30-SNAPSHOT",
-            "org.geotools:gt-svg:30-SNAPSHOT",
-            "org.geotools:gt-cql:30-SNAPSHOT"
+            "org.geotools:gt-epsg-hsql:31-SNAPSHOT",
+            "org.geotools:gt-render:31-SNAPSHOT",
+            "org.geotools:gt-geojson:31-SNAPSHOT",
+            "org.geotools:gt-geotiff:31-SNAPSHOT",
+            "org.geotools:gt-wms:31-SNAPSHOT",
+            "org.geotools.xsd:gt-xsd-gml3:31-SNAPSHOT",
+            "org.geotools:gt-svg:31-SNAPSHOT",
+            "org.geotools:gt-cql:31-SNAPSHOT"
     )
     jasper(
             "net.sf.jasperreports:jasperreports:6.20.5",


### PR DESCRIPTION
This is a somewhat speculative change to fix the broken CI for GeoTools.