### PR TITLE
Fix CVE

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -184,7 +184,7 @@ dependencies {
             'com.github.spullara.cli-parser:cli-parser:1.1.6',
             'org.apache.httpcomponents:httpclient:4.5.14',
             'com.sun.mail:javax.mail:1.6.2',
-            'com.amazonaws:aws-java-sdk-s3:1.12.629',
+            'com.amazonaws:aws-java-sdk-s3:1.12.639',
             'com.adobe.xmp:xmpcore:6.1.11',
             'io.sentry:sentry-logback:6.25.2',
             'net.logstash.logback:logstash-logback-encoder:7.1.1',


### PR DESCRIPTION
    Upgrade com.amazonaws:aws-java-sdk-s3@1.12.629 to com.amazonaws:aws-java-sdk-s3@1.12.639 to fix
    ✗ Allocation of Resources Without Limits or Throttling (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-SOFTWAREAMAZONION-6153869] in software.amazon.ion:ion-java@1.0.2
      introduced by com.amazonaws:aws-java-sdk-s3@1.12.629 > com.amazonaws:aws-java-sdk-core@1.12.629 > software.amazon.ion:ion-java@1.0.2