### PR TITLE
Allow delta between completed job status registered stats

### DIFF
--- a/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
+++ b/core/src/test/java/org/mapfish/print/servlet/MapPrinterServletTest.java
@@ -425,8 +425,9 @@ public class MapPrinterServletTest extends AbstractMapfishSpringTest {
               + lastTimeElapsed
               + " is not less or equal to timeElapsed: "
               + timeElapsed,
-          lastTimeElapsed <=
-              timeElapsed + allowDeltaBetweenCompletedJobStatusRegisteredStatsAndInstantaneousElapsedTime);
+          lastTimeElapsed
+              <= timeElapsed
+                  + allowDeltaBetweenCompletedJobStatusRegisteredStatsAndInstantaneousElapsedTime);
 
       lastTimeElapsed = timeElapsed;
 


### PR DESCRIPTION
 and instantaneous elapsed time.

cf. https://camptocamp.atlassian.net/browse/GSMFP-37