### PR TITLE
Close resources to stop Apache lib from pending

### DIFF
--- a/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingHttpRequestFactory.java
+++ b/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingHttpRequestFactory.java
@@ -54,7 +54,9 @@ public final class ConfigFileResolvingHttpRequestFactory implements MfClientHttp
   }
 
   @Override
-  public ClientHttpRequest createRequest(final URI uri, final HttpMethod httpMethod) {
+  @Nonnull
+  public ClientHttpRequest createRequest(
+      @Nonnull final URI uri, @Nonnull final HttpMethod httpMethod) {
     return new ConfigFileResolvingRequest(this, uri, httpMethod);
   }
 

--- a/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingHttpRequestFactory.java
+++ b/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingHttpRequestFactory.java
@@ -14,7 +14,7 @@ import org.springframework.http.client.ClientHttpRequest;
  * This request factory will attempt to load resources using {@link
  * org.mapfish.print.config.Configuration#loadFile(String)} and {@link
  * org.mapfish.print.config.Configuration#isAccessible(String)} to load the resources if the http
- * method is GET and will fallback to the normal/wrapped factory to make http requests.
+ * method is GET and will fall back to the normal/wrapped factory to make http requests.
  */
 public final class ConfigFileResolvingHttpRequestFactory implements MfClientHttpRequestFactory {
   private final Configuration config;
@@ -22,6 +22,7 @@ public final class ConfigFileResolvingHttpRequestFactory implements MfClientHttp
   private final MfClientHttpRequestFactoryImpl httpRequestFactory;
   private final List<RequestConfigurator> callbacks = new CopyOnWriteArrayList<>();
 
+  /** Maximum number of attempts to try to fetch the same http request in case it is failing. */
   @Value("${httpRequest.fetchRetry.maxNumber}")
   private int httpRequestMaxNumberFetchRetry;
 

--- a/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingRequest.java
+++ b/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingRequest.java
@@ -141,16 +141,28 @@ final class ConfigFileResolvingRequest extends AbstractClientHttpRequest {
   }
 
   private ClientHttpResponse doHttpRequestWithRetry(final HttpHeaders headers) throws IOException {
-    AtomicInteger counter = new AtomicInteger();
+    final AtomicInteger counter = new AtomicInteger();
     do {
       logFetchingURIResource(headers);
       try {
-        ClientHttpResponse response = attemptToFetchResponse(headers, counter);
+        ClientHttpResponse response = attemptToFetchResponse(headers);
         if (response != null) {
           return response;
+        } else {
+          if (canRetry(counter)) {
+            sleepWithExceptionHandling();
+            LOGGER.debug("Retry fetching {}", this.getURI());
+          } else {
+            PrintException printException = new PrintException("Failed fetching " + getURI());
+            LOGGER.debug("Throwing exception since it cannot retry.", printException);
+            throw printException;
+          }
         }
       } catch (final IOException e) {
         handleIOException(e, counter);
+      } catch (final RuntimeException e) {
+        // handle other exceptions
+        handleIOException(new IOException(e), counter);
       }
     } while (true);
   }
@@ -158,38 +170,33 @@ final class ConfigFileResolvingRequest extends AbstractClientHttpRequest {
   private void logFetchingURIResource(final HttpHeaders headers) {
     // Display headers, one by line <name>: <value>
     LOGGER.debug(
-        "Fetching URI resource {}, headers:\n{}",
+        "Fetching {}, using headers:\n{}",
         this.getURI(),
         headers.entrySet().stream()
             .map(entry -> entry.getKey() + "=" + String.join(", ", entry.getValue()))
             .collect(Collectors.joining("\n")));
   }
 
-  private ClientHttpResponse attemptToFetchResponse(
-      final HttpHeaders headers, final AtomicInteger counter) throws IOException {
+  private ClientHttpResponse attemptToFetchResponse(final HttpHeaders headers) throws IOException {
     ClientHttpRequest requestUsed =
         this.request != null ? this.request : createRequestFromWrapped(headers);
     LOGGER.debug("Executing http request: {}", requestUsed.getURI());
     ClientHttpResponse response = executeCallbacksAndRequest(requestUsed);
-    if (response.getRawStatusCode() < 500) {
-      LOGGER.debug(
-          "Fetching success URI resource {}, status code {}",
-          getURI(),
-          response.getRawStatusCode());
-      return response;
+    final int minStatusCodeError = HttpStatus.INTERNAL_SERVER_ERROR.value();
+    int rawStatusCode = minStatusCodeError;
+    try {
+      rawStatusCode = response.getRawStatusCode();
+      if (rawStatusCode < minStatusCodeError) {
+        LOGGER.debug("Successfully fetched {}, with status code {}", getURI(), rawStatusCode);
+        return response;
+      }
+      LOGGER.debug("Failed fetching {}, with error code {}", getURI(), rawStatusCode);
+      return null;
+    } finally {
+      if (rawStatusCode >= minStatusCodeError) {
+        response.close();
+      }
     }
-    LOGGER.debug(
-        "Fetching failed URI resource {}, error code {}", getURI(), response.getRawStatusCode());
-    if (canRetry(counter)) {
-      sleepWithExceptionHandling();
-      LOGGER.debug("Retry fetching URI resource {}", this.getURI());
-    } else {
-      throw new PrintException(
-          String.format(
-              "Fetching failed URI resource %s, error code %s",
-              getURI(), response.getRawStatusCode()));
-    }
-    return null;
   }
 
   private void handleIOException(final IOException e, final AtomicInteger counter)
@@ -197,17 +204,18 @@ final class ConfigFileResolvingRequest extends AbstractClientHttpRequest {
 
     if (canRetry(counter)) {
       sleepWithExceptionHandling();
-      LOGGER.debug("Retry fetching URI resource {}", this.getURI());
+      LOGGER.debug("Retry fetching {} following exception", this.getURI(), e);
     } else {
-      LOGGER.debug("Fetching failed URI resource {}", getURI());
+      LOGGER.debug("Failed fetching {}", getURI());
       throw e;
     }
   }
 
   private void sleepWithExceptionHandling() {
+    int sleepMs = configFileResolvingHttpRequestFactory.getHttpRequestFetchRetryIntervalMillis();
+    LOGGER.debug("Sleeping {} ms before retrying.", sleepMs);
     try {
-      TimeUnit.MILLISECONDS.sleep(
-          configFileResolvingHttpRequestFactory.getHttpRequestFetchRetryIntervalMillis());
+      TimeUnit.MILLISECONDS.sleep(sleepMs);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new PrintException("Interrupted while sleeping", e);
@@ -215,7 +223,7 @@ final class ConfigFileResolvingRequest extends AbstractClientHttpRequest {
   }
 
   private boolean canRetry(final AtomicInteger counter) {
-    return counter.incrementAndGet() < getHttpRequestMaxNumberFetchRetry();
+    return counter.incrementAndGet() <= getHttpRequestMaxNumberFetchRetry();
   }
 
   private int getHttpRequestMaxNumberFetchRetry() {

--- a/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingRequest.java
+++ b/core/src/main/java/org/mapfish/print/http/ConfigFileResolvingRequest.java
@@ -205,7 +205,10 @@ final class ConfigFileResolvingRequest extends AbstractClientHttpRequest {
       LOGGER.debug("Retry fetching {} following exception", this.getURI(), e);
       return true;
     } else {
-      LOGGER.debug("Has reached maximum number of retry for {}", getURI());
+      LOGGER.debug(
+          "Reached maximum number of {} allowed requests attempts for {}",
+          getHttpRequestMaxNumberFetchRetry(),
+          getURI());
       return false;
     }
   }
@@ -222,7 +225,7 @@ final class ConfigFileResolvingRequest extends AbstractClientHttpRequest {
   }
 
   private boolean canRetry(final AtomicInteger counter) {
-    return counter.incrementAndGet() <= getHttpRequestMaxNumberFetchRetry();
+    return counter.incrementAndGet() < getHttpRequestMaxNumberFetchRetry();
   }
 
   private int getHttpRequestMaxNumberFetchRetry() {

--- a/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
+++ b/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
@@ -87,18 +87,22 @@ public final class HttpRequestFetcher {
       this.headers = originalResponse.getHeaders();
       this.status = originalResponse.getRawStatusCode();
       this.statusText = originalResponse.getStatusText();
-      this.cachedFile =
+      this.cachedFile = createCachedFile(originalResponse.getBody());
+    }
+
+    private File createCachedFile(final InputStream originalBody) throws IOException {
+      File tempFile =
           File.createTempFile("cacheduri", null, HttpRequestFetcher.this.temporaryDirectory);
-      LOGGER.debug("Caching URI resource to {}", this.cachedFile);
-      try (OutputStream os = Files.newOutputStream(this.cachedFile.toPath())) {
-        InputStream body = originalResponse.getBody();
+      LOGGER.debug("Caching URI resource to {}", tempFile);
+      try (OutputStream os = Files.newOutputStream(tempFile.toPath())) {
         LOGGER.debug(
-            "Get from input stream {}, for response {}, body available: {}",
-            body.getClass(),
-            originalResponse.getClass(),
-            body.available());
-        IOUtils.copy(body, os);
+            "Get from input stream {}, body available: {}",
+            originalBody.getClass(),
+            originalBody.available());
+        IOUtils.copy(originalBody, os);
+        originalBody.close();
       }
+      return tempFile;
     }
 
     @Override

--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -89,7 +89,14 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
             .setMaxConnTotal(maxConnTotal)
             .setMaxConnPerRoute(maxConnPerRoute)
             .setUserAgent(UserAgentCreator.getUserAgent());
-    return httpClientBuilder.build();
+    CloseableHttpClient closeableHttpClient = httpClientBuilder.build();
+    LOGGER.debug(
+        "Created CloseableHttpClient using connectionRequestTimeout: {} connectTimeout: {}"
+            + " socketTimeout: {}",
+        getIntProperty("http.connectionRequestTimeout"),
+        getIntProperty("http.connectTimeout"),
+        getIntProperty("http.socketTimeout"));
+    return closeableHttpClient;
   }
 
   // allow extension only for testing

--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -94,6 +94,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
 
   // allow extension only for testing
   @Override
+  @Nonnull
   public ConfigurableRequest createRequest(
       @Nonnull final URI uri, @Nonnull final HttpMethod httpMethod) {
     HttpRequestBase httpRequest = (HttpRequestBase) createHttpUriRequest(httpMethod, uri);
@@ -161,20 +162,24 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
       return HttpMethod.valueOf(this.request.getMethod());
     }
 
+    @Nonnull
     @Override
     public String getMethodValue() {
       return this.request.getMethod();
     }
 
+    @Nonnull
     public URI getURI() {
       return this.request.getURI();
     }
 
+    @Nonnull
     @Override
     protected OutputStream getBodyInternal(@Nonnull final HttpHeaders headers) {
       return this.outputStream;
     }
 
+    @Nonnull
     @Override
     protected Response executeInternal(@Nonnull final HttpHeaders headers) throws IOException {
       CURRENT_CONFIGURATION.set(this.configuration);
@@ -207,7 +212,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
     }
   }
 
-  static class Response extends AbstractClientHttpResponse {
+  public static class Response extends AbstractClientHttpResponse {
     private static final Logger LOGGER = LoggerFactory.getLogger(Response.class);
     private static final AtomicInteger ID_COUNTER = new AtomicInteger();
     private final HttpResponse response;
@@ -224,6 +229,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
       return this.response.getStatusLine().getStatusCode();
     }
 
+    @Nonnull
     @Override
     public String getStatusText() {
       return this.response.getStatusLine().getReasonPhrase();
@@ -247,6 +253,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
       LOGGER.trace("Closed Http Response object: {}", this.id);
     }
 
+    @Nonnull
     @Override
     public synchronized InputStream getBody() throws IOException {
       if (this.inputStream == null) {
@@ -262,6 +269,7 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
       return this.inputStream;
     }
 
+    @Nonnull
     @Override
     public HttpHeaders getHeaders() {
       final HttpHeaders translatedHeaders = new HttpHeaders();

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
@@ -136,6 +136,10 @@ public class ThreadPoolJobManager implements JobManager {
     this.timeout = timeout;
   }
 
+  public final long getTimeout() {
+    return this.timeout;
+  }
+
   public final void setAbandonedTimeout(final long abandonedTimeout) {
     this.abandonedTimeout = abandonedTimeout;
   }

--- a/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
+++ b/core/src/main/java/org/mapfish/print/servlet/job/impl/ThreadPoolJobManager.java
@@ -452,10 +452,13 @@ public class ThreadPoolJobManager implements JobManager {
       final SubmittedPrintJob printJob = submittedJobs.next();
       if (!printJob.getReportFuture().isDone()
           && (isTimeoutExceeded(printJob) || isAbandoned(printJob))) {
-        LOGGER.info("Canceling job after timeout {}", printJob.getEntry().getReferenceId());
+        LOGGER.info(
+            "About to attempt timeout based automatic cancellation of job {}",
+            printJob.getEntry().getReferenceId());
         if (!printJob.getReportFuture().cancel(true)) {
           LOGGER.info(
-              "Could not cancel job after timeout {}", printJob.getEntry().getReferenceId());
+              "Automatic cancellation after timeout failed for job {}",
+              printJob.getEntry().getReferenceId());
         }
         // remove all canceled tasks from the work queue (otherwise the queue comparator
         // might stumble on non-PrintJob entries)

--- a/core/src/main/resources/mapfish-spring-application-context.xml
+++ b/core/src/main/resources/mapfish-spring-application-context.xml
@@ -62,7 +62,8 @@
     <bean id="healthCheckRegistry" class="org.mapfish.print.metrics.HealthCheckingRegistry"/>
     <bean id="httpClientFactory" class="org.mapfish.print.http.MfClientHttpRequestFactoryImpl">
         <constructor-arg index="0" value="${maxConnectionsTotal}" />
-        <constructor-arg index="1" value="${maxConnectionsPerRoute}" />
+        <constructor-arg index="1" value="${maxConnectionsPerRoute}"/>
+        <constructor-arg index="2" ref="jobManager"/>
     </bean>
     <bean id="metricNameStrategy" class="org.mapfish.print.metrics.MetricsNameStrategyFactory" factory-method="hostAndMethod" />
     <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator" lazy-init="false"/>

--- a/core/src/test/java/org/mapfish/print/TestHttpClientFactory.java
+++ b/core/src/test/java/org/mapfish/print/TestHttpClientFactory.java
@@ -1,13 +1,12 @@
 package org.mapfish.print;
 
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.mapfish.print.config.Configuration;
 import org.mapfish.print.http.ConfigurableRequest;
@@ -37,8 +36,9 @@ public class TestHttpClientFactory extends MfClientHttpRequestFactoryImpl
     handlers.put(matcher, handler);
   }
 
+  @Nonnull
   @Override
-  public ConfigurableRequest createRequest(URI uri, final HttpMethod httpMethod) {
+  public ConfigurableRequest createRequest(@Nonnull URI uri, @Nonnull final HttpMethod httpMethod) {
     for (Map.Entry<Predicate<URI>, Handler> entry : handlers.entrySet()) {
       if (entry.getKey().test(uri)) {
         try {
@@ -75,18 +75,6 @@ public class TestHttpClientFactory extends MfClientHttpRequestFactoryImpl
       request.setResponse(response);
       return request;
     }
-
-    public MockClientHttpRequest failOnExecute(final URI uri, final HttpMethod httpMethod) {
-      MockClientHttpRequest request =
-          new MockClientHttpRequest(httpMethod, uri) {
-            @Override
-            protected ClientHttpResponse executeInternal() throws IOException {
-              fail("request should not be executed " + uri.toString());
-              throw new IOException();
-            }
-          };
-      return request;
-    }
   }
 
   private static class TestConfigurableRequest implements ConfigurableRequest {
@@ -106,11 +94,13 @@ public class TestHttpClientFactory extends MfClientHttpRequestFactoryImpl
       // ignore
     }
 
+    @Nonnull
     @Override
     public ClientHttpResponse execute() throws IOException {
       return httpRequest.execute();
     }
 
+    @Nonnull
     @Override
     public OutputStream getBody() throws IOException {
       return httpRequest.getBody();
@@ -121,6 +111,7 @@ public class TestHttpClientFactory extends MfClientHttpRequestFactoryImpl
       return httpRequest.getMethod();
     }
 
+    @Nonnull
     @Override
     public String getMethodValue() {
       final HttpMethod method = httpRequest.getMethod();
@@ -128,11 +119,13 @@ public class TestHttpClientFactory extends MfClientHttpRequestFactoryImpl
       return method.name();
     }
 
+    @Nonnull
     @Override
     public URI getURI() {
       return httpRequest.getURI();
     }
 
+    @Nonnull
     @Override
     public HttpHeaders getHeaders() {
       return httpRequest.getHeaders();

--- a/core/src/test/java/org/mapfish/print/TestHttpClientFactory.java
+++ b/core/src/test/java/org/mapfish/print/TestHttpClientFactory.java
@@ -115,7 +115,6 @@ public class TestHttpClientFactory extends MfClientHttpRequestFactoryImpl
     @Override
     public String getMethodValue() {
       final HttpMethod method = httpRequest.getMethod();
-      assert method != null;
       return method.name();
     }
 

--- a/core/src/test/java/org/mapfish/print/TestHttpClientFactory.java
+++ b/core/src/test/java/org/mapfish/print/TestHttpClientFactory.java
@@ -12,6 +12,7 @@ import org.mapfish.print.config.Configuration;
 import org.mapfish.print.http.ConfigurableRequest;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.http.MfClientHttpRequestFactoryImpl;
+import org.mapfish.print.servlet.job.impl.ThreadPoolJobManager;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -26,7 +27,7 @@ public class TestHttpClientFactory extends MfClientHttpRequestFactoryImpl
   private final Map<Predicate<URI>, Handler> handlers = new ConcurrentHashMap<>();
 
   public TestHttpClientFactory() {
-    super(20, 10);
+    super(20, 10, new ThreadPoolJobManager());
   }
 
   public void registerHandler(Predicate<URI> matcher, Handler handler) {

--- a/core/src/test/java/org/mapfish/print/http/ConfigFileResolvingRequestTest.java
+++ b/core/src/test/java/org/mapfish/print/http/ConfigFileResolvingRequestTest.java
@@ -29,6 +29,7 @@ public class ConfigFileResolvingRequestTest {
 
     // Then
     assertEquals("OK", resp.getStatusText());
+    resp.close();
   }
 
   @Test
@@ -46,6 +47,7 @@ public class ConfigFileResolvingRequestTest {
 
     // Then
     assertEquals(200, resp.getRawStatusCode());
+    resp.close();
   }
 
   @Test
@@ -66,6 +68,7 @@ public class ConfigFileResolvingRequestTest {
 
     // Then
     assertEquals(200, resp.getRawStatusCode());
+    resp.close();
   }
 
   @Test
@@ -81,9 +84,10 @@ public class ConfigFileResolvingRequestTest {
     try {
       ClientHttpResponse resp = req.executeInternal(new HttpHeaders());
       fail("Should not have return the response " + resp);
+      resp.close();
     } catch (PrintException e) {
       // Then
-      assertEquals("Fetching failed URI resource http://ex.com, error code 500", e.getMessage());
+      assertEquals("Failed fetching http://ex.com", e.getMessage());
     }
   }
 

--- a/core/src/test/java/org/mapfish/print/http/MfClientHttpRequestFactoryImplTest.java
+++ b/core/src/test/java/org/mapfish/print/http/MfClientHttpRequestFactoryImplTest.java
@@ -3,19 +3,17 @@ package org.mapfish.print.http;
 import static org.junit.Assert.assertEquals;
 
 import com.sun.net.httpserver.Headers;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mapfish.print.servlet.job.impl.ThreadPoolJobManager;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 
-public class MfClientHttpRequestFactoryImpl_ResponseTest {
+public class MfClientHttpRequestFactoryImplTest {
   private static final int TARGET_PORT = 33212;
   private static HttpServer targetServer;
 
@@ -35,23 +33,23 @@ public class MfClientHttpRequestFactoryImpl_ResponseTest {
   public void testGetHeaders() throws Exception {
     targetServer.createContext(
         "/request",
-        new HttpHandler() {
-          @Override
-          public void handle(HttpExchange httpExchange) throws IOException {
-            final Headers responseHeaders = httpExchange.getResponseHeaders();
-            responseHeaders.add("Content-Type", "application/json; charset=utf8");
-            httpExchange.sendResponseHeaders(200, 0);
-            httpExchange.close();
-          }
+        httpExchange -> {
+          final Headers responseHeaders = httpExchange.getResponseHeaders();
+          responseHeaders.add("Content-Type", "application/json; charset=utf8");
+          httpExchange.sendResponseHeaders(200, 0);
+          httpExchange.close();
         });
 
-    MfClientHttpRequestFactoryImpl factory = new MfClientHttpRequestFactoryImpl(20, 10);
+    MfClientHttpRequestFactoryImpl factory =
+        new MfClientHttpRequestFactoryImpl(20, 10, new ThreadPoolJobManager());
     final ConfigurableRequest request =
         factory.createRequest(
             new URI("http://" + HttpProxyTest.LOCALHOST + ":" + TARGET_PORT + "/request"),
             HttpMethod.GET);
 
-    final ClientHttpResponse response = request.execute();
-    assertEquals("application/json; charset=utf8", response.getHeaders().getFirst("Content-Type"));
+    try (ClientHttpResponse response = request.execute()) {
+      assertEquals(
+          "application/json; charset=utf8", response.getHeaders().getFirst("Content-Type"));
+    }
   }
 }

--- a/examples/src/test/java/org/mapfish/print/AbstractApiTest.java
+++ b/examples/src/test/java/org/mapfish/print/AbstractApiTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.mapfish.print.http.MfClientHttpRequestFactoryImpl;
+import org.mapfish.print.servlet.job.impl.ThreadPoolJobManager;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequest;
@@ -21,7 +22,7 @@ public abstract class AbstractApiTest {
   protected static final String PRINT_SERVER = "http://print:8080/";
 
   protected ClientHttpRequestFactory httpRequestFactory =
-      new MfClientHttpRequestFactoryImpl(10, 10);
+      new MfClientHttpRequestFactoryImpl(10, 10, new ThreadPoolJobManager());
 
   protected ClientHttpRequest getRequest(String path, HttpMethod method)
       throws IOException, URISyntaxException {


### PR DESCRIPTION
Fix issue where you no longer get a reply after 5 requests with:
`        try (CloseableHttpClient client = HttpClients.createDefault()) {
            HttpUriRequest request = new HttpGet("https://map.geo.ti.ch/oereb2/image/symbol/ch.Nutzungsplanung/legend_entry.png?identifier=423441325078");
            HttpContext context = null;

            for (int i = 1; i < 7; i++) {
                System.out.println("i = " + i);
                HttpResponse response = client.execute(request, context);
                System.out.println(response.getReasonPhrase());
            }
        }
`
<!-- pull request links -->
See JIRA issue: [ISSUE-36](https://camptocamp.atlassian.net/browse/GSMFP-36).