### PR TITLE
Yaml reader is not thread safe

### DIFF
--- a/core/src/test/resources/org/mapfish/print/config/configThread1.yaml
+++ b/core/src/test/resources/org/mapfish/print/config/configThread1.yaml
@@ -1,0 +1,5 @@
+templates:
+  main: !template
+    attributes:
+      thread1: !string
+        default: 'thread1'

--- a/core/src/test/resources/org/mapfish/print/config/configThread2.yaml
+++ b/core/src/test/resources/org/mapfish/print/config/configThread2.yaml
@@ -1,0 +1,5 @@
+templates:
+  main: !template
+    attributes:
+      thread2: !string
+        default: 'thread2'


### PR DESCRIPTION
Yaml reader in ConfigurationFactory is not thread safe, it can be problematic when 'getConfig' function is called (line 64) with multiple threads as the same time.