### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,7 +1,7 @@
-c2cciutils[checks,publish]==1.4.13
+c2cciutils[checks,publish]==1.4.15
 attrs>=22.2.0 # because c2cciutils 1.4.12 does not work with 19.3
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography>=39.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=42.0.2 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.17 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
    Upgrade cryptography@41.0.7 to cryptography@42.0.2 to fix
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6050294] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ Information Exposure [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6126975] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ Use of a Broken or Risky Cryptographic Algorithm (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6149518] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ Uncontrolled Resource Consumption ('Resource Exhaustion') (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6157248] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ NULL Pointer Dereference (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6210214] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)