### PR TITLE
Fix CVE

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -127,8 +127,8 @@ dependencies {
             "org.springframework:spring-context:$springVersion",
             "org.springframework:spring-web:$springVersion",
             "org.springframework:spring-webmvc:$springVersion",
-            "org.springframework.security:spring-security-config:5.5.8",
-            "org.springframework.security:spring-security-web:5.5.8",
+            "org.springframework.security:spring-security-config:5.7.12",
+            "org.springframework.security:spring-security-web:5.7.12",
             'com.thetransactioncompany:cors-filter:2.10',
             // Hibernate & Postgres
             'org.hibernate:hibernate-core:5.6.15.Final',


### PR DESCRIPTION
    Upgrade org.springframework.security:spring-security-config@5.5.8 to org.springframework.security:spring-security-config@5.7.12 to fix
    ✗ Improper Access Control (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293] in org.springframework.security:spring-security-core@5.5.8
      introduced by org.springframework.security:spring-security-config@5.5.8 > org.springframework.security:spring-security-core@5.5.8 and 1 other path(s)

    Upgrade org.springframework.security:spring-security-web@5.5.8 to org.springframework.security:spring-security-web@5.7.12 to fix
    ✗ Improper Access Control (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293] in org.springframework.security:spring-security-core@5.5.8
      introduced by org.springframework.security:spring-security-config@5.5.8 > org.springframework.security:spring-security-core@5.5.8 and 1 other path(s)