### PR TITLE
Correct geodetic scale denominator calculation

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/Scale.java
+++ b/core/src/main/java/org/mapfish/print/map/Scale.java
@@ -201,7 +201,7 @@ public final class Scale implements Comparable<Scale> {
       double width = 1;
       double geoWidthInches = getResolutionInInches() * width;
       double geoWidth = DistanceUnit.IN.convertTo(geoWidthInches, this.unit);
-      double minGeoX = position.y - (geoWidth / 2.0);
+      double minGeoX = position.x - (geoWidth / 2.0);
       double maxGeoX = minGeoX + geoWidth;
 
       final GeodeticCalculator calculator = new GeodeticCalculator(projection);


### PR DESCRIPTION
This commit fixes a bug in the `getGeodeticDenominator` method within the `Scale` class.

Problem:
The calculation for `minGeoX`, which defines the starting X-coordinate of the horizontal line segment used for geodetic distance measurement, incorrectly used `position.y` instead of `position.x`. This resulted in the geodetic calculation being performed at an incorrect location on the map, leading to an inaccurate scale denominator.

Fix:
The `minGeoX` calculation has been corrected to use `position.x - (geoWidth / 2.0)`, ensuring that the horizontal line segment is properly centered around the provided `position`'s X-coordinate.

Impact:
This fix ensures that geodetic scale denominators are calculated accurately, improving the precision of map rendering and scale representation, especially for projections where geodetic corrections are critical.
