### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -3,6 +3,6 @@ pip>=21.1 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.5 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography>=39.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=41.0.6 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
 pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
    Upgrade cryptography@41.0.5 to cryptography@41.0.6 to fix
    ✗ NULL Pointer Dereference (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6092044] in cryptography@41.0.5
      introduced by cryptography@41.0.5 and 4 other path(s)