### PR TITLE
Fix MDC for project working with logback 1.2.x

### DIFF
--- a/core/src/main/java/org/mapfish/print/processor/AbstractProcessor.java
+++ b/core/src/main/java/org/mapfish/print/processor/AbstractProcessor.java
@@ -3,6 +3,7 @@ package org.mapfish.print.processor;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -251,7 +252,7 @@ public abstract class AbstractProcessor<IN, OUT> implements Processor<IN, OUT> {
         return action.get();
       } finally {
         if (changed) {
-          MDC.setContextMap(prev);
+          MDC.setContextMap(prev != null ? prev : new HashMap<>());
         }
       }
     }
@@ -268,7 +269,7 @@ public abstract class AbstractProcessor<IN, OUT> implements Processor<IN, OUT> {
         return action.call();
       } finally {
         if (mdcChanged) {
-          MDC.setContextMap(prev);
+          MDC.setContextMap(prev != null ? prev : new HashMap<>());
         }
       }
     }


### PR DESCRIPTION
We integrate your library into our spring boot 2 project, which can use only 1.2.x logback versions.
https://docs.spring.io/spring-boot/docs/2.7.18/reference/html/dependency-versions.html#appendix.dependency-versions

But in logback 1.2.x, call MDC.setContextMap with a null object create a null pointer. 
The modifications does not change the actual behaviour and provide retocompatibilty. I don't know if it's okay for you.