### PR TITLE
Use correct geoserver version numbering scheme

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,12 @@
       versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?(-(?<compatibility>.*))$',
       matchDepNames: ['gradle', 'tomcat'],
     },
+    {
+      matchDatasources: ['docker'],
+      matchDepNames: ['georchestra/geoserver'],
+      allowedVersions: '/[0-9]+\.[0-9]+\.[0-9]+-georchestra-[0-9]+$/',
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<compatibility>.*))?$',
+    },
     /** Define the groups */
     {
       matchUpdateTypes: ['major'],
@@ -107,7 +113,7 @@
       matchPackageNames: ['com.puppycrawl.tools:checkstyle', 'checkstyle'],
       enabled: false,
     },
-    /** Ungoup geotools minor and multiple */
+    /** Ungroup geotools minor and multiple */
     {
       automerge: true,
       groupName: 'geotools',

--- a/docker-compose-lib.yaml
+++ b/docker-compose-lib.yaml
@@ -1,6 +1,6 @@
 services:
   geoserver:
-    image: georchestra/geoserver:25.0.3
+    image: georchestra/geoserver:2.28.4-georchestra-00
     volumes:
       - ./examples/geoserver-data/:/mnt/geoserver_datadir:rw
       - ./core/src/test/resources/map-data/:/mnt/geoserver_datadir/www/map-data:ro


### PR DESCRIPTION
Geoserver does not use version 25. So to run the correct version we need to use 2.x
At the same time we should ensure renovate does not upgrade to "not allowed" versions