### PR TITLE
Fix TableProcessorTest Jasper print access

### DIFF
--- a/core/src/test/java/org/mapfish/print/processor/jasper/TableProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/jasper/TableProcessorTest.java
@@ -250,9 +250,7 @@ public class TableProcessorTest extends AbstractMapfishSpringTest {
         (AbstractJasperReportOutputFormat) this.outputFormat.get("pngOutputFormat");
     final File file = getFile(TableProcessorTest.class, baseDir);
     JasperPrint print =
-        format
-            .getJasperPrint(new HashMap<>(), requestData, config, file, getTaskDirectory())
-            .print;
+        format.getJasperPrint(new HashMap<>(), requestData, config, file, getTaskDirectory()).print;
 
     new ImageSimilarity(getFile(baseDir + "expectedImage-quoted.png"))
         .assertSimilarity(print, 0, 0);

--- a/core/src/test/java/org/mapfish/print/processor/jasper/TableProcessorTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/jasper/TableProcessorTest.java
@@ -252,7 +252,7 @@ public class TableProcessorTest extends AbstractMapfishSpringTest {
     JasperPrint print =
         format
             .getJasperPrint(new HashMap<>(), requestData, config, file, getTaskDirectory())
-            .print();
+            .print;
 
     new ImageSimilarity(getFile(baseDir + "expectedImage-quoted.png"))
         .assertSimilarity(print, 0, 0);


### PR DESCRIPTION
## Summary
- fix `TableProcessorTest` to use the `print` field from `getJasperPrint(...)` instead of calling a non-existent `print()` method