### PR TITLE
Handle HTTP 200 responses with no image for coverage task when failOnError enabled

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
+++ b/core/src/main/java/org/mapfish/print/map/tiled/CoverageTask.java
@@ -271,6 +271,16 @@ public final class CoverageTask implements Callable<GridCoverage2D> {
         final ClientHttpResponse response, final String baseMetricName) throws IOException {
       BufferedImage image = ImageIO.read(response.getBody());
       if (image == null) {
+        if (this.failOnError) {
+          this.registry.counter(baseMetricName + ".failOn.error").inc();
+          String message =
+              String.format(
+                  "SingleTileLoader Task stopped since fail on error parameter is enabled and the"
+                      + " URL %s is an image format than cannot be decoded",
+                  this.tileRequest.getURI());
+          LOGGER.error(message);
+          throw new PrintException(message);
+        }
         LOGGER.warn(
             "The URL: {} is an image format that cannot be decoded", this.tileRequest.getURI());
         image = this.errorImage;


### PR DESCRIPTION
When using some tiled request that use coverage task, and fail on error is activated, no error occured on 200 HTTP response that does not send an actual image. Just a warn log is displayed and the generation is done.

I have fixed it. And added some UT. 