### PR TITLE
Codebase cleanup. Bug fixes

### DIFF
--- a/core/src/main/java/org/mapfish/print/FontTools.java
+++ b/core/src/main/java/org/mapfish/print/FontTools.java
@@ -64,7 +64,7 @@ public final class FontTools {
 
         inputStreamReader = new InputStreamReader(process.getInputStream(), "utf-8");
         stdInput = new BufferedReader(inputStreamReader);
-        String inputLine = null;
+        String inputLine;
         FontConfigDescription description = null;
         while ((inputLine = stdInput.readLine()) != null) {
           if (inputLine.startsWith("Pattern ")) {

--- a/core/src/main/java/org/mapfish/print/attribute/DataSourceAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/DataSourceAttribute.java
@@ -115,8 +115,7 @@ public final class DataSourceAttribute implements Attribute {
     for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
       Attribute attribute = entry.getValue();
       if (attribute == null) {
-        final String msg =
-            "Attribute: '" + entry.getKey() + "' is not an attribute. It is a: " + null;
+        final String msg = "Attribute: '" + entry.getKey() + "' is not a defined attribute.";
         LOGGER.error("Error setting the Attributes: {}", msg);
         throw new IllegalArgumentException(msg);
       } else {

--- a/core/src/main/java/org/mapfish/print/attribute/DataSourceAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/DataSourceAttribute.java
@@ -113,14 +113,14 @@ public final class DataSourceAttribute implements Attribute {
    */
   public void setAttributes(final Map<String, Attribute> attributes) {
     for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
-      Object attribute = entry.getValue();
-      if (!(attribute instanceof Attribute)) {
+      Attribute attribute = entry.getValue();
+      if (attribute == null) {
         final String msg =
-            "Attribute: '" + entry.getKey() + "' is not an attribute. It is a: " + attribute;
+            "Attribute: '" + entry.getKey() + "' is not an attribute. It is a: " + null;
         LOGGER.error("Error setting the Attributes: {}", msg);
         throw new IllegalArgumentException(msg);
       } else {
-        ((Attribute) attribute).setConfigName(entry.getKey());
+        attribute.setConfigName(entry.getKey());
       }
     }
     this.attributes = attributes;

--- a/core/src/main/java/org/mapfish/print/attribute/NorthArrowAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/NorthArrowAttribute.java
@@ -69,7 +69,7 @@ public class NorthArrowAttribute
   }
 
   /** The value of {@link NorthArrowAttribute}. */
-  public class NorthArrowAttributeValues {
+  public static class NorthArrowAttributeValues {
 
     private static final String DEFAULT_BACKGROUND_COLOR = "rgba(255, 255, 255, 0)";
 

--- a/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/ReflectiveAttribute.java
@@ -376,7 +376,7 @@ public abstract class ReflectiveAttribute<VALUE> implements Attribute {
       json.value(valueToAdd);
     }
     if (type.isArray()) {
-      json.key(JSON_ATTRIBUTE_IS_ARRAY).value(type.isArray());
+      json.key(JSON_ATTRIBUTE_IS_ARRAY).value(true);
     }
 
     json.endObject();

--- a/core/src/main/java/org/mapfish/print/attribute/ScalebarAttribute.java
+++ b/core/src/main/java/org/mapfish/print/attribute/ScalebarAttribute.java
@@ -96,7 +96,7 @@ public class ScalebarAttribute
   }
 
   /** The value of {@link ScalebarAttribute}. */
-  public class ScalebarAttributeValues {
+  public static class ScalebarAttributeValues {
 
     private static final int DEFAULT_INTERVALS = 3;
     private static final String DEFAULT_FONT = "Helvetica";

--- a/core/src/main/java/org/mapfish/print/config/Template.java
+++ b/core/src/main/java/org/mapfish/print/config/Template.java
@@ -133,8 +133,7 @@ public class Template implements ConfigurationObject, HasConfiguration {
     for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
       Attribute attribute = entry.getValue();
       if (attribute == null) {
-        final String msg =
-            "Attribute: '" + entry.getKey() + "' is not an attribute. It is a: " + null;
+        final String msg = "Attribute: '" + entry.getKey() + "' is not a defined attribute";
         LOGGER.error("Error setting the Attributes: {}", msg);
         throw new IllegalArgumentException(msg);
       } else {
@@ -169,8 +168,8 @@ public class Template implements ConfigurationObject, HasConfiguration {
   private void assertProcessors(final List<Processor> processorsToCheck) {
     for (Processor entry : processorsToCheck) {
       if (entry == null) {
-        final String msg = "Processor: " + null + " is not a processor.";
-        LOGGER.error("Error in the processors to check while setting the Attributes:  {}", msg);
+        final String msg = "Processor is missing.";
+        LOGGER.error("Error in the processors to check while setting the Attributes: {}", msg);
         throw new IllegalArgumentException(msg);
       }
     }

--- a/core/src/main/java/org/mapfish/print/config/Template.java
+++ b/core/src/main/java/org/mapfish/print/config/Template.java
@@ -131,14 +131,14 @@ public class Template implements ConfigurationObject, HasConfiguration {
    */
   public final void setAttributes(final Map<String, Attribute> attributes) {
     for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
-      Object attribute = entry.getValue();
-      if (!(attribute instanceof Attribute)) {
+      Attribute attribute = entry.getValue();
+      if (attribute == null) {
         final String msg =
-            "Attribute: '" + entry.getKey() + "' is not an attribute. It is a: " + attribute;
+            "Attribute: '" + entry.getKey() + "' is not an attribute. It is a: " + null;
         LOGGER.error("Error setting the Attributes: {}", msg);
         throw new IllegalArgumentException(msg);
       } else {
-        ((Attribute) attribute).setConfigName(entry.getKey());
+        attribute.setConfigName(entry.getKey());
       }
     }
     this.attributes = attributes;
@@ -168,9 +168,9 @@ public class Template implements ConfigurationObject, HasConfiguration {
 
   private void assertProcessors(final List<Processor> processorsToCheck) {
     for (Processor entry : processorsToCheck) {
-      if (!(entry instanceof Processor)) {
-        final String msg = "Processor: " + entry + " is not a processor.";
-        LOGGER.error("Error setting the Attributes: {}", msg);
+      if (entry == null) {
+        final String msg = "Processor: " + null + " is not a processor.";
+        LOGGER.error("Error in the processors to check while setting the Attributes:  {}", msg);
         throw new IllegalArgumentException(msg);
       }
     }

--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -113,7 +113,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
     public InetAddress[] resolve(final String host) throws UnknownHostException {
       final List<InetAddress> list = Arrays.asList(super.resolve(host));
       Collections.shuffle(list);
-      return list.toArray(new InetAddress[list.size()]);
+      return list.toArray(new InetAddress[0]);
     }
   }
 

--- a/core/src/main/java/org/mapfish/print/map/geotools/grid/GridLabelFormat.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/grid/GridLabelFormat.java
@@ -32,7 +32,7 @@ public abstract class GridLabelFormat {
 
   /** Label format where value and unit are formatted at once. */
   public static class Simple extends GridLabelFormat {
-    private String labelFormat = null;
+    private final String labelFormat;
 
     /**
      * Constructor.
@@ -77,7 +77,7 @@ public abstract class GridLabelFormat {
 
     @Override
     public final String format(final double value, final String unit) {
-      DecimalFormat decimalFormat = null;
+      DecimalFormat decimalFormat;
 
       if (this.formatDecimalSeparator != null || this.formatGroupingSeparator != null) {
         // if custom separator characters are given, use them to create the format

--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -88,7 +88,7 @@ public final class WmsUtilities {
     return URIUtils.addParams(getMapUri, extraParams, Collections.emptySet());
   }
 
-  private static URL getUrl(URI commonURI) throws MalformedURLException {
+  private static URL getUrl(final URI commonURI) throws MalformedURLException {
     if (commonURI == null || commonURI.getAuthority() == null) {
       throw new RuntimeException("Invalid WMS URI: " + commonURI);
     }

--- a/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
+++ b/core/src/main/java/org/mapfish/print/map/image/wms/WmsUtilities.java
@@ -4,10 +4,10 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.awt.Dimension;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,21 +52,7 @@ public final class WmsUtilities {
       final double angle,
       final ReferencedEnvelope bounds)
       throws FactoryException, URISyntaxException, IOException {
-    if (commonURI == null || commonURI.getAuthority() == null) {
-      throw new RuntimeException("Invalid WMS URI: " + commonURI);
-    }
-    String[] authority = commonURI.getAuthority().split(":");
-    URL url;
-    if (authority.length == 2) {
-      url =
-          new URL(
-              commonURI.getScheme(),
-              authority[0],
-              Integer.parseInt(authority[1]),
-              commonURI.getPath());
-    } else {
-      url = new URL(commonURI.getScheme(), authority[0], commonURI.getPath());
-    }
+    URL url = getUrl(commonURI);
     final GetMapRequest getMapRequest =
         WmsVersion.lookup(wmsLayerParam.version).getGetMapRequest(url);
     getMapRequest.setBBox(bounds);
@@ -86,7 +72,7 @@ public final class WmsUtilities {
 
     Multimap<String, String> extraParams = HashMultimap.create();
     if (commonURI.getQuery() != null) {
-      for (NameValuePair pair : URLEncodedUtils.parse(commonURI, Charset.forName("UTF-8"))) {
+      for (NameValuePair pair : URLEncodedUtils.parse(commonURI, StandardCharsets.UTF_8)) {
         extraParams.put(pair.getName(), pair.getValue());
       }
     }
@@ -100,6 +86,25 @@ public final class WmsUtilities {
       }
     }
     return URIUtils.addParams(getMapUri, extraParams, Collections.emptySet());
+  }
+
+  private static URL getUrl(URI commonURI) throws MalformedURLException {
+    if (commonURI == null || commonURI.getAuthority() == null) {
+      throw new RuntimeException("Invalid WMS URI: " + commonURI);
+    }
+    String[] authority = commonURI.getAuthority().split(":");
+    URL url;
+    if (authority.length == 2) {
+      url =
+          new URL(
+              commonURI.getScheme(),
+              authority[0],
+              Integer.parseInt(authority[1]),
+              commonURI.getPath());
+    } else {
+      url = new URL(commonURI.getScheme(), authority[0], commonURI.getPath());
+    }
+    return url;
   }
 
   private static void addDpiParam(
@@ -117,7 +122,7 @@ public final class WmsUtilities {
         break;
       case GEOSERVER:
         if (!contains(extraParams, FORMAT_OPTIONS)) {
-          extraParams.put(FORMAT_OPTIONS, "dpi:" + Integer.toString(dpi));
+          extraParams.put(FORMAT_OPTIONS, "dpi:" + dpi);
         } else if (!isDpiSet(extraParams)) {
           setDpiValue(extraParams, dpi);
         }
@@ -131,12 +136,6 @@ public final class WmsUtilities {
       final Multimap<String, String> extraParams, final double angle, final ServerType type) {
     switch (type) {
       case MAPSERVER:
-        if (!contains(extraParams, "ANGLE")) {
-          extraParams.put("ANGLE", Double.toString(Math.toDegrees(angle)));
-        }
-        break;
-      case QGISSERVER:
-        break;
       case GEOSERVER:
         if (!contains(extraParams, "ANGLE")) {
           extraParams.put("ANGLE", Double.toString(Math.toDegrees(angle)));
@@ -179,7 +178,7 @@ public final class WmsUtilities {
         List<String> newValues = new ArrayList<>();
         for (String value : values) {
           if (!StringUtils.isEmpty(value)) {
-            value += ";dpi:" + Integer.toString(dpi);
+            value += ";dpi:" + dpi;
             newValues.add(value);
           }
         }

--- a/core/src/main/java/org/mapfish/print/map/style/json/MapfishJsonStyleVersion2.java
+++ b/core/src/main/java/org/mapfish/print/map/style/json/MapfishJsonStyleVersion2.java
@@ -27,7 +27,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 public final class MapfishJsonStyleVersion2 {
   static final String JSON_SYMB = "symbolizers";
   private static final String JSON_TYPE = "type";
-  private static final Pattern VALUE_EXPR_PATTERN = Pattern.compile("\\$\\{([\\w\\d_-]+)\\}");
+  private static final Pattern VALUE_EXPR_PATTERN = Pattern.compile("\\$\\{([\\w_-]+)\\}");
   private static final String JSON_MIN_SCALE = "minScale";
   private static final String JSON_MAX_SCALE = "maxScale";
   private static final String JSON_FILTER_INCLUDE = "*";

--- a/core/src/main/java/org/mapfish/print/map/tiled/TilePreparationTask.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/TilePreparationTask.java
@@ -166,24 +166,18 @@ public final class TilePreparationTask implements Callable<TilePreparationInfo> 
                   }
                 } else {
                   if (LOGGER.isDebugEnabled()) {
-                    if (tileBounds != null && tileCacheBounds != null) {
-                      LOGGER.debug(
-                          "Tile '{}' bounds [{}, {}, {}, {}]  out of tile cache bounds [{}, {}, {},"
-                              + " {}]",
-                          tileRequest == null ? "-" : tileRequest.getURI(),
-                          tileBounds.getMinX(),
-                          tileBounds.getMinY(),
-                          tileBounds.getMaxX(),
-                          tileBounds.getMaxY(),
-                          tileCacheBounds.getMinX(),
-                          tileCacheBounds.getMinY(),
-                          tileCacheBounds.getMaxX(),
-                          tileCacheBounds.getMaxY());
-                    } else {
-                      LOGGER.debug(
-                          "Tile '{}' with missing bounds.",
-                          tileRequest == null ? "-" : tileRequest.getURI());
-                    }
+                    LOGGER.debug(
+                        "Tile '{}' bounds [{}, {}, {}, {}]  out of tile cache bounds [{}, {}, {},"
+                            + " {}]",
+                        tileRequest.getURI(),
+                        tileBounds.getMinX(),
+                        tileBounds.getMinY(),
+                        tileBounds.getMaxX(),
+                        tileBounds.getMaxY(),
+                        tileCacheBounds.getMinX(),
+                        tileCacheBounds.getMinY(),
+                        tileCacheBounds.getMaxX(),
+                        tileCacheBounds.getMaxY());
                   }
                 }
               }

--- a/core/src/main/java/org/mapfish/print/processor/map/CreateMapPagesProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/CreateMapPagesProcessor.java
@@ -199,7 +199,7 @@ public class CreateMapPagesProcessor
     }
     LOGGER.info("Paging generate {} maps definitions.", mapList.size());
     DataSourceAttributeValue datasourceAttributes = new DataSourceAttributeValue();
-    datasourceAttributes.attributesValues = mapList.toArray(new Map[mapList.size()]);
+    datasourceAttributes.attributesValues = mapList.toArray(new Map[0]);
     return new Output(datasourceAttributes);
   }
 

--- a/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
+++ b/core/src/main/java/org/mapfish/print/processor/map/scalebar/ScalebarGraphic.java
@@ -450,7 +450,7 @@ public class ScalebarGraphic {
     settings.setPadding(getPadding(settings));
 
     // start the rendering
-    File path = null;
+    File path;
     if (template.getConfiguration().renderAsSvg(scalebarParams.renderAsSvg)) {
       // render scalebar as SVG
       final SVGGraphics2D graphics2D =

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/RegistryJobQueue.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/RegistryJobQueue.java
@@ -217,7 +217,7 @@ public class RegistryJobQueue implements JobQueue {
       PrintJobStatus.Status status = PrintJobStatus.Status.valueOf(metadata.getString(JSON_STATUS));
 
       PJsonObject requestData = new PJsonObject(metadata.getJSONObject(JSON_REQUEST_DATA), "spec");
-      Long startTime = metadata.getLong(JSON_START_DATE);
+      long startTime = metadata.getLong(JSON_START_DATE);
       long requestCount = metadata.getLong(JSON_REQUEST_COUNT);
 
       JSONObject accessJSON = metadata.getJSONObject(JSON_ACCESS_ASSERTION);

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/AccessAssertionUserType.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/AccessAssertionUserType.java
@@ -26,7 +26,7 @@ public class AccessAssertionUserType implements UserType {
   @Override
   public final Object deepCopy(final Object value) {
     if (value == null) {
-      return value;
+      return null;
     }
     return ((AccessAssertion) value).copy();
   }

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernateReportLoader.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/HibernateReportLoader.java
@@ -19,7 +19,7 @@ public class HibernateReportLoader implements ReportLoader {
 
   @Override
   @Transactional
-  public final void loadReport(final URI reportURI, final OutputStream out) throws IOException {
+  public void loadReport(final URI reportURI, final OutputStream out) throws IOException {
     out.write(this.dao.getResult(reportURI).getData());
   }
 }

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/PJsonObjectUserType.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/hibernate/PJsonObjectUserType.java
@@ -26,7 +26,7 @@ public class PJsonObjectUserType implements UserType {
   @Override
   public final Object deepCopy(final Object value) {
     if (value == null) {
-      return value;
+      return null;
     } else {
       try {
         return new PJsonObject(

--- a/core/src/main/java/org/mapfish/print/wrapper/multi/PMultiObject.java
+++ b/core/src/main/java/org/mapfish/print/wrapper/multi/PMultiObject.java
@@ -135,7 +135,7 @@ public class PMultiObject extends PAbstractObject {
     if (results.size() == 1) {
       return results.get(0);
     }
-    return new PMultiObject(results.toArray(new PObject[results.size()]));
+    return new PMultiObject(results.toArray(new PObject[0]));
   }
 
   @Override


### PR DESCRIPTION
1. Avoid running testpdfA twice. Introduce new list to validate pdfs.
2. Fix bug stopping method from being transactional
3. Make inner classes static to avoid memory leaks
4. Improve logging messages
5. Improve performance using empty arrays. Also remove data race risk between the size and toArray calls
6. Remove dead code