### PR TITLE
Fix CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     version = '1.0.0'
     ext.junitVersion = "4.13.2"
     ext.groovyVersion = "3.0.19"
-    ext.spotbugsVersion = '4.5.3'
+    ext.spotbugsVersion = '4.8.0'
     ext.jasperreportVersion = "6.20.5"
 
     apply plugin: 'org.owasp.dependencycheck'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -179,7 +179,7 @@ dependencies {
             "org.slf4j:jul-to-slf4j:${slf4jVersion}",
             "ch.qos.logback:logback-classic:${logbackVersion}",
             "ch.qos.logback:logback-access:${logbackVersion}",
-            'org.json:json:20230227',
+            'org.json:json:20231013',
             'org.yaml:snakeyaml:2.0',
             'com.github.spullara.cli-parser:cli-parser:1.1.6',
             'org.apache.httpcomponents:httpclient:4.5.14',


### PR DESCRIPTION
    Upgrade com.github.spotbugs:spotbugs@4.5.3 to com.github.spotbugs:spotbugs@4.8.0 to fix
    ✗ Out-of-bounds Write [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEBCEL-3106013] in org.apache.bcel:bcel@6.5.0
      introduced by com.github.spotbugs:spotbugs@4.5.3 > org.apache.bcel:bcel@6.5.0

    Upgrade io.sentry:sentry-logback@6.0.0 to io.sentry:sentry-logback@6.25.2 to fix

    Upgrade org.hibernate:hibernate-core@5.4.33 to org.hibernate:hibernate-core@6.0.0.Final to fix

    Upgrade org.json:json@20230227 to org.json:json@20231013 to fix
    ✗ Allocation of Resources Without Limits or Throttling (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-5962464] in org.json:json@20230227
      introduced by org.json:json@20230227