### PR TITLE
fix: Support java-17 version of the javadoc for doc generator

### DIFF
--- a/docs/src/main/groovy/Javadoc7Parser.groovy
+++ b/docs/src/main/groovy/Javadoc7Parser.groovy
@@ -29,24 +29,21 @@ class Javadoc7Parser {
     String findJavadocDescription(String objectName, Class cls, String obj, Closure errorHandler) {
         try {
             def html = loadJavadocFile(cls)
-
             def contentContainer = html.depthFirst().find {
-                it.name() == 'div' && it.@class == 'contentContainer'
+                it.name() == 'main' && it.@role == 'main'
             }
             def detailsEl = contentContainer.depthFirst().find {
-                it.name() == 'div' && it.@class == 'details'
+                it.name() == 'section' && it.@class == 'details'
             }
-
             def descDiv = detailsEl.depthFirst().find {
 
                 if (it.name() == "li") {
-                    def h4 = it.h4
-                    return h4.size() > 0 && !h4.text().isEmpty() && obj == h4.text()
+                    def h3 = it.section.h3
+                    return h3.size() > 0 && !h3.text().isEmpty() && obj == h3.text()
                 } else {
                     return false
                 }
             }
-
 
             def firstDescriptionDiv = descDiv.div[0]
             return DocsXmlSupport.toXmlString(firstDescriptionDiv)
@@ -67,17 +64,19 @@ class Javadoc7Parser {
         return "Unable to find javadoc for method '$method' in '$objectName'"
     }
 
-
     String findClassDescription(Class cls) {
         def html = loadJavadocFile(cls)
 
         def contentContainer = html.depthFirst().find {
-            it.name() == 'div' && it.@class == 'contentContainer'
+            it.name() == 'main' && it.@role == 'main'
         }
         def descriptionEl = contentContainer.depthFirst().find {
-            it.name() == 'div' && it.@class == 'description'
+            it.name() == 'section' && it.@class == 'class-description'
         }
-        return DocsXmlSupport.toXmlString(descriptionEl.ul.li.div[0])
+        def result = contentContainer.depthFirst().find {
+            it.name() == 'div' && it.@class == 'block'
+        }
+        return DocsXmlSupport.toXmlString(result)
     }
     def xmlCache = [:]
 

--- a/docs/src/main/groovy/Javadoc7Parser.groovy
+++ b/docs/src/main/groovy/Javadoc7Parser.groovy
@@ -45,8 +45,11 @@ class Javadoc7Parser {
                 }
             }
 
-            def firstDescriptionDiv = descDiv.div[0]
-            return DocsXmlSupport.toXmlString(firstDescriptionDiv)
+            def description = descDiv.breadthFirst().find {
+                return  it.name() == 'div' && it.@class == 'block'
+            }
+
+            return DocsXmlSupport.toXmlString(description)
         } catch (Exception e) {
             if (cls.getSuperclass() != null) {
                 try {
@@ -55,7 +58,7 @@ class Javadoc7Parser {
                     throw new IllegalArgumentException(errorHandler(obj, objectName))
                 }
             } else {
-                throw new IllegalArgumentException(errorHandler(obj, objectName))
+                return ""
             }
         }
     }


### PR DESCRIPTION
Breaks backwards compatibility because of the HTML differences in javadoc generated by java-11 and java-17.