### PR TITLE
Backport: fix pooled HTTP connection leak in HttpRequestFetcher and add pool metrics

### DIFF
--- a/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
+++ b/core/src/main/java/org/mapfish/print/http/HttpRequestFetcher.java
@@ -85,10 +85,18 @@ public final class HttpRequestFetcher {
     private InputStream body;
 
     private CachedClientHttpResponse(final ClientHttpResponse originalResponse) throws IOException {
-      this.headers = originalResponse.getHeaders();
-      this.status = originalResponse.getStatusCode();
-      this.statusText = originalResponse.getStatusText();
-      this.cachedFile = createCachedFile(originalResponse.getBody());
+      try {
+        this.headers = originalResponse.getHeaders();
+        this.status = originalResponse.getStatusCode();
+        this.statusText = originalResponse.getStatusText();
+        this.cachedFile = createCachedFile(originalResponse.getBody());
+      } catch (IOException | RuntimeException e) {
+        // Release the underlying connection back to the pool. Without this, a failure here
+        // (e.g. the temp file cannot be created) leaks the pooled connection forever, since
+        // nothing else keeps a reference to originalResponse after this constructor throws.
+        originalResponse.close();
+        throw e;
+      }
     }
 
     private File createCachedFile(final InputStream originalBody) throws IOException {

--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -1,5 +1,6 @@
 package org.mapfish.print.http;
 
+import com.codahale.metrics.MetricRegistry;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.io.ByteArrayInputStream;
@@ -25,6 +26,7 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -68,13 +70,38 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
       final int connectionRequestTimeout,
       final int connectTimeout,
       final int socketTimeout) {
+    this(maxConnTotal, maxConnPerRoute, connectionRequestTimeout, connectTimeout, socketTimeout,
+        null);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param maxConnTotal Maximum total connections.
+   * @param maxConnPerRoute Maximum connections per route.
+   * @param connectionRequestTimeout Number of milliseconds used when requesting a connection from
+   *     the connection manager.
+   * @param connectTimeout Number of milliseconds until a connection is established.
+   * @param socketTimeout Maximum number of milliseconds during which a socket remains inactive
+   *     between two consecutive data packets.
+   * @param metricRegistry Registry to publish connection pool usage gauges to. May be {@code
+   *     null} to skip metrics registration (e.g. in tests).
+   */
+  public MfClientHttpRequestFactoryImpl(
+      final int maxConnTotal,
+      final int maxConnPerRoute,
+      final int connectionRequestTimeout,
+      final int connectTimeout,
+      final int socketTimeout,
+      @Nullable final MetricRegistry metricRegistry) {
     super(
         createHttpClient(
             maxConnTotal,
             maxConnPerRoute,
             connectionRequestTimeout,
             connectTimeout,
-            socketTimeout));
+            socketTimeout,
+            metricRegistry));
     setHttpContextFactory(
         ((httpMethod, uri) -> {
           var context = HttpClientContext.create();
@@ -94,27 +121,31 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
       final int maxConnPerRoute,
       final int connectionRequestTimeout,
       final int connectTimeout,
-      final int socketTimeout) {
+      final int socketTimeout,
+      @Nullable final MetricRegistry metricRegistry) {
     final RequestConfig requestConfig =
         RequestConfig.custom()
             .setConnectionRequestTimeout(connectionRequestTimeout, TimeUnit.MILLISECONDS)
             .setResponseTimeout(socketTimeout, TimeUnit.MILLISECONDS)
             .build();
 
+    final PoolingHttpClientConnectionManager connectionManager =
+        PoolingHttpClientConnectionManagerBuilder.create()
+            .setDefaultConnectionConfig(
+                ConnectionConfig.custom()
+                    .setConnectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+                    .build())
+            .setTlsSocketStrategy(new MfTLSSocketStrategy())
+            .setDnsResolver(new RandomizingDnsResolver())
+            .setMaxConnTotal(maxConnTotal)
+            .setMaxConnPerRoute(maxConnPerRoute)
+            .build();
+    registerConnectionPoolMetrics(connectionManager, metricRegistry);
+
     final HttpClientBuilder httpClientBuilder =
         HttpClients.custom()
             .disableCookieManagement()
-            .setConnectionManager(
-                PoolingHttpClientConnectionManagerBuilder.create()
-                    .setDefaultConnectionConfig(
-                        ConnectionConfig.custom()
-                            .setConnectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
-                            .build())
-                    .setTlsSocketStrategy(new MfTLSSocketStrategy())
-                    .setDnsResolver(new RandomizingDnsResolver())
-                    .setMaxConnPerRoute(maxConnTotal)
-                    .setMaxConnPerRoute(maxConnPerRoute)
-                    .build())
+            .setConnectionManager(connectionManager)
             .setRoutePlanner(new MfRoutePlanner())
             .setDefaultCredentialsProvider(new MfCredentialsProvider())
             .setDefaultRequestConfig(requestConfig)
@@ -127,6 +158,36 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
         connectTimeout,
         socketTimeout);
     return closeableHttpClient;
+  }
+
+  /**
+   * Publishes the connection pool's usage stats (leased, pending, available, max) as gauges, so
+   * pool exhaustion (e.g. from a connection leak) shows up in the existing metrics reporters
+   * (JMX, logging, metrics servlet) instead of only surfacing indirectly as {@code
+   * ConnectionRequestTimeoutException}s.
+   */
+  private static void registerConnectionPoolMetrics(
+      final PoolingHttpClientConnectionManager connectionManager,
+      @Nullable final MetricRegistry metricRegistry) {
+    if (metricRegistry == null) {
+      return;
+    }
+    final String base = MetricRegistry.name(MfClientHttpRequestFactoryImpl.class, "connectionPool");
+    metricRegistry.register(
+        MetricRegistry.name(base, "leased"),
+        (com.codahale.metrics.Gauge<Integer>)
+            () -> connectionManager.getTotalStats().getLeased());
+    metricRegistry.register(
+        MetricRegistry.name(base, "pending"),
+        (com.codahale.metrics.Gauge<Integer>)
+            () -> connectionManager.getTotalStats().getPending());
+    metricRegistry.register(
+        MetricRegistry.name(base, "available"),
+        (com.codahale.metrics.Gauge<Integer>)
+            () -> connectionManager.getTotalStats().getAvailable());
+    metricRegistry.register(
+        MetricRegistry.name(base, "max"),
+        (com.codahale.metrics.Gauge<Integer>) () -> connectionManager.getTotalStats().getMax());
   }
 
   // allow extension only for testing

--- a/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
+++ b/core/src/main/java/org/mapfish/print/http/MfClientHttpRequestFactoryImpl.java
@@ -70,7 +70,12 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
       final int connectionRequestTimeout,
       final int connectTimeout,
       final int socketTimeout) {
-    this(maxConnTotal, maxConnPerRoute, connectionRequestTimeout, connectTimeout, socketTimeout,
+    this(
+        maxConnTotal,
+        maxConnPerRoute,
+        connectionRequestTimeout,
+        connectTimeout,
+        socketTimeout,
         null);
   }
 
@@ -84,8 +89,8 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
    * @param connectTimeout Number of milliseconds until a connection is established.
    * @param socketTimeout Maximum number of milliseconds during which a socket remains inactive
    *     between two consecutive data packets.
-   * @param metricRegistry Registry to publish connection pool usage gauges to. May be {@code
-   *     null} to skip metrics registration (e.g. in tests).
+   * @param metricRegistry Registry to publish connection pool usage gauges to. May be {@code null}
+   *     to skip metrics registration (e.g. in tests).
    */
   public MfClientHttpRequestFactoryImpl(
       final int maxConnTotal,
@@ -162,8 +167,8 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
 
   /**
    * Publishes the connection pool's usage stats (leased, pending, available, max) as gauges, so
-   * pool exhaustion (e.g. from a connection leak) shows up in the existing metrics reporters
-   * (JMX, logging, metrics servlet) instead of only surfacing indirectly as {@code
+   * pool exhaustion (e.g. from a connection leak) shows up in the existing metrics reporters (JMX,
+   * logging, metrics servlet) instead of only surfacing indirectly as {@code
    * ConnectionRequestTimeoutException}s.
    */
   private static void registerConnectionPoolMetrics(
@@ -175,12 +180,10 @@ public class MfClientHttpRequestFactoryImpl extends HttpComponentsClientHttpRequ
     final String base = MetricRegistry.name(MfClientHttpRequestFactoryImpl.class, "connectionPool");
     metricRegistry.register(
         MetricRegistry.name(base, "leased"),
-        (com.codahale.metrics.Gauge<Integer>)
-            () -> connectionManager.getTotalStats().getLeased());
+        (com.codahale.metrics.Gauge<Integer>) () -> connectionManager.getTotalStats().getLeased());
     metricRegistry.register(
         MetricRegistry.name(base, "pending"),
-        (com.codahale.metrics.Gauge<Integer>)
-            () -> connectionManager.getTotalStats().getPending());
+        (com.codahale.metrics.Gauge<Integer>) () -> connectionManager.getTotalStats().getPending());
     metricRegistry.register(
         MetricRegistry.name(base, "available"),
         (com.codahale.metrics.Gauge<Integer>)

--- a/core/src/main/resources/mapfish-spring-application-context.xml
+++ b/core/src/main/resources/mapfish-spring-application-context.xml
@@ -66,6 +66,7 @@
         <constructor-arg index="2" value="${http.connectionRequestTimeout}"/>
         <constructor-arg index="3" value="${http.connectTimeout}"/>
         <constructor-arg index="4" value="${http.socketTimeout}"/>
+        <constructor-arg index="5" ref="metricRegistry"/>
     </bean>
     <bean id="metricNameStrategy" class="org.mapfish.print.metrics.MetricsNameStrategyFactory" factory-method="hostAndMethod" />
     <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator" lazy-init="false"/>

--- a/core/src/test/java/org/mapfish/print/http/HttpRequestFetcherTest.java
+++ b/core/src/test/java/org/mapfish/print/http/HttpRequestFetcherTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import com.codahale.metrics.MetricRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.concurrent.ForkJoinPool;
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapfish.print.processor.AbstractProcessor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
@@ -41,10 +39,10 @@ public class HttpRequestFetcherTest {
 
   /**
    * Regression test: if caching the response to a temp file fails (e.g. the temp directory is
-   * unusable), the underlying original response must still be closed so its pooled HTTP
-   * connection is released. Before the fix, the exception from {@code createCachedFile} would
-   * propagate out of the {@code CachedClientHttpResponse} constructor without the original
-   * response ever being closed, leaking the connection.
+   * unusable), the underlying original response must still be closed so its pooled HTTP connection
+   * is released. Before the fix, the exception from {@code createCachedFile} would propagate out of
+   * the {@code CachedClientHttpResponse} constructor without the original response ever being
+   * closed, leaking the connection.
    */
   @Test
   public void registeredRequestClosesOriginalResponseWhenCachingFails() throws Exception {

--- a/core/src/test/java/org/mapfish/print/http/HttpRequestFetcherTest.java
+++ b/core/src/test/java/org/mapfish/print/http/HttpRequestFetcherTest.java
@@ -1,0 +1,114 @@
+package org.mapfish.print.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapfish.print.processor.AbstractProcessor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
+public class HttpRequestFetcherTest {
+
+  private ForkJoinPool pool;
+
+  @BeforeEach
+  public void setUp() {
+    this.pool = new ForkJoinPool(1);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    this.pool.shutdownNow();
+  }
+
+  /**
+   * Regression test: if caching the response to a temp file fails (e.g. the temp directory is
+   * unusable), the underlying original response must still be closed so its pooled HTTP
+   * connection is released. Before the fix, the exception from {@code createCachedFile} would
+   * propagate out of the {@code CachedClientHttpResponse} constructor without the original
+   * response ever being closed, leaking the connection.
+   */
+  @Test
+  public void registeredRequestClosesOriginalResponseWhenCachingFails() throws Exception {
+    // Given: a temp directory that does not exist, so File.createTempFile(...) inside
+    // HttpRequestFetcher will fail with an IOException, mirroring the production failure.
+    File nonExistentDirectory = new File("/does/not/exist/" + System.nanoTime());
+    HttpRequestFetcher fetcher =
+        new HttpRequestFetcher(
+            nonExistentDirectory,
+            new MetricRegistry(),
+            new AbstractProcessor.Context(new HashMap<>(), new AtomicBoolean(false)),
+            this.pool);
+
+    ClientHttpResponse originalResponse = mock(ClientHttpResponse.class);
+    when(originalResponse.getHeaders()).thenReturn(new HttpHeaders());
+    when(originalResponse.getStatusCode()).thenReturn(HttpStatusCode.valueOf(200));
+    when(originalResponse.getStatusText()).thenReturn("OK");
+    when(originalResponse.getBody()).thenReturn(new ByteArrayInputStream(new byte[] {1, 2, 3}));
+
+    ClientHttpRequest originalRequest = mock(ClientHttpRequest.class);
+    when(originalRequest.getURI()).thenReturn(java.net.URI.create("http://example.invalid/wms"));
+    when(originalRequest.execute()).thenReturn(originalResponse);
+
+    // When
+    ClientHttpRequest cachedRequest = fetcher.register(originalRequest);
+    ClientHttpResponse result = cachedRequest.execute();
+
+    // Then: the caller gets an ErrorResponseClientHttpResponse back instead of a thrown
+    // exception (this is HttpRequestFetcher's existing behaviour) ...
+    assertEquals(HttpStatusCode.valueOf(406), result.getStatusCode());
+    // ... and, crucially, the leaked connection is released.
+    verify(originalResponse, times(1)).close();
+  }
+
+  @Test
+  public void registeredRequestDoesNotCloseOriginalResponseOnSuccess() throws Exception {
+    // Given: a working temp directory, so caching succeeds normally.
+    File tempDir = new File(System.getProperty("java.io.tmpdir"));
+    HttpRequestFetcher fetcher =
+        new HttpRequestFetcher(
+            tempDir,
+            new MetricRegistry(),
+            new AbstractProcessor.Context(new HashMap<>(), new AtomicBoolean(false)),
+            this.pool);
+
+    InputStream body = new ByteArrayInputStream(new byte[] {1, 2, 3});
+    ClientHttpResponse originalResponse = mock(ClientHttpResponse.class);
+    when(originalResponse.getHeaders()).thenReturn(new HttpHeaders());
+    when(originalResponse.getStatusCode()).thenReturn(HttpStatusCode.valueOf(200));
+    when(originalResponse.getStatusText()).thenReturn("OK");
+    when(originalResponse.getBody()).thenReturn(body);
+
+    ClientHttpRequest originalRequest = mock(ClientHttpRequest.class);
+    when(originalRequest.getURI()).thenReturn(java.net.URI.create("http://example.invalid/wms"));
+    when(originalRequest.execute()).thenReturn(originalResponse);
+
+    // When
+    ClientHttpRequest cachedRequest = fetcher.register(originalRequest);
+    ClientHttpResponse result = cachedRequest.execute();
+
+    // Then: caching worked, and there was no need to force-close the original response (the
+    // caching code closes the body stream itself as part of the normal, successful path).
+    assertEquals(HttpStatusCode.valueOf(200), result.getStatusCode());
+    verify(originalResponse, never()).close();
+    result.close();
+  }
+}

--- a/core/src/test/java/org/mapfish/print/http/MfClientHttpRequestFactoryImplTest.java
+++ b/core/src/test/java/org/mapfish/print/http/MfClientHttpRequestFactoryImplTest.java
@@ -57,8 +57,8 @@ public class MfClientHttpRequestFactoryImplTest {
   }
 
   /**
-   * Regression test for the connection pool metrics: when a {@link MetricRegistry} is supplied,
-   * the pool's usage stats (leased/pending/available/max) must be published as gauges, and the
+   * Regression test for the connection pool metrics: when a {@link MetricRegistry} is supplied, the
+   * pool's usage stats (leased/pending/available/max) must be published as gauges, and the
    * configured {@code maxConnTotal} must actually be applied to the pool (it was previously
    * dropped, see the setMaxConnPerRoute/setMaxConnPerRoute double-call bug).
    */
@@ -68,8 +68,7 @@ public class MfClientHttpRequestFactoryImplTest {
     new MfClientHttpRequestFactoryImpl(20, 10, 1000, 1000, 1000, metricRegistry);
 
     SortedMap<String, Gauge> gauges = metricRegistry.getGauges();
-    String base =
-        MetricRegistry.name(MfClientHttpRequestFactoryImpl.class, "connectionPool");
+    String base = MetricRegistry.name(MfClientHttpRequestFactoryImpl.class, "connectionPool");
     assertTrue(gauges.containsKey(MetricRegistry.name(base, "leased")));
     assertTrue(gauges.containsKey(MetricRegistry.name(base, "pending")));
     assertTrue(gauges.containsKey(MetricRegistry.name(base, "available")));

--- a/core/src/test/java/org/mapfish/print/http/MfClientHttpRequestFactoryImplTest.java
+++ b/core/src/test/java/org/mapfish/print/http/MfClientHttpRequestFactoryImplTest.java
@@ -1,11 +1,15 @@
 package org.mapfish.print.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpServer;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.SortedMap;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -50,5 +54,27 @@ public class MfClientHttpRequestFactoryImplTest {
       assertEquals(
           "application/json; charset=utf8", response.getHeaders().getFirst("Content-Type"));
     }
+  }
+
+  /**
+   * Regression test for the connection pool metrics: when a {@link MetricRegistry} is supplied,
+   * the pool's usage stats (leased/pending/available/max) must be published as gauges, and the
+   * configured {@code maxConnTotal} must actually be applied to the pool (it was previously
+   * dropped, see the setMaxConnPerRoute/setMaxConnPerRoute double-call bug).
+   */
+  @Test
+  public void testConnectionPoolMetricsAreRegistered() {
+    MetricRegistry metricRegistry = new MetricRegistry();
+    new MfClientHttpRequestFactoryImpl(20, 10, 1000, 1000, 1000, metricRegistry);
+
+    SortedMap<String, Gauge> gauges = metricRegistry.getGauges();
+    String base =
+        MetricRegistry.name(MfClientHttpRequestFactoryImpl.class, "connectionPool");
+    assertTrue(gauges.containsKey(MetricRegistry.name(base, "leased")));
+    assertTrue(gauges.containsKey(MetricRegistry.name(base, "pending")));
+    assertTrue(gauges.containsKey(MetricRegistry.name(base, "available")));
+    assertTrue(gauges.containsKey(MetricRegistry.name(base, "max")));
+    assertEquals(0, gauges.get(MetricRegistry.name(base, "leased")).getValue());
+    assertEquals(20, gauges.get(MetricRegistry.name(base, "max")).getValue());
   }
 }


### PR DESCRIPTION
Backport of #4332 to the `4.0` maintenance branch.

## Problem

`HttpRequestFetcher.CachedClientHttpResponse` fails to close the original response if caching it to a temp file throws (e.g. the temp directory was deleted mid-flight, or the disk is full). Nothing keeps a reference to `originalResponse` once the constructor throws, so its underlying pooled HTTP connection is never released. Every occurrence leaks one connection permanently; over time this exhausts the connection pool and causes unrelated later requests to fail with `ConnectionRequestTimeoutException`.

## Fix

- Close `originalResponse` on any exception in the `CachedClientHttpResponse` constructor before rethrowing, plus a regression test.
- Added HTTP connection pool metrics (`MfClientHttpRequestFactoryImpl.connectionPool.{leased,pending,available,max}`) via the existing `MetricRegistry`.
- Fixed a related bug where `maxConnectionsTotal` was silently never applied to the pool (leftover from the HttpClient 4→5 migration double-calling `.setMaxConnPerRoute(...)` instead of `.setMaxConnTotal(...)` + `.setMaxConnPerRoute(...)`).

Cherry-picked cleanly onto `4.0` (same HttpClient5 API surface already present on this branch); compiles and all `org.mapfish.print.http.*` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)