### PR TITLE
fix(3725): Updated jdk version for jitpack to jdk17

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk11
+  - openjdk17


### PR DESCRIPTION
Fixes an issue with jitpack build system: https://jitpack.io/com/github/mapfish/mapfish-print/jitpack-535a773ef4-1/build.log

Fix: #3725