### PR TITLE
Fix spelling and grammar issues in docs and source code comments

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/jasper/DataSourceProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/jasper/DataSourceProcessor.java
@@ -44,7 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * <p>The {@link org.mapfish.print.attribute.DataSourceAttribute.DataSourceAttributeValue} has an
  * array of maps, each map in the array equates to a row in the Jasper DataSource.
  *
- * <p>The DataSourceProcessor can be configured with processors which will be used to transform each
+ * <p>The DataSourceProcessor can be configured with processors that will be used to transform each
  * map in the input array before constructing the final DataSource row.
  *
  * <p>For example, each map in the array could be {@link

--- a/docs/src/main/resources/templates/api.html
+++ b/docs/src/main/resources/templates/api.html
@@ -106,7 +106,7 @@
   </ul>
 
   <p>
-    If the report must sent by email and the feature is enabled in the app, a <code>smtp</code> property
+    If the report must be sent by email and the feature is enabled in the app, an <code>smtp</code> property
     looking like that (<code>subject</code> and <code>body</code> are optional) must be added to the request:
   </p>
   <div class="highlight">

--- a/docs/src/main/resources/templates/download.html
+++ b/docs/src/main/resources/templates/download.html
@@ -15,15 +15,15 @@
 </p>
 
 <h4 id="cli">
-  Command Line Distribution <a class="headerlink" href="#cli" title="Permalink to this headline">¶</a>
+  Command-Line Distribution <a class="headerlink" href="#cli" title="Permalink to this headline">¶</a>
 </h4>
 <p>
-  The Zip file and the Tar file are Mapfish Print distributed as an application that can be ran from the
-  commandline to execute print jobs. It is useful for debugging print configurations and requests.
+  The Zip file and the Tar file are Mapfish Print distributed as an application that can be run from the
+  command-line to execute print jobs. It is useful for debugging print configurations and requests.
 </p>
 <p>
   Assuming you have Java 7+ installed, the <code>bin/print</code> script will execute a print task. The
-  command line usage can be printed by executing: <code>bin/print -?</code>.
+  command-line usage can be printed by executing: <code>bin/print -?</code>.
 </p>
 <p>
   An example of using the application is:

--- a/docs/src/main/resources/templates/index.html
+++ b/docs/src/main/resources/templates/index.html
@@ -3,9 +3,9 @@
   them.
 </p>
 <p>
-  The project is a Java based servlet/library/application based on the mature
+  The project is a Java-based servlet/library/application based on the mature
   <a href="https://community.jaspersoft.com/project/jasperreports-library" target="_blank" rel="noopener"
-    >Jasper Reports Library</a
+    >JasperReports Library</a
   >.
 </p>
 <div class="admonition note examples">
@@ -33,7 +33,7 @@
   </li>
 
   <li>
-    The last distribution is an command-line application where the reports can be generated via command line.
+    The last distribution is a command-line application where the reports can be generated via command-line.
     This is useful for debugging configurations and requests.
   </li>
 </ul>


### PR DESCRIPTION
These changes harmonize and fix some spellings to improve readability and accuracy in several documentation files and comments.