### PR TITLE
Block XXE payloads in GML layer parsing

### DIFF
--- a/core/src/main/java/org/mapfish/print/map/geotools/GmlLayer.java
+++ b/core/src/main/java/org/mapfish/print/map/geotools/GmlLayer.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 import org.eclipse.emf.ecore.resource.URIHandler;
@@ -25,7 +26,9 @@ import org.mapfish.print.config.Template;
 import org.mapfish.print.http.MfClientHttpRequestFactory;
 import org.mapfish.print.map.AbstractLayerParams;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
 
 /** Parses GML from the request data. */
 public final class GmlLayer extends AbstractFeatureSourceLayer {
@@ -70,6 +73,31 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
         new org.geotools.gml3.GMLConfiguration();
     private static final org.geotools.gml3.v3_2.GMLConfiguration GML_32_PARSER =
         new org.geotools.gml3.v3_2.GMLConfiguration(true);
+    private static final Pattern DOCTYPE_PATTERN =
+        Pattern.compile("<\\s*!\\s*DOCTYPE\\b", Pattern.CASE_INSENSITIVE);
+    private static final EntityResolver2 BLOCK_EXTERNAL_ENTITIES =
+        new EntityResolver2() {
+          @Override
+          public InputSource getExternalSubset(final String name, final String baseURI) {
+            return null;
+          }
+
+          @Override
+          public InputSource resolveEntity(
+              final String name,
+              final String publicId,
+              final String baseURI,
+              final String systemId)
+              throws SAXException {
+            throw new SAXException("External XML entities are not allowed in GML layers");
+          }
+
+          @Override
+          public InputSource resolveEntity(final String publicId, final String systemId)
+              throws SAXException {
+            throw new SAXException("External XML entities are not allowed in GML layers");
+          }
+        };
 
     @Autowired private URIHandler cachingUrihandler;
 
@@ -120,8 +148,9 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
         FileUtils.testForLegalFileUrl(template.getConfiguration(), url);
         try {
           final String gmlData = URIUtils.toString(httpRequestFactory, url.toURI());
+          validateXmlSafety(gmlData);
           final int endIndex = 200;
-          String startOfData = gmlData.substring(0, endIndex);
+          String startOfData = gmlData.substring(0, Math.min(endIndex, gmlData.length()));
           if (startOfData.contains("\"http://www.opengis.net/gml/3.2\"")) {
             return parseGml32(gmlData);
           } else {
@@ -132,6 +161,12 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
         }
       } catch (MalformedURLException | URISyntaxException e) {
         return null;
+      }
+    }
+
+    private void validateXmlSafety(final String gmlData) {
+      if (DOCTYPE_PATTERN.matcher(gmlData).find()) {
+        throw new PrintException("DOCTYPE declarations are not allowed in GML layers");
       }
     }
 
@@ -178,16 +213,17 @@ public final class GmlLayer extends AbstractFeatureSourceLayer {
         if (featureCollection instanceof SimpleFeatureCollection) {
           return (SimpleFeatureCollection) featureCollection;
         } else {
-          throw new RuntimeException("unable to parse gml: \n\n" + gmlData);
+          throw new PrintException("Unable to parse GML 3.2 feature collection");
         }
 
       } catch (SAXException | ParserConfigurationException e) {
-        throw new PrintException("Failed to parse Gml32 " + gmlData, e);
+        throw new PrintException("Failed to parse GML 3.2 feature collection", e);
       }
     }
 
     private Parser createParser(final Configuration configuration) {
       final Parser parser = new Parser(configuration);
+      parser.setEntityResolver(BLOCK_EXTERNAL_ENTITIES);
       parser.getURIHandlers().addFirst(this.cachingUrihandler);
       return parser;
     }

--- a/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleBBoxGmlTest.java
+++ b/core/src/test/java/org/mapfish/print/processor/map/CreateMapProcessorFlexibleScaleBBoxGmlTest.java
@@ -1,6 +1,9 @@
 package org.mapfish.print.processor.map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -87,5 +91,48 @@ public class CreateMapProcessorFlexibleScaleBBoxGmlTest extends AbstractMapfishS
       new ImageSimilarity(getFile(String.format("%sexpected%s.png", BASE_DIR, gmlDataName)))
           .assertSimilarity(new File(layerGraphics.getFirst()), 0);
     }
+  }
+
+  @Test
+  @DirtiesContext
+  public void testRejectsGmlWithDoctype() throws Exception {
+    final String host = "center_gml_flexible_scale.com";
+    requestFactory.registerHandler(
+        input -> (("" + input.getHost()).contains(host)) || input.getAuthority().contains(host),
+        createFileHandler(uri -> "/map-data" + uri.getPath()));
+    final Configuration config = configurationFactory.getConfig(getFile(BASE_DIR + "config.yaml"));
+    final Template template = config.getTemplate("main");
+
+    PJsonObject requestData = loadJsonRequestData();
+    final JSONObject jsonLayer =
+        requestData
+            .getJSONObject("attributes")
+            .getJSONObject("map")
+            .getJSONArray("layers")
+            .getJSONObject(0)
+            .getInternalObj();
+    jsonLayer.remove("url");
+    jsonLayer.accumulate("url", "http://" + host + ":23432/gml/xxe.gml");
+
+    Values values =
+        new Values(
+            new HashMap<>(),
+            requestData,
+            template,
+            getTaskDirectory(),
+            this.requestFactory,
+            new File("."),
+            HTTP_REQUEST_MAX_NUMBER_FETCH_RETRY,
+            HTTP_REQUEST_FETCH_RETRY_INTERVAL_MILLIS,
+            new AtomicBoolean(false));
+
+    final ForkJoinTask<Values> taskFuture =
+        this.forkJoinPool.submit(template.getProcessorGraph().createTask(values));
+    final ExecutionException exception = assertThrows(ExecutionException.class, taskFuture::get);
+    final String exceptionText = exception.toString() + exception.getCause();
+
+    assertTrue(exceptionText.contains("DOCTYPE declarations are not allowed in GML layers"));
+    assertFalse(exceptionText.contains("XXE_REGRESSION_SENTINEL"));
+    assertFalse(exceptionText.contains("mapfish-print-xxe-regression-secret"));
   }
 }

--- a/core/src/test/resources/map-data/gml/xxe.gml
+++ b/core/src/test/resources/map-data/gml/xxe.gml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -->
+<!DOCTYPE x [
+  <!ENTITY xxe SYSTEM "file:///mapfish-print-xxe-regression-secret">
+]>
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:null>&xxe;</gml:null>
+  </gml:boundedBy>
+  <gml:featureMember>XXE_REGRESSION_SENTINEL</gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
## Summary

Fixes #4209.

This hardens GML layer parsing against XXE-style payloads by:

- rejecting DOCTYPE declarations anywhere in downloaded GML data before it is passed to GeoTools parsers, including payloads hidden after the current 200-character GML version sniff
- installing a blocking EntityResolver2 on each GeoTools Parser
- avoiding raw GML payload echoing in GML 3.2 parse error messages
- making the existing 200-character sniff safe for shorter inputs

## Verification

- .\\gradlew.bat core:test --tests org.mapfish.print.processor.map.CreateMapProcessorFlexibleScaleBBoxGmlTest
- .\\gradlew.bat core:checkstyleMain
- git diff --check

core:checkstyleTest still reports pre-existing violations in unrelated test helper files (TestHttpClientFactory, TestMapAttribute, TestDataUrlConnection).