### PR TITLE
Introduce single version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-  id("com.github.spotbugs") version "6.5.11"
+  alias(libs.plugins.spotbugs)
 }
 
 defaultTasks 'build'
@@ -26,7 +26,7 @@ allprojects {
 
 configurations.configureEach {
     resolutionStrategy {
-        force 'xml-apis:xml-apis:2.0.2'
+        force libs.xml.apis
     }
 }
 
@@ -49,7 +49,7 @@ configure(subprojects.findAll { ['core', 'examples'].contains(it.name) }) {
     }
 
     spotbugs {
-        toolVersion = "4.10.3" // com.github.spotbugs:spotbugs-annotations
+        toolVersion = libs.versions.spotbugs.asProvider().get() // com.github.spotbugs:spotbugs-annotations
         reportsDir = layout.buildDirectory.dir("reports/SpotBugsReports").get().asFile
         effort = Effort.MAX
         reportLevel = Confidence.valueOf("HIGH")
@@ -68,7 +68,7 @@ configure(subprojects.findAll { ['core', 'examples'].contains(it.name) }) {
 
     dependencies {
         testImplementation(
-            'org.mockito:mockito-core:5.23.0',
+            libs.mockito.core,
         )
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -127,96 +127,96 @@ configurations {
 
 dependencies {
     implementation(
-        'org.springframework:spring-context:7.0.8',
-        'org.springframework:spring-core:7.0.8',
-        'org.springframework:spring-web:7.0.8',
-        'org.springframework:spring-webmvc:7.0.8',
-        'org.springframework:spring-aspects:7.0.8',
-        'org.springframework:spring-orm:7.0.8',
-        'org.springframework:spring-jdbc:7.0.8',
-        'org.springframework:spring-tx:7.0.8',
-        'org.springframework:spring-test:7.0.8',
-        'org.springframework.security:spring-security-config:7.1.0',
-        'org.springframework.security:spring-security-web:7.1.0',
-        'com.thetransactioncompany:cors-filter:3.1',
-        'org.hibernate:hibernate-core:6.6.55.Final',
-        'org.postgresql:postgresql:42.7.13',
-        'io.hypersistence:hypersistence-utils-hibernate-63:3.15.4',
-        'com.mchange:c3p0:0.14.1',
-        'javax.media:jai-core:1.1.3',
-        'jakarta.annotation:jakarta.annotation-api:3.0.0',
-        'jakarta.persistence:jakarta.persistence-api:3.2.0',
-        'jakarta.servlet:jakarta.servlet-api:6.1.0',
-        'org.checkerframework:checker-qual:4.2.2',
-        'com.ibm.icu:icu4j:78.3'
+        libs.spring.context,
+        libs.spring.core,
+        libs.spring.web,
+        libs.spring.webmvc,
+        libs.spring.aspects,
+        libs.spring.orm,
+        libs.spring.jdbc,
+        libs.spring.tx,
+        libs.spring.test,
+        libs.spring.security.config,
+        libs.spring.security.web,
+        libs.cors.filter,
+        libs.hibernate.core,
+        libs.postgresql,
+        libs.hypersistence.utils.hibernate63,
+        libs.c3p0,
+        libs.jai.core,
+        libs.jakarta.annotation.api,
+        libs.jakarta.persistence.api,
+        libs.jakarta.servlet.api,
+        libs.checker.qual,
+        libs.icu4j,
     )
     metrics(
-        'io.dropwizard.metrics:metrics-core:4.2.39',
-        'io.dropwizard.metrics:metrics-jakarta-servlet:4.2.39',
-        'io.dropwizard.metrics:metrics-jakarta-servlets:4.2.39',
-        'io.dropwizard.metrics:metrics-httpclient:4.2.39',
-        'io.dropwizard.metrics:metrics-jvm:4.2.39',
-        'io.dropwizard.metrics:metrics-jmx:4.2.39',
-        'io.dropwizard.metrics:metrics-logback:4.2.39',
+        libs.metrics.core,
+        libs.metrics.jakarta.servlet,
+        libs.metrics.jakarta.servlets,
+        libs.metrics.httpclient,
+        libs.metrics.jvm,
+        libs.metrics.jmx,
+        libs.metrics.logback,
     )
     geotools(
-        'org.geotools:gt-epsg-hsql:35.0',
-        'org.geotools:gt-render:35.0',
-        'org.geotools:gt-geojson:35.0',
-        'org.geotools:gt-geotiff:35.0',
-        'org.geotools:gt-wms:35.0',
-        'org.geotools.xsd:gt-xsd-gml3:35.0',
-        'org.geotools:gt-svg:35.0',
-        'org.geotools:gt-cql:35.0',
+        libs.geotools.gt.epsg.hsql,
+        libs.geotools.gt.render,
+        libs.geotools.gt.geojson,
+        libs.geotools.gt.geotiff,
+        libs.geotools.gt.wms,
+        libs.geotools.gt.xsd.gml3,
+        libs.geotools.gt.svg,
+        libs.geotools.gt.cql,
     )
-    implementation "org.apache.httpcomponents.client5:httpclient5:5.6.4"
+    implementation libs.httpclient5
     jasper(
-        'ar.com.fdvs:DynamicJasper:5.3.9',
-        'com.itextpdf:itextpdf:5.5.13.6',
-        'net.sf.jasperreports:jasperreports:7.0.7',
-        'net.sf.jasperreports:jasperreports-excel-poi:7.0.7',
-        'net.sf.jasperreports:jasperreports-fonts:7.0.7',
-        'net.sf.jasperreports:jasperreports-functions:7.0.7',
-        'net.sf.jasperreports:jasperreports-json:7.0.7',
-        'net.sf.jasperreports:jasperreports-jdt:7.0.7',
-        'net.sf.jasperreports:jasperreports-pdf:7.0.7',
+        libs.dynamicjasper,
+        libs.itextpdf,
+        libs.jasperreports,
+        libs.jasperreports.excel.poi,
+        libs.jasperreports.fonts,
+        libs.jasperreports.functions,
+        libs.jasperreports.json,
+        libs.jasperreports.jdt,
+        libs.jasperreports.pdf,
     )
     implementation(
-        'org.slf4j:slf4j-api:2.0.18',
-        'org.slf4j:jcl-over-slf4j:2.0.18',
-        'org.slf4j:jul-to-slf4j:2.0.18',
-        'ch.qos.logback:logback-classic:1.6.3',
-        'org.json:json:20250517',
-        'org.yaml:snakeyaml:2.6',
-        'com.github.spullara.cli-parser:cli-parser:1.1.6',
-        'com.sun.mail:javax.mail:1.6.2',
-        'com.amazonaws:aws-java-sdk-s3:1.12.797',
-        'io.sentry:sentry-logback:8.53.0',
+        libs.slf4j.api,
+        libs.slf4j.jcl.over.slf4j,
+        libs.slf4j.jul.to.slf4j,
+        libs.logback.classic,
+        libs.json,
+        libs.snakeyaml,
+        libs.cli.parser,
+        libs.javax.mail,
+        libs.aws.java.sdk.s3,
+        libs.sentry.logback,
         // For JSON logs
-        'net.logstash.logback:logstash-logback-encoder:9.0',
+        libs.logstash.logback.encoder,
         // For PDF/A
-        'com.adobe.xmp:xmpcore:6.1.11',
+        libs.adobe.xmpcore,
         // For JasperReports
-        'joda-time:joda-time:2.14.3',
-        'org.jfree:jcommon:1.0.24',
-        'org.apache.groovy:groovy-all:5.1.0',
-        'xalan:serializer:2.7.3',
+        libs.joda.time,
+        libs.jcommon,
+        libs.groovy.all,
+        libs.xalan.serializer,
         // For WebP images
-        'com.twelvemonkeys.imageio:imageio-webp:3.14.0',
+        libs.imageio.webp,
     )
 
     implementation(
-        'org.apache.xmlgraphics:batik-codec:1.19',
-        'org.apache.xmlgraphics:batik-svg-dom:1.19'
+        libs.batik.codec,
+        libs.batik.svg.dom,
     )
 
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.10.3'
+    compileOnly libs.spotbugs.annotations
 
-    testImplementation (
-        'de.saly:javamail-mock2-fullmock:0.5-beta4',
-        'com.h2database:h2:2.4.240',
-        'org.junit.jupiter:junit-jupiter:6.1.3',
-        'org.junit.jupiter:junit-jupiter-api:6.1.3',
+    testImplementation(
+        libs.javamail.mock2.fullmock,
+        libs.h2,
+        libs.junit.jupiter,
+        libs.junit.jupiter.api,
     )
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -18,16 +18,16 @@ repositories {
 dependencies {
     implementation project(':core')
     implementation (
-            'org.apache.groovy:groovy-xml:5.1.0',
-            'org.apache.groovy:groovy-json:5.1.0',
-            "org.springframework:spring-test:7.0.8",
-            'org.ccil.cowan.tagsoup:tagsoup:1.2.1',
-            'com.samskivert:jmustache:1.16',
-            'com.google.guava:guava:33.6.0-jre',
-            'commons-io:commons-io:2.22.0',
-            "org.springframework:spring-beans:7.0.8",
-            "org.springframework:spring-web:7.0.8",
-            "org.springframework:spring-context:7.0.8",
+        libs.groovy.xml,
+        libs.groovy.json,
+        libs.spring.test,
+        libs.tagsoup,
+        libs.jmustache,
+        libs.guava,
+        libs.commons.io,
+        libs.spring.beans,
+        libs.spring.web,
+        libs.spring.context,
     )
 }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -13,18 +13,18 @@ repositories {
 dependencies {
     testImplementation(
         project(':core'),
-        'ch.qos.logback:logback-classic:1.6.3',
-        'org.springframework:spring-core:7.0.8',
-        'org.springframework:spring-tx:7.0.8',
-        'org.springframework:spring-test:7.0.8',
-        'org.springframework:spring-web:7.0.8',
-        'org.junit.jupiter:junit-jupiter:6.0.1',
-        'org.json:json:20250517',
-        'commons-io:commons-io:2.21.0',
-        'org.apache.commons:commons-lang3:3.20.0',
-        "org.locationtech.jts:jts-core:1.18.2",
-        'org.verapdf:validation-model:1.30.2',
-        'org.junit.platform:junit-platform-launcher:6.0.1',
+        libs.logback.classic,
+        libs.spring.core,
+        libs.spring.tx,
+        libs.spring.test,
+        libs.spring.web,
+        libs.junit.jupiter,
+        libs.json,
+        libs.commons.io,
+        libs.commons.lang3,
+        libs.jts.core,
+        libs.verapdf.validation.model,
+        libs.junit.platform.launcher,
     )
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,140 @@
+[versions]
+adobe-xmpcore = "6.1.11"
+aws-sdk = "1.12.797"
+batik = "1.19"
+c3p0 = "0.14.1"
+checker-qual = "4.2.2"
+cli-parser = "1.1.6"
+commons-io = "2.22.0"
+commons-lang3 = "3.20.0"
+cors-filter = "3.1"
+dynamicjasper = "5.3.9"
+geotools = "35.0"
+groovy = "5.1.0"
+guava = "33.6.0-jre"
+h2 = "2.4.240"
+hibernate = "6.6.55.Final"
+httpclient5 = "5.6.4"
+hypersistence-utils = "3.15.4"
+icu4j = "78.3"
+imageio-webp = "3.14.0"
+itextpdf = "5.5.13.6"
+jai-core = "1.1.3"
+jakarta-annotation = "3.0.0"
+jakarta-persistence = "3.2.0"
+jakarta-servlet = "6.1.0"
+jasperreports = "7.0.7"
+javamail = "1.6.2"
+javamail-mock2 = "0.5-beta4"
+jcommon = "1.0.24"
+jmustache = "1.16"
+joda-time = "2.14.3"
+json = "20250517"
+jts = "1.18.2"
+junit = "6.1.3"
+junit-platform = "6.0.1"
+logback = "1.6.3"
+logstash-logback = "9.0"
+metrics = "4.2.39"
+mockito = "5.23.0"
+postgresql = "42.7.13"
+sentry = "8.53.0"
+slf4j = "2.0.18"
+snakeyaml = "2.6"
+spotbugs = "4.10.3"
+spotbugs-plugin = "6.5.11"
+spring = "7.0.8"
+spring-security = "7.1.0"
+tagsoup = "1.2.1"
+verapdf = "1.30.2"
+xalan = "2.7.3"
+xml-apis = "2.0.2"
+
+[libraries]
+adobe-xmpcore = { module = "com.adobe.xmp:xmpcore", version.ref = "adobe-xmpcore" }
+aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version.ref = "aws-sdk" }
+batik-codec = { module = "org.apache.xmlgraphics:batik-codec", version.ref = "batik" }
+batik-svg-dom = { module = "org.apache.xmlgraphics:batik-svg-dom", version.ref = "batik" }
+c3p0 = { module = "com.mchange:c3p0", version.ref = "c3p0" }
+checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
+cli-parser = { module = "com.github.spullara.cli-parser:cli-parser", version.ref = "cli-parser" }
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+cors-filter = { module = "com.thetransactioncompany:cors-filter", version.ref = "cors-filter" }
+dynamicjasper = { module = "ar.com.fdvs:DynamicJasper", version.ref = "dynamicjasper" }
+geotools-gt-cql = { module = "org.geotools:gt-cql", version.ref = "geotools" }
+geotools-gt-epsg-hsql = { module = "org.geotools:gt-epsg-hsql", version.ref = "geotools" }
+geotools-gt-geojson = { module = "org.geotools:gt-geojson", version.ref = "geotools" }
+geotools-gt-geotiff = { module = "org.geotools:gt-geotiff", version.ref = "geotools" }
+geotools-gt-render = { module = "org.geotools:gt-render", version.ref = "geotools" }
+geotools-gt-svg = { module = "org.geotools:gt-svg", version.ref = "geotools" }
+geotools-gt-wms = { module = "org.geotools:gt-wms", version.ref = "geotools" }
+geotools-gt-xsd-gml3 = { module = "org.geotools.xsd:gt-xsd-gml3", version.ref = "geotools" }
+groovy-all = { module = "org.apache.groovy:groovy-all", version.ref = "groovy" }
+groovy-json = { module = "org.apache.groovy:groovy-json", version.ref = "groovy" }
+groovy-xml = { module = "org.apache.groovy:groovy-xml", version.ref = "groovy" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
+hibernate-core = { module = "org.hibernate:hibernate-core", version.ref = "hibernate" }
+httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpclient5" }
+hypersistence-utils-hibernate63 = { module = "io.hypersistence:hypersistence-utils-hibernate-63", version.ref = "hypersistence-utils" }
+icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu4j" }
+imageio-webp = { module = "com.twelvemonkeys.imageio:imageio-webp", version.ref = "imageio-webp" }
+itextpdf = { module = "com.itextpdf:itextpdf", version.ref = "itextpdf" }
+jai-core = { module = "javax.media:jai-core", version.ref = "jai-core" }
+jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
+jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version.ref = "jakarta-persistence" }
+jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api", version.ref = "jakarta-servlet" }
+jasperreports = { module = "net.sf.jasperreports:jasperreports", version.ref = "jasperreports" }
+jasperreports-excel-poi = { module = "net.sf.jasperreports:jasperreports-excel-poi", version.ref = "jasperreports" }
+jasperreports-fonts = { module = "net.sf.jasperreports:jasperreports-fonts", version.ref = "jasperreports" }
+jasperreports-functions = { module = "net.sf.jasperreports:jasperreports-functions", version.ref = "jasperreports" }
+jasperreports-jdt = { module = "net.sf.jasperreports:jasperreports-jdt", version.ref = "jasperreports" }
+jasperreports-json = { module = "net.sf.jasperreports:jasperreports-json", version.ref = "jasperreports" }
+jasperreports-pdf = { module = "net.sf.jasperreports:jasperreports-pdf", version.ref = "jasperreports" }
+javax-mail = { module = "com.sun.mail:javax.mail", version.ref = "javamail" }
+javamail-mock2-fullmock = { module = "de.saly:javamail-mock2-fullmock", version.ref = "javamail-mock2" }
+jcommon = { module = "org.jfree:jcommon", version.ref = "jcommon" }
+jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }
+joda-time = { module = "joda-time:joda-time", version.ref = "joda-time" }
+json = { module = "org.json:json", version.ref = "json" }
+jts-core = { module = "org.locationtech.jts:jts-core", version.ref = "jts" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback" }
+metrics-core = { module = "io.dropwizard.metrics:metrics-core", version.ref = "metrics" }
+metrics-httpclient = { module = "io.dropwizard.metrics:metrics-httpclient", version.ref = "metrics" }
+metrics-jakarta-servlet = { module = "io.dropwizard.metrics:metrics-jakarta-servlet", version.ref = "metrics" }
+metrics-jakarta-servlets = { module = "io.dropwizard.metrics:metrics-jakarta-servlets", version.ref = "metrics" }
+metrics-jmx = { module = "io.dropwizard.metrics:metrics-jmx", version.ref = "metrics" }
+metrics-jvm = { module = "io.dropwizard.metrics:metrics-jvm", version.ref = "metrics" }
+metrics-logback = { module = "io.dropwizard.metrics:metrics-logback", version.ref = "metrics" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+sentry-logback = { module = "io.sentry:sentry-logback", version.ref = "sentry" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4j-jcl-over-slf4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
+slf4j-jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
+snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
+spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
+spring-aspects = { module = "org.springframework:spring-aspects", version.ref = "spring" }
+spring-beans = { module = "org.springframework:spring-beans", version.ref = "spring" }
+spring-context = { module = "org.springframework:spring-context", version.ref = "spring" }
+spring-core = { module = "org.springframework:spring-core", version.ref = "spring" }
+spring-jdbc = { module = "org.springframework:spring-jdbc", version.ref = "spring" }
+spring-orm = { module = "org.springframework:spring-orm", version.ref = "spring" }
+spring-security-config = { module = "org.springframework.security:spring-security-config", version.ref = "spring-security" }
+spring-security-web = { module = "org.springframework.security:spring-security-web", version.ref = "spring-security" }
+spring-test = { module = "org.springframework:spring-test", version.ref = "spring" }
+spring-tx = { module = "org.springframework:spring-tx", version.ref = "spring" }
+spring-web = { module = "org.springframework:spring-web", version.ref = "spring" }
+spring-webmvc = { module = "org.springframework:spring-webmvc", version.ref = "spring" }
+tagsoup = { module = "org.ccil.cowan.tagsoup:tagsoup", version.ref = "tagsoup" }
+verapdf-validation-model = { module = "org.verapdf:validation-model", version.ref = "verapdf" }
+xalan-serializer = { module = "xalan:serializer", version.ref = "xalan" }
+xml-apis = { module = "xml-apis:xml-apis", version.ref = "xml-apis" }
+
+[plugins]
+spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs-plugin" }


### PR DESCRIPTION
This will ensure that CI does not run with unaligned version of packages (since renovate was moving core and not examples)