### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/monthly-release.yaml
+++ b/.github/workflows/monthly-release.yaml
@@ -5,6 +5,9 @@ on:
     # The 10th at every month
     - cron: '0 0 10 * *'
 
+permissions:
+  contents: write
+
 jobs:
   audit:
     name: Monthly release

--- a/.github/workflows/pull-request-automation.yaml
+++ b/.github/workflows/pull-request-automation.yaml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
       - reopened
+
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     name: Auto reviews pull requests from bots


### PR DESCRIPTION
## Summary
Add explicit workflow permissions to GitHub Actions workflows to follow the principle of least privilege.

## Context
GitHub Actions workflows should declare explicit permissions rather than relying on the default broad permissions. This is a security best practice recommended by GitHub.

## Implementation Details
- `.github/workflows/monthly-release.yaml`: Added top-level `permissions: contents: write` (needed for creating releases)
- `.github/workflows/pull-request-automation.yaml`: Added top-level `permissions: contents: read`