### PR TITLE
Handle 204 no content for SingleImageLayer

### DIFF
--- a/core/src/test/java/org/mapfish/print/map/image/AbstractSingleImageLayerTest.java
+++ b/core/src/test/java/org/mapfish/print/map/image/AbstractSingleImageLayerTest.java
@@ -3,8 +3,10 @@ package org.mapfish.print.map.image;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.codahale.metrics.MetricRegistry;
+import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mapfish.print.Constants;
@@ -33,6 +35,34 @@ public class AbstractSingleImageLayerTest {
       Assertions.fail("Did not throw exception with unsupported status code");
     } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains(String.valueOf(unsupportedStatusCode)));
+    }
+  }
+
+  @Test
+  public void testFetch204NonContent() throws IOException {
+    MapfishMapContext mapContext =
+        new MapfishMapContext(null, new Dimension(10, 10), 100, 100, false, true);
+    MockClientHttpRequest mockClientHttpRequest = new MockClientHttpRequest();
+    final int noContentCode = 204;
+    mockClientHttpRequest.setResponse(new MockClientHttpResponse(new byte[0], noContentCode));
+    AbstractLayerParams layerParams = new AbstractLayerParams();
+    layerParams.failOnError = true;
+    AbstractSingleImageLayer layer = new AbstractSingleImageLayerTestImpl(layerParams);
+    try {
+      BufferedImage bufferedImage = layer.fetchImage(mockClientHttpRequest, mapContext);
+
+      Assert.assertEquals("Image width is not correct", 10, bufferedImage.getWidth());
+      Assert.assertEquals("Image height is not correct", 10, bufferedImage.getHeight());
+
+      // check alpha chanel is equal to 0 for every pixels
+      for (int x = 0; x < bufferedImage.getWidth(); x++) {
+        for (int y = 0; y < bufferedImage.getHeight(); y++) {
+          int argb = bufferedImage.getRGB(x, y);
+          Assert.assertEquals("Pixel (" + x + "," + y + ") is not transparent", 0, (argb >>> 24));
+        }
+      }
+    } catch (Exception e) {
+      Assert.fail("Did throw exception " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
When receiving a 204 HTTP status code in tiled requests, Mapfish handles it by inserting a transparent tile. This is not the case for SingleImageLayer (such as WMS), where it results in an error.
I have implemented the same behavior as for tiled requests in this PR.