### PR TITLE
[Security] Raise exception on IOException on StreamRepositoryService

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -3,6 +3,8 @@
 ## Version 3.31
 
 - `HumanAlphaSerie` is moved from package `org.mapfish.print` to `org.mapfish.print.jasperreports`.
+- Rather than returning `null` when we fail to get a Resource from the JasperReport, we now throw
+  the exception (wrapped in a `RuntimeException`).
 
 ## Version 3.30
 

--- a/core/src/main/java/org/mapfish/print/output/MapfishPrintRepositoryService.java
+++ b/core/src/main/java/org/mapfish/print/output/MapfishPrintRepositoryService.java
@@ -46,7 +46,7 @@ class MapfishPrintRepositoryService implements StreamRepositoryService {
           this.httpRequestFactory.createRequest(uri, HttpMethod.GET).execute();
       return new ResponseClosingStream(response);
     } catch (IOException e) {
-      return null;
+      throw new RuntimeException(String.format("Error on getting resource '%s'", uriString), e);
     }
   }
 


### PR DESCRIPTION
The old code can be a security issue because the JasperReport will try to get the recourse by other way when we return null.