### PR TITLE
Revert "Reformulate examples to be Renovate compatible"

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -11,10 +11,9 @@ repositories {
 }
 
 dependencies {
-    testImplementation('ch.qos.logback:logback-classic:1.6.3')
-
     testImplementation(
         project(':core'),
+        'ch.qos.logback:logback-classic:1.6.3',
         'org.springframework:spring-core:7.0.8',
         'org.springframework:spring-tx:7.0.8',
         'org.springframework:spring-test:7.0.8',


### PR DESCRIPTION
Reverts mapfish/mapfish-print#4356 (It was an AI suggestion, which did not work) So we remove it.